### PR TITLE
Ensure we use a clean RunId.

### DIFF
--- a/lib/temporal/client/grpc_client.rb
+++ b/lib/temporal/client/grpc_client.rb
@@ -107,7 +107,7 @@ module Temporal
         client.start_workflow_execution(request)
       rescue GRPC::AlreadyExists => e
         # Feel like there should be cleaner way to do this...
-        run_id = e.details[/RunId: (.*)\.$/, 1]
+        run_id = e.details[/RunId: ([a-f0-9]+-[a-f0-9]+-[a-f0-9]+-[a-f0-9]+-[a-f0-9]+)/, 1]
         raise Temporal::WorkflowExecutionAlreadyStartedFailure.new(e.details, run_id)
       end
 

--- a/spec/unit/lib/temporal/grpc_client_spec.rb
+++ b/spec/unit/lib/temporal/grpc_client_spec.rb
@@ -1,0 +1,27 @@
+describe Temporal::Client::GRPCClient do
+  let(:grpc_stub) { double('grpc stub') }
+
+  describe '#start_workflow_execution' do
+    it 'provides the existing run_id when the workflow is already started' do
+      client = Temporal::Client::GRPCClient.new(nil, nil, nil)
+      allow(client).to receive(:client).and_return(grpc_stub)
+      allow(grpc_stub).to receive(:start_workflow_execution).and_raise(
+        GRPC::AlreadyExists,
+        'Workflow execution already finished successfully. WorkflowId: TestWorkflow-1, RunId: baaf1d86-4459-4ecd-a288-47aeae55245d. Workflow Id reuse policy: allow duplicate workflow Id if last run failed.'
+      )
+
+      expect {
+        client.start_workflow_execution(
+          namespace: 'test',
+          workflow_id: 'TestWorkflow-1',
+          workflow_name: 'Test',
+          task_queue: 'test',
+          execution_timeout: 0,
+          task_timeout: 0
+        )
+      }.to raise_error(Temporal::WorkflowExecutionAlreadyStartedFailure) { |e|
+        expect(e.run_id).to eql('baaf1d86-4459-4ecd-a288-47aeae55245d')
+      }
+    end
+  end
+end


### PR DESCRIPTION
Previously we would accidentally catch the text following the run id.

Reported by: @drewhoskins-stripe