### PR TITLE
Wrap some GRPC errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Temporal.start_workflow(RenewSubscriptionWorkflow, user_id, options: { workflow_
 
 Passing in a `workflow_id` allows you to prevent concurrent execution of a workflow — a subsequent
 call with the same `workflow_id` will always get rejected while it is still running, raising
-`TemporalThrift::WorkflowExecutionAlreadyStartedError`. You can adjust the behaviour for finished
+`Temporal::WorkflowExecutionAlreadyStartedFailure`. You can adjust the behaviour for finished
 workflows by supplying the `workflow_id_reuse_policy:` argument with one of these options:
 
 - `:allow_failed` will allow re-running workflows that have failed (terminated, cancelled, timed out or failed)

--- a/lib/temporal/client/grpc_client.rb
+++ b/lib/temporal/client/grpc_client.rb
@@ -31,6 +31,8 @@ module Temporal
           )
         )
         client.register_namespace(request)
+      rescue GRPC::AlreadyExists => e
+        raise Temporal::NamespaceAlreadyExistsFailure, e.details
       end
 
       def describe_namespace(name:)
@@ -97,6 +99,10 @@ module Temporal
         end
 
         client.start_workflow_execution(request)
+      rescue GRPC::AlreadyExists => e
+        # Feel like there should be cleaner way to do this...
+        run_id = e.details[/RunId: (.*)\.$/, 1]
+        raise Temporal::WorkflowExecutionAlreadyStartedFailure.new(e.details, run_id)
       end
 
       def get_workflow_execution_history(namespace:, workflow_id:, run_id:)

--- a/lib/temporal/errors.rb
+++ b/lib/temporal/errors.rb
@@ -20,7 +20,14 @@ module Temporal
   class ApiError < Error; end
 
   class NotFoundFailure < ApiError; end
-  class WorkflowExecutionAlreadyStartedFailure < ApiError; end
+  class WorkflowExecutionAlreadyStartedFailure < ApiError
+    attr_accessor :run_id
+
+    def initialize(message, run_id)
+      super(message)
+      @run_id = run_id
+    end
+  end
   class NamespaceNotActiveFailure < ApiError; end
   class ClientVersionNotSupportedFailure < ApiError; end
   class FeatureVersionNotSupportedFailure < ApiError; end

--- a/lib/temporal/errors.rb
+++ b/lib/temporal/errors.rb
@@ -21,7 +21,7 @@ module Temporal
 
   class NotFoundFailure < ApiError; end
   class WorkflowExecutionAlreadyStartedFailure < ApiError
-    attr_accessor :run_id
+    attr_reader :run_id
 
     def initialize(message, run_id)
       super(message)

--- a/rbi/temporal-ruby.rbi
+++ b/rbi/temporal-ruby.rbi
@@ -21,19 +21,23 @@ module Temporal
     class ExecutionInfo; end
   end
   class Worker; end
-end
-module TemporalThrift
-  class BadRequestError; end
-  class InternalServiceError; end
-  class DomainAlreadyExistsError; end
-  class WorkflowExecutionAlreadyStartedError; end
-  class EntityNotExistsError; end
-  class ServiceBusyError; end
-  class CancellationAlreadyRequestedError; end
-  class QueryFailedError; end
-  class DomainNotActiveError; end
-  class LimitExceededError; end
-  class AccessDeniedError; end
-  class RetryTaskError; end
-  class ClientVersionNotSupportedError; end
+
+  class Error; end
+  class InternalError; end
+  class ClientError; end
+  class TimeoutError; end
+  class ActivityException; end
+
+  class ActivityNotRegistered; end
+
+  class ApiError; end
+
+  class NotFoundFailure; end
+  class WorkflowExecutionAlreadyStartedFailure; end
+  class NamespaceNotActiveFailure; end
+  class ClientVersionNotSupportedFailure; end
+  class FeatureVersionNotSupportedFailure; end
+  class NamespaceAlreadyExistsFailure; end
+  class CancellationAlreadyRequestedFailure; end
+  class QueryFailedFailure; end
 end

--- a/spec/unit/lib/temporal/testing_spec.rb
+++ b/spec/unit/lib/temporal/testing_spec.rb
@@ -84,7 +84,7 @@ describe Temporal::Testing::TemporalOverride do
             let(:status) { Temporal::Workflow::ExecutionInfo::RUNNING_STATUS }
 
             it 'raises error' do
-              expect { subject }.to raise_error(error_class) { |e| expect(e.run_id).to eql run_id }
+              expect { subject }.to raise_error(error_class) { |e| expect(e.run_id).to eql(run_id) }
             end
           end
 
@@ -92,7 +92,7 @@ describe Temporal::Testing::TemporalOverride do
             let(:status) { Temporal::Workflow::ExecutionInfo::COMPLETED_STATUS }
 
             it 'raises error' do
-              expect { subject }.to raise_error(error_class) { |e| expect(e.run_id).to eql run_id }
+              expect { subject }.to raise_error(error_class) { |e| expect(e.run_id).to eql(run_id) }
             end
           end
 
@@ -116,7 +116,7 @@ describe Temporal::Testing::TemporalOverride do
             let(:status) { Temporal::Workflow::ExecutionInfo::RUNNING_STATUS }
 
             it 'raises error' do
-              expect { subject }.to raise_error(error_class) { |e| expect(e.run_id).to eql run_id }
+              expect { subject }.to raise_error(error_class) { |e| expect(e.run_id).to eql(run_id) }
             end
           end
 
@@ -146,7 +146,7 @@ describe Temporal::Testing::TemporalOverride do
             let(:status) { Temporal::Workflow::ExecutionInfo::RUNNING_STATUS }
 
             it 'raises error' do
-              expect { subject }.to raise_error(error_class) { |e| expect(e.run_id).to eql run_id }
+              expect { subject }.to raise_error(error_class) { |e| expect(e.run_id).to eql(run_id) }
             end
           end
 
@@ -154,7 +154,7 @@ describe Temporal::Testing::TemporalOverride do
             let(:status) { Temporal::Workflow::ExecutionInfo::COMPLETED_STATUS }
 
             it 'raises error' do
-              expect { subject }.to raise_error(error_class) { |e| expect(e.run_id).to eql run_id }
+              expect { subject }.to raise_error(error_class) { |e| expect(e.run_id).to eql(run_id) }
             end
           end
 
@@ -162,7 +162,7 @@ describe Temporal::Testing::TemporalOverride do
             let(:status) { Temporal::Workflow::ExecutionInfo::FAILED_STATUS }
 
             it 'raises error' do
-              expect { subject }.to raise_error(error_class) { |e| expect(e.run_id).to eql run_id }
+              expect { subject }.to raise_error(error_class) { |e| expect(e.run_id).to eql(run_id) }
             end
           end
         end

--- a/spec/unit/lib/temporal/testing_spec.rb
+++ b/spec/unit/lib/temporal/testing_spec.rb
@@ -64,7 +64,7 @@ describe Temporal::Testing::TemporalOverride do
         let(:run_id) { SecureRandom.uuid }
         let(:error_class) { Temporal::WorkflowExecutionAlreadyStartedFailure }
 
-        # Simulate exiwting execution
+        # Simulate existing execution
         before do
           if execution
             Temporal.send(:executions)[[workflow_id, run_id]] = execution
@@ -84,7 +84,7 @@ describe Temporal::Testing::TemporalOverride do
             let(:status) { Temporal::Workflow::ExecutionInfo::RUNNING_STATUS }
 
             it 'raises error' do
-              expect { subject }.to raise_error(error_class)
+              expect { subject }.to raise_error(error_class) { |e| expect(e.run_id).to eql run_id }
             end
           end
 
@@ -92,7 +92,7 @@ describe Temporal::Testing::TemporalOverride do
             let(:status) { Temporal::Workflow::ExecutionInfo::COMPLETED_STATUS }
 
             it 'raises error' do
-              expect { subject }.to raise_error(error_class)
+              expect { subject }.to raise_error(error_class) { |e| expect(e.run_id).to eql run_id }
             end
           end
 
@@ -116,7 +116,7 @@ describe Temporal::Testing::TemporalOverride do
             let(:status) { Temporal::Workflow::ExecutionInfo::RUNNING_STATUS }
 
             it 'raises error' do
-              expect { subject }.to raise_error(error_class)
+              expect { subject }.to raise_error(error_class) { |e| expect(e.run_id).to eql run_id }
             end
           end
 
@@ -146,7 +146,7 @@ describe Temporal::Testing::TemporalOverride do
             let(:status) { Temporal::Workflow::ExecutionInfo::RUNNING_STATUS }
 
             it 'raises error' do
-              expect { subject }.to raise_error(error_class)
+              expect { subject }.to raise_error(error_class) { |e| expect(e.run_id).to eql run_id }
             end
           end
 
@@ -154,7 +154,7 @@ describe Temporal::Testing::TemporalOverride do
             let(:status) { Temporal::Workflow::ExecutionInfo::COMPLETED_STATUS }
 
             it 'raises error' do
-              expect { subject }.to raise_error(error_class)
+              expect { subject }.to raise_error(error_class) { |e| expect(e.run_id).to eql run_id }
             end
           end
 
@@ -162,7 +162,7 @@ describe Temporal::Testing::TemporalOverride do
             let(:status) { Temporal::Workflow::ExecutionInfo::FAILED_STATUS }
 
             it 'raises error' do
-              expect { subject }.to raise_error(error_class)
+              expect { subject }.to raise_error(error_class) { |e| expect(e.run_id).to eql run_id }
             end
           end
         end


### PR DESCRIPTION
Don't leak GRPC errors outside the client.

More work to do here, this is just low hanging fruit.