### PR TITLE
[Fix] Wait before canceling pending requests

### DIFF
--- a/lib/temporal/activity/poller.rb
+++ b/lib/temporal/activity/poller.rb
@@ -21,9 +21,12 @@ module Temporal
         @thread = Thread.new(&method(:poll_loop))
       end
 
-      def stop
+      def stop_polling
         @shutting_down = true
         Temporal.logger.info('Shutting down activity poller')
+      end
+
+      def cancel_pending_requests
         client.cancel_polling_request
       end
 

--- a/lib/temporal/worker.rb
+++ b/lib/temporal/worker.rb
@@ -51,17 +51,19 @@ module Temporal
 
       pollers.each(&:start)
 
-      # wait until instructed to shut down
-      while !shutting_down? do
-        sleep 1
-      end
+      # keep the main thread alive
+      sleep 1 while !shutting_down?
     end
 
     def stop
       @shutting_down = true
 
       Thread.new do
-        pollers.each(&:stop)
+        pollers.each(&:stop_polling)
+        # allow workers to drain in-transit tasks.
+        # https://github.com/temporalio/temporal/issues/1058
+        sleep 1
+        pollers.each(&:cancel_pending_requests)
         pollers.each(&:wait)
       end.join
     end

--- a/lib/temporal/workflow/poller.rb
+++ b/lib/temporal/workflow/poller.rb
@@ -18,9 +18,12 @@ module Temporal
         @thread = Thread.new(&method(:poll_loop))
       end
 
-      def stop
+      def stop_polling
         @shutting_down = true
         Temporal.logger.info('Shutting down a workflow poller')
+      end
+
+      def cancel_pending_requests
         client.cancel_polling_request
       end
 

--- a/spec/unit/lib/temporal/activity/poller_spec.rb
+++ b/spec/unit/lib/temporal/activity/poller_spec.rb
@@ -28,7 +28,7 @@ describe Temporal::Activity::Poller do
       subject.start
 
       # stop poller before inspecting
-      subject.stop; subject.wait
+      subject.stop_polling; subject.wait
 
       expect(client)
         .to have_received(:poll_activity_task_queue)
@@ -51,7 +51,7 @@ describe Temporal::Activity::Poller do
         subject.start
 
         # stop poller before inspecting
-        subject.stop; subject.wait
+        subject.stop_polling; subject.wait
 
         expect(thread_pool).to have_received(:schedule)
       end
@@ -60,7 +60,7 @@ describe Temporal::Activity::Poller do
         subject.start
 
         # stop poller before inspecting
-        subject.stop; subject.wait
+        subject.stop_polling; subject.wait
 
         expect(Temporal::Activity::TaskProcessor)
           .to have_received(:new)
@@ -82,7 +82,7 @@ describe Temporal::Activity::Poller do
           subject.start
 
           # stop poller before inspecting
-          subject.stop; subject.wait
+          subject.stop_polling; subject.wait
 
           expect(Temporal::Middleware::Chain).to have_received(:new).with(middleware)
           expect(Temporal::Activity::TaskProcessor)
@@ -104,7 +104,7 @@ describe Temporal::Activity::Poller do
         subject.start
 
         # stop poller before inspecting
-        subject.stop; subject.wait
+        subject.stop_polling; subject.wait
 
         expect(Temporal.logger)
           .to have_received(:error)
@@ -113,12 +113,13 @@ describe Temporal::Activity::Poller do
     end
   end
 
-  describe '#stop' do
+  describe '#cancel_pending_requests' do
     before { subject.start }
     after { subject.wait }
 
     it 'tells client to cancel polling requests' do
-      subject.stop
+      subject.stop_polling
+      subject.cancel_pending_requests
 
       expect(client).to have_received(:cancel_polling_request)
     end
@@ -127,7 +128,7 @@ describe Temporal::Activity::Poller do
   describe '#wait' do
     before do
       subject.start
-      subject.stop
+      subject.stop_polling
     end
 
     it 'shuts down the thread poll' do


### PR DESCRIPTION
There's a known issue in Temporal (https://github.com/temporalio/temporal/issues/1058) that might drop tasks that are in-transit when canceling a GRPC connection. Temporal will only retry these tasks after a timeout since it's not aware that these were dropped. This can be very confusing and is mostly visible when stopping workers under load.

This simple solution will give in-transit requests a chance to finish (without starting new ones) before canceling pending requests, which should eliminate the majority of occurrences. A proper fix should hopefully land in Temporal server.