### PR TITLE
Support multiple payloads from array input

### DIFF
--- a/lib/temporal/activity/task_processor.rb
+++ b/lib/temporal/activity/task_processor.rb
@@ -31,7 +31,7 @@ module Temporal
         context = Activity::Context.new(client, metadata)
 
         result = middleware_chain.invoke(metadata) do
-          activity_class.execute_in_context(context, parse_payload(task.input))
+          activity_class.execute_in_context(context, Client::Serializer::Payload.from_proto(task.input))
         end
 
         # Do not complete asynchronous activities, these should be completed manually

--- a/lib/temporal/workflow/state_manager.rb
+++ b/lib/temporal/workflow/state_manager.rb
@@ -305,10 +305,7 @@ module Temporal
       end
 
       def parse_payload(payload)
-        return if payload.nil? || payload.payloads.empty?
-
-        binary = payload.payloads.first.data
-        JSON.deserialize(binary)
+        Client::Serializer::Payload.from_proto(payload)
       end
 
       def parse_failure(failure, default_exception_class = StandardError)

--- a/spec/unit/lib/temporal/client/serializer/payload_spec.rb
+++ b/spec/unit/lib/temporal/client/serializer/payload_spec.rb
@@ -1,13 +1,45 @@
 require 'temporal/client/serializer/payload'
 
 describe Temporal::Client::Serializer::Payload do
-  let(:hash) { { 'one' => 'one', two: :two, ':three' => '☻' } }
-
   describe 'round trip' do
-    it 'safely handles non-ASCII encodable UTF characters' do
-      expect(
-        described_class.from_proto(described_class.new(hash).to_proto)
-      ).to eq(hash)
+    context 'when object is a hash' do
+      let(:hash) { { 'one' => 'one', two: :two, ':three' => 3 } }
+
+      it 'converts to and from proto' do
+        expect(
+          described_class.from_proto(described_class.new(hash).to_proto)
+        ).to eq(hash)
+      end
+    end
+
+    context 'when object is an array' do
+      let(:hash) { %w[one two] }
+
+      it 'converts to and from proto' do
+        expect(
+          described_class.from_proto(described_class.new(hash).to_proto)
+        ).to eq(hash)
+      end
+    end
+
+    context 'when object has non-ASCII chars' do
+      let(:hash) { { 'three' => '☻' } }
+
+      it 'safely handles non-ASCII encodable UTF characters' do
+        expect(
+          described_class.from_proto(described_class.new(hash).to_proto)
+        ).to eq(hash)
+      end
+    end
+  end
+
+  describe 'array handling' do
+    it 'creates multiple payloads' do
+      object = %w[one two]
+
+      proto = described_class.new(object).to_proto
+
+      expect(proto.payloads.count).to eq(object.count)
     end
   end
 end


### PR DESCRIPTION
We have a workflow written in Go that receives two args.

```go
func Workflow(ctx workflow.Context, a string, b string) error {
```

When calling it from a different go program, everything works as expected.

```go
we, err := c.ExecuteWorkflow(context.Background(), workflowOptions, "Workflow", "a.json", "b.json")
```

This is a simple screenshot of the input, from `localhost:8088`.

<img width="158" alt="Screen Shot 2021-03-18 at 20 45 10" src="https://user-images.githubusercontent.com/856480/111711894-68505b00-882b-11eb-8630-ddb2394c5aea.png">

However, when calling the very same workflow from Ruby, the current code doesn't work.

```ruby
Temporal.start_workflow('Workflow', 'a.json', 'b.json', options: options)
```

Here's a screenshot of the input in this case:

<img width="187" alt="Screen Shot 2021-03-18 at 20 45 27" src="https://user-images.githubusercontent.com/856480/111712032-a3eb2500-882b-11eb-8860-9e57a22be6d4.png">

We get the following error:

```
wrapError: unable to decode the workflow function input payload with error: payload item 0: unable to decode: json: cannot unmarshal array into Go value of type string
```

... which makes a lot of sense, as it tries to put an array into a string.

-----------

If you dive in and see the code in Go that encodes payloads, you'll end up with something like this:

```go
dataConverter := converter.GetDefaultDataConverter()
input, _ := dataConverter.ToPayloads("a.json", "b.json")
fmt.Println(input.Payloads[0])
fmt.Println(input.Payloads[1])
```

Here, `input` ends up with 2 payloads.

But if you try to do the very same thing in Ruby, you'll get something like this:

```ruby
Temporal::Client::Serializer::Payload.new(['a.json', 'b.json']).to_proto
```

In this case, with the current code, you are going to get a single payload, which encodes the array, hence the wrong input you can see above.

-------

All I've done is to map the array into payloads. I monkey-patched it into the application (for testing purposes) and it worked.