### PR TITLE
Add support for heartbeat details.

### DIFF
--- a/lib/temporal/activity/context.rb
+++ b/lib/temporal/activity/context.rb
@@ -35,6 +35,10 @@ module Temporal
         client.record_activity_task_heartbeat(task_token: task_token, details: details)
       end
 
+      def heartbeat_details
+        metadata.heartbeat_details
+      end
+
       def logger
         Temporal.logger
       end

--- a/lib/temporal/client/serializer/payload.rb
+++ b/lib/temporal/client/serializer/payload.rb
@@ -7,6 +7,13 @@ module Temporal
       class Payload < Base
         JSON_ENCODING = 'json/plain'.freeze
 
+        def self.from_proto(proto)
+          return if proto.nil? || proto.payloads.empty?
+
+          binary = proto.payloads.first.data
+          JSON.deserialize(binary)
+        end
+
         def to_proto
           return if object.nil?
 

--- a/lib/temporal/metadata.rb
+++ b/lib/temporal/metadata.rb
@@ -39,7 +39,8 @@ module Temporal
           workflow_run_id: task.workflow_execution.run_id,
           workflow_id: task.workflow_execution.workflow_id,
           workflow_name: task.workflow_type.name,
-          headers: headers(task.header&.fields.to_h)
+          headers: headers(task.header&.fields.to_h),
+          heartbeat_details: Temporal::Client::Serializer::Payload.from_proto(task.heartbeat_details)
         )
       end
 

--- a/lib/temporal/metadata/activity.rb
+++ b/lib/temporal/metadata/activity.rb
@@ -3,9 +3,9 @@ require 'temporal/metadata/base'
 module Temporal
   module Metadata
     class Activity < Base
-      attr_reader :namespace, :id, :name, :task_token, :attempt, :workflow_run_id, :workflow_id, :workflow_name, :headers
+      attr_reader :namespace, :id, :name, :task_token, :attempt, :workflow_run_id, :workflow_id, :workflow_name, :headers, :heartbeat_details
 
-      def initialize(namespace:, id:, name:, task_token:, attempt:, workflow_run_id:, workflow_id:, workflow_name:, headers: {})
+      def initialize(namespace:, id:, name:, task_token:, attempt:, workflow_run_id:, workflow_id:, workflow_name:, headers: {}, heartbeat_details:)
         @namespace = namespace
         @id = id
         @name = name
@@ -15,6 +15,7 @@ module Temporal
         @workflow_id = workflow_id
         @workflow_name = workflow_name
         @headers = headers
+        @heartbeat_details = heartbeat_details
 
         freeze
       end

--- a/lib/temporal/testing/local_workflow_context.rb
+++ b/lib/temporal/testing/local_workflow_context.rb
@@ -48,7 +48,8 @@ module Temporal
           workflow_run_id: run_id,
           workflow_id: workflow_id,
           workflow_name: nil, # not yet used, but will be in the future
-          headers: execution_options.headers
+          headers: execution_options.headers,
+          heartbeat_details: nil
         )
         context = LocalActivityContext.new(metadata)
 
@@ -88,7 +89,8 @@ module Temporal
           workflow_run_id: run_id,
           workflow_id: workflow_id,
           workflow_name: nil, # not yet used, but will be in the future
-          headers: execution_options.headers
+          headers: execution_options.headers,
+          heartbeat_details: nil
         )
         context = LocalActivityContext.new(metadata)
 

--- a/spec/fabricators/activity_metadata_fabricator.rb
+++ b/spec/fabricators/activity_metadata_fabricator.rb
@@ -10,4 +10,5 @@ Fabricator(:activity_metadata, from: :open_struct) do
   workflow_id { SecureRandom.uuid }
   workflow_name 'TestWorkflow'
   headers { {} }
+  heartbeat_details nil
 end

--- a/spec/unit/lib/temporal/activity/context_spec.rb
+++ b/spec/unit/lib/temporal/activity/context_spec.rb
@@ -29,6 +29,14 @@ describe Temporal::Activity::Context do
     end
   end
 
+  describe '#heartbeat_details' do
+    let(:metadata_hash) { Fabricate(:activity_metadata, heartbeat_details: 4).to_h }
+
+    it 'returns the most recent heartbeat details' do
+      expect(subject.heartbeat_details).to eq 4
+    end
+  end
+
   describe '#async!' do
     it 'marks activity context as async' do
       expect { subject.async }.to change { subject.async? }.from(false).to(true)

--- a/spec/unit/lib/temporal/metadata/activity_spec.rb
+++ b/spec/unit/lib/temporal/metadata/activity_spec.rb
@@ -15,6 +15,7 @@ describe Temporal::Metadata::Activity do
       expect(subject.workflow_id).to eq(args.workflow_id)
       expect(subject.workflow_name).to eq(args.workflow_name)
       expect(subject.headers).to eq(args.headers)
+      expect(subject.heartbeat_details).to eq(args.heartbeat_details)
     end
 
     it { is_expected.to be_frozen }


### PR DESCRIPTION
This allows activities to resume where they left off when retring based
on the previously recorded heartbeat details.