### PR TITLE
Handle nil payloads.

### DIFF
--- a/lib/temporal/workflow/state_manager.rb
+++ b/lib/temporal/workflow/state_manager.rb
@@ -305,7 +305,7 @@ module Temporal
       end
 
       def parse_payload(payload)
-        return if payload.payloads.empty?
+        return if payload.nil? || payload.payloads.empty?
 
         binary = payload.payloads.first.data
         JSON.deserialize(binary)


### PR DESCRIPTION
This happens if the Payloads object is missing, rather than present with
an empty payloads array.