### PR TITLE
Surface replay? on workflow contexts

### DIFF
--- a/lib/temporal/testing/local_workflow_context.rb
+++ b/lib/temporal/testing/local_workflow_context.rb
@@ -24,6 +24,11 @@ module Temporal
         Temporal.logger
       end
 
+      def replay?
+        # We never replay in a test context
+        false
+      end
+
       def headers
         metadata.headers
       end

--- a/lib/temporal/workflow/context.rb
+++ b/lib/temporal/workflow/context.rb
@@ -25,8 +25,12 @@ module Temporal
 
       def logger
         @logger ||= ReplayAwareLogger.new(Temporal.logger)
-        @logger.replay = state_manager.replay?
+        @logger.replay = replay?
         @logger
+      end
+
+      def replay?
+        @state_manager.replay?
       end
 
       def headers

--- a/spec/unit/lib/temporal/testing/local_workflow_context_spec.rb
+++ b/spec/unit/lib/temporal/testing/local_workflow_context_spec.rb
@@ -98,4 +98,10 @@ describe Temporal::Testing::LocalWorkflowContext do
       expect(result).to eq('ok')
     end
   end
+
+  describe '#replay?' do
+    it 'always false' do
+      expect(workflow_context.replay?).to be false
+    end
+  end
 end

--- a/spec/unit/lib/temporal/workflow/context_spec.rb
+++ b/spec/unit/lib/temporal/workflow/context_spec.rb
@@ -1,0 +1,20 @@
+require 'temporal/workflow/context'
+
+describe Temporal::Workflow::Context do
+  let(:state_manager) { instance_double('Temporal::Workflow::StateManager') }
+  let(:workflow_context) do
+    Temporal::Workflow::Context.new(
+      state_manager,
+      nil,
+      nil
+    )
+  end
+  describe '#replay' do
+    it 'gets value from state_manager' do
+      allow(state_manager).to receive(:replay?).and_return true
+
+      expect(workflow_context.replay?).to be true
+      expect(state_manager).to have_received(:replay?)
+    end
+  end
+end


### PR DESCRIPTION
Adds a method to `Temporal::Workflow::Context` and `Temporal::Testing::LocalWorkflowContext` for determining if a replay is occurring. This makes it possible to write a replay-aware custom logger or metrics emitter for other logging libraries besides the built-in Ruby logger. Specs for `LocalWorkflowContext` are extended to cover this new method and a new specs file is added for testing `Workflow::Context`. 