### PR TITLE
Make execute_in_context clean up after itself

### DIFF
--- a/lib/temporal/workflow.rb
+++ b/lib/temporal/workflow.rb
@@ -8,6 +8,7 @@ module Temporal
     extend ConvenienceMethods
 
     def self.execute_in_context(context, input)
+      old_context = Temporal::ThreadLocalContext.get
       Temporal::ThreadLocalContext.set(context)
 
       workflow = new(context)
@@ -19,6 +20,8 @@ module Temporal
       Temporal.logger.debug(error.backtrace.join("\n"))
 
       context.fail(error)
+    ensure
+      Temporal::ThreadLocalContext.set(old_context)
     end
 
     def initialize(context)

--- a/spec/unit/lib/temporal/testing_spec.rb
+++ b/spec/unit/lib/temporal/testing_spec.rb
@@ -35,6 +35,21 @@ describe Temporal::Testing::TemporalOverride do
       Temporal::Testing.local! { example.run }
     end
 
+    describe 'Workflow.execute_locally' do
+      let(:workflow) { TestTemporalOverrideWorkflow.new(nil) }
+
+      before { allow(TestTemporalOverrideWorkflow).to receive(:new).and_return(workflow) }
+
+      it 'restores original context after finishing' do
+        allow(workflow).to receive(:execute)
+
+        TestTemporalOverrideWorkflow.execute_locally
+
+        expect(workflow).to have_received(:execute)
+        expect(Temporal::ThreadLocalContext.get).to equal(nil)
+      end
+    end
+
     describe 'Temporal.start_workflow' do
       let(:workflow) { TestTemporalOverrideWorkflow.new(nil) }
 

--- a/spec/unit/lib/temporal/testing_spec.rb
+++ b/spec/unit/lib/temporal/testing_spec.rb
@@ -36,16 +36,29 @@ describe Temporal::Testing::TemporalOverride do
     end
 
     describe 'Workflow.execute_locally' do
-      let(:workflow) { TestTemporalOverrideWorkflow.new(nil) }
-
-      before { allow(TestTemporalOverrideWorkflow).to receive(:new).and_return(workflow) }
-
-      it 'restores original context after finishing' do
+      it 'executes the workflow' do
+        workflow = TestTemporalOverrideWorkflow.new(nil)
+        allow(TestTemporalOverrideWorkflow).to receive(:new).and_return(workflow)
         allow(workflow).to receive(:execute)
 
         TestTemporalOverrideWorkflow.execute_locally
 
         expect(workflow).to have_received(:execute)
+      end
+
+      it 'restores original context after finishing successfully' do
+        TestTemporalOverrideWorkflow.execute_locally
+        expect(Temporal::ThreadLocalContext.get).to equal(nil)
+      end
+
+      class FailingWorkflow
+        def execute
+          raise 'uh oh'
+        end
+      end
+
+      it 'restores original context after failing' do
+        expect { FailingWorkflow.execute_locally }.to raise_error(StandardError)
         expect(Temporal::ThreadLocalContext.get).to equal(nil)
       end
     end

--- a/spec/unit/lib/temporal/testing_spec.rb
+++ b/spec/unit/lib/temporal/testing_spec.rb
@@ -48,7 +48,7 @@ describe Temporal::Testing::TemporalOverride do
 
       it 'restores original context after finishing successfully' do
         TestTemporalOverrideWorkflow.execute_locally
-        expect(Temporal::ThreadLocalContext.get).to equal(nil)
+        expect(Temporal::ThreadLocalContext.get).to eq(nil)
       end
 
       class FailingWorkflow
@@ -59,7 +59,7 @@ describe Temporal::Testing::TemporalOverride do
 
       it 'restores original context after failing' do
         expect { FailingWorkflow.execute_locally }.to raise_error(StandardError)
-        expect(Temporal::ThreadLocalContext.get).to equal(nil)
+        expect(Temporal::ThreadLocalContext.get).to eq(nil)
       end
     end
 


### PR DESCRIPTION
Minor change to improve hygiene.
Previously, the change to the thread-local context persisted on the main thread in testing mode, making it a bit harder to isolate tests that used `Workflow.execute_locally` from one another.

Test plan:
`rspec ./spec/unit/lib/temporal/testing_spec.rb`
Also ran end-to-end tests in non-testing mode in our environment.