### PR TITLE
Correct id selection for WorkflowExecutionTerminated event.

### DIFF
--- a/lib/temporal/workflow/history/event.rb
+++ b/lib/temporal/workflow/history/event.rb
@@ -10,8 +10,6 @@ module Temporal
           ACTIVITY_TASK_CANCELED
           TIMER_FIRED
           REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_FAILED
-          WORKFLOW_EXECUTION_SIGNALED
-          WORKFLOW_EXECUTION_TERMINATED
           SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED
           EXTERNAL_WORKFLOW_EXECUTION_CANCEL_REQUESTED
           EXTERNAL_WORKFLOW_EXECUTION_SIGNALED
@@ -46,7 +44,7 @@ module Temporal
           case type
           when 'TIMER_FIRED'
             attributes.started_event_id
-          when 'WORKFLOW_EXECUTION_SIGNALED'
+          when 'WORKFLOW_EXECUTION_SIGNALED', 'WORKFLOW_EXECUTION_TERMINATED'
             1 # fixed id for everything related to current workflow
           when *EVENT_TYPES
             attributes.scheduled_event_id


### PR DESCRIPTION
Fixes: NoMethodError: undefined method `scheduled_event_id' for #<Temporal::Api::History::V1::WorkflowExecutionTerminatedEventAttributes:0x000056370c436d38>