### PR TITLE
Allow adjusting the activity poller's thread pool size.

### DIFF
--- a/lib/temporal/activity/poller.rb
+++ b/lib/temporal/activity/poller.rb
@@ -73,7 +73,7 @@ module Temporal
       end
 
       def process(task)
-        client = Temporal::Client.generate(options)
+        client = Temporal::Client.generate
         middleware_chain = Middleware::Chain.new(middleware)
 
         TaskProcessor.new(task, namespace, activity_lookup, client, middleware_chain).process

--- a/lib/temporal/activity/poller.rb
+++ b/lib/temporal/activity/poller.rb
@@ -6,15 +6,17 @@ require 'temporal/activity/task_processor'
 module Temporal
   class Activity
     class Poller
-      DEFAULT_THREAD_POOL_SIZE = 20
+      DEFAULT_OPTIONS = {
+        thread_pool_size: 20
+      }.freeze
 
-      def initialize(namespace, task_queue, activity_lookup, middleware = [], thread_pool_size:)
+      def initialize(namespace, task_queue, activity_lookup, middleware = [], options = {})
         @namespace = namespace
         @task_queue = task_queue
         @activity_lookup = activity_lookup
         @middleware = middleware
         @shutting_down = false
-        @thread_pool_size = thread_pool_size
+        @options = DEFAULT_OPTIONS.merge(options)
       end
 
       def start
@@ -38,7 +40,7 @@ module Temporal
 
       private
 
-      attr_reader :namespace, :task_queue, :activity_lookup, :middleware, :thread, :thread_pool_size
+      attr_reader :namespace, :task_queue, :activity_lookup, :middleware, :options, :thread
 
       def client
         @client ||= Temporal::Client.generate
@@ -78,7 +80,7 @@ module Temporal
       end
 
       def thread_pool
-        @thread_pool ||= ThreadPool.new(thread_pool_size)
+        @thread_pool ||= ThreadPool.new(options[:thread_pool_size])
       end
     end
   end

--- a/lib/temporal/activity/poller.rb
+++ b/lib/temporal/activity/poller.rb
@@ -6,14 +6,15 @@ require 'temporal/activity/task_processor'
 module Temporal
   class Activity
     class Poller
-      THREAD_POOL_SIZE = 20
+      DEFAULT_THREAD_POOL_SIZE = 20
 
-      def initialize(namespace, task_queue, activity_lookup, middleware = [])
+      def initialize(namespace, task_queue, activity_lookup, middleware = [], thread_pool_size:)
         @namespace = namespace
         @task_queue = task_queue
         @activity_lookup = activity_lookup
         @middleware = middleware
         @shutting_down = false
+        @thread_pool_size = thread_pool_size
       end
 
       def start
@@ -37,7 +38,7 @@ module Temporal
 
       private
 
-      attr_reader :namespace, :task_queue, :activity_lookup, :middleware, :thread
+      attr_reader :namespace, :task_queue, :activity_lookup, :middleware, :thread, :thread_pool_size
 
       def client
         @client ||= Temporal::Client.generate
@@ -77,7 +78,7 @@ module Temporal
       end
 
       def thread_pool
-        @thread_pool ||= ThreadPool.new(THREAD_POOL_SIZE)
+        @thread_pool ||= ThreadPool.new(thread_pool_size)
       end
     end
   end

--- a/spec/unit/lib/temporal/worker_spec.rb
+++ b/spec/unit/lib/temporal/worker_spec.rb
@@ -132,24 +132,24 @@ describe Temporal::Worker do
     it 'starts a poller for each namespace/task list combination' do
       allow(subject).to receive(:shutting_down?).and_return(true)
 
-      expect(Temporal::Workflow::Poller)
+      allow(Temporal::Workflow::Poller)
         .to receive(:new)
         .with('default-namespace', 'default-task-queue', an_instance_of(Temporal::ExecutableLookup), [])
         .and_return(workflow_poller_1)
 
-      expect(Temporal::Workflow::Poller)
+      allow(Temporal::Workflow::Poller)
         .to receive(:new)
         .with('other-namespace', 'default-task-queue', an_instance_of(Temporal::ExecutableLookup), [])
         .and_return(workflow_poller_2)
 
-      expect(Temporal::Activity::Poller)
+      allow(Temporal::Activity::Poller)
         .to receive(:new)
-        .with('default-namespace', 'default-task-queue', an_instance_of(Temporal::ExecutableLookup), [], thread_pool_size: 20)
+        .with('default-namespace', 'default-task-queue', an_instance_of(Temporal::ExecutableLookup), [], {thread_pool_size: 20})
         .and_return(activity_poller_1)
 
-      expect(Temporal::Activity::Poller)
+      allow(Temporal::Activity::Poller)
         .to receive(:new)
-        .with('default-namespace', 'other-task-queue', an_instance_of(Temporal::ExecutableLookup), [], thread_pool_size: 20)
+        .with('default-namespace', 'other-task-queue', an_instance_of(Temporal::ExecutableLookup), [], {thread_pool_size: 20})
         .and_return(activity_poller_2)
 
       subject.register_workflow(TestWorkerWorkflow)
@@ -166,10 +166,10 @@ describe Temporal::Worker do
     end
 
     it 'can have an activity poller with a different thread pool size' do
-      activity_poller = instance_double(Temporal::Activity::Poller, start: nil, thread_pool_size: 10)
+      activity_poller = instance_double(Temporal::Activity::Poller, start: nil)
       expect(Temporal::Activity::Poller)
         .to receive(:new)
-        .with('default-namespace', 'default-task-queue', an_instance_of(Temporal::ExecutableLookup), [], thread_pool_size: 10)
+        .with('default-namespace', 'default-task-queue', an_instance_of(Temporal::ExecutableLookup), [], {thread_pool_size: 10})
         .and_return(activity_poller)
 
       worker = Temporal::Worker.new(activity_thread_pool_size: 10)


### PR DESCRIPTION
We need to temporarily set the thread pool size to 1 so that activities do not run in parallel within a process.  This seems like a useful thing for clients to be able to be able adjust to anyway.

# Test Plan
Unit:
`rspec spec/unit/lib/temporal/worker_spec.rb`
