### PR TITLE
Make execution timeout default to infinite

### DIFF
--- a/lib/temporal/configuration.rb
+++ b/lib/temporal/configuration.rb
@@ -6,8 +6,11 @@ module Temporal
     attr_reader :timeouts
     attr_accessor :client_type, :host, :port, :logger, :metrics_adapter, :namespace, :task_queue, :headers
 
+    # We want an infinite execution timeout for cron schedules and other perpetual workflows.
+    # We choose an 10-year execution timeout because that's the maximum the cassandra DB supports,
+    # matching the go SDK, see https://github.com/temporalio/sdk-go/blob/d96130dad3d2bc189bc7626543bd5911cc07ff6d/internal/internal_workflow_testsuite.go#L68
     DEFAULT_TIMEOUTS = {
-      execution: 60,          # End-to-end workflow time
+      execution: 86_400 * 365 * 10, # End-to-end workflow time, including all recurrences if it's scheduled.
       task: 10,               # Workflow task processing time
       schedule_to_close: nil, # End-to-end activity time (default: schedule_to_start + start_to_close)
       schedule_to_start: 10,  # Queue time for an activity


### PR DESCRIPTION
## Description
See the comment for justification.

## Test Plan
Enqueued a workflow with no override, went to temporal web UI:
<img width="1517" alt="Screen Shot 2021-01-13 at 10 38 14 AM" src="https://user-images.githubusercontent.com/37816070/104659335-4692f600-5679-11eb-9ca7-25050c2d4523.png">
