### PR TITLE
Integration specs against a running server

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ jobs:
           - POSTGRES_USER=postgres
           - POSTGRES_PWD=temporal
           - POSTGRES_SEEDS=postgres
+          - TEMPORAL_HOST=temporal
           - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,8 +29,11 @@ jobs:
           - POSTGRES_USER=postgres
           - POSTGRES_PWD=temporal
           - POSTGRES_SEEDS=postgres
-          - TEMPORAL_HOST=temporal
           - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml
+
+    environment:
+      - TEMPORAL_HOST=temporal
+
     steps:
       - checkout
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,11 +17,35 @@ jobs:
   test_examples:
     docker:
       - image: circleci/ruby:2.6.3-stretch-node
+      - image: circleci/postgres:alpine
+        name: postgres
+        environment:
+          POSTGRES_PASSWORD: temporal
+      - image: temporalio/auto-setup:latest
+        name: temporal
+        environment:
+          - DB=postgresql
+          - DB_PORT=5432
+          - POSTGRES_USER=postgres
+          - POSTGRES_PWD=temporal
+          - POSTGRES_SEEDS=postgres
+          - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml
     steps:
       - checkout
+
       - run:
           name: Bundle Install
           command: cd examples && bundle install --path vendor/bundle
+
+      - run:
+          name: Register Namespace
+          command: cd examples && bin/register_namespace ruby-samples
+
+      - run:
+          name: Boot up worker
+          command: cd examples && bin/worker
+          background: true
+
       - run:
           name: Run RSpec
           command: cd examples && bundle exec rspec

--- a/examples/bin/register_namespace
+++ b/examples/bin/register_namespace
@@ -6,4 +6,21 @@ description = ARGV[1]
 
 fail 'Missing namespace name, please run register_namespace <namespace_name>' unless namespace
 
-Temporal.register_namespace(namespace, description)
+Temporal.register_namespace(namespace, description) rescue exit
+
+client = Temporal.send(:client)
+
+sleep 5
+
+# wait for namespace to get created
+loop do
+  begin
+    client.describe_namespace(name: namespace)
+  rescue
+    p 'Waiting for namespace to set up'
+    sleep 1
+    next
+  end
+
+  break
+end

--- a/examples/init.rb
+++ b/examples/init.rb
@@ -9,7 +9,7 @@ require 'temporal/metrics_adapters/log'
 metrics_logger = Logger.new(STDOUT, progname: 'metrics')
 
 Temporal.configure do |config|
-  config.host = 'localhost'
+  config.host = 'temporal'
   config.port = 7233
   config.namespace = 'ruby-samples'
   config.task_queue = 'general'

--- a/examples/init.rb
+++ b/examples/init.rb
@@ -9,9 +9,9 @@ require 'temporal/metrics_adapters/log'
 metrics_logger = Logger.new(STDOUT, progname: 'metrics')
 
 Temporal.configure do |config|
-  config.host = 'temporal'
-  config.port = 7233
-  config.namespace = 'ruby-samples'
-  config.task_queue = 'general'
+  config.host = ENV.fetch('TEMPORAL_HOST', 'localhost')
+  config.port = ENV.fetch('TEMPORAL_PORT', 7233).to_i
+  config.namespace = ENV.fetch('TEMPORAL_NAMESPACE', 'ruby-samples')
+  config.task_queue = ENV.fetch('TEMPORAL_TASK_LIST', 'general')
   config.metrics_adapter = Temporal::MetricsAdapters::Log.new(metrics_logger)
 end

--- a/examples/spec/helpers.rb
+++ b/examples/spec/helpers.rb
@@ -1,0 +1,23 @@
+require 'securerandom'
+
+module Helpers
+  def run_workflow(workflow, *input, **args)
+    workflow_id = SecureRandom.uuid
+    run_id = Temporal.start_workflow(
+      workflow,
+      *input,
+      **args.merge(options: { workflow_id: workflow_id })
+    )
+
+    client = Temporal.send(:client)
+
+    result = client.get_workflow_execution_history(
+      namespace: Temporal.configuration.namespace,
+      workflow_id: workflow_id,
+      run_id: run_id,
+      next_page_token: nil,
+      wait_for_new_event: true,
+      event_type: :close
+    )
+  end
+end

--- a/examples/spec/integration/serial_hello_world_workflow_spec.rb
+++ b/examples/spec/integration/serial_hello_world_workflow_spec.rb
@@ -3,6 +3,37 @@ require 'workflows/serial_hello_world_workflow'
 describe SerialHelloWorldWorkflow do
   subject { described_class }
 
+  it 'works' do
+    Temporal.configure do |config|
+      config.host = 'temporal'
+      config.port = 7233
+      config.namespace = 'ruby-samples'
+      config.task_queue = 'general'
+    end
+
+    workflow_id = SecureRandom.uuid
+    run_id = Temporal.start_workflow(
+      SerialHelloWorldWorkflow,
+      'Alice',
+      'Bob',
+      'John',
+      options: { workflow_id: workflow_id }
+    )
+
+    client = Temporal.send(:client)
+
+    result = client.get_workflow_execution_history(
+      namespace: Temporal.configuration.namespace,
+      workflow_id: workflow_id,
+      run_id: run_id,
+      next_page_token: nil,
+      wait_for_new_event: true,
+      event_type: :close
+    )
+
+    expect(result.history.events.first.event_type).to eq(:EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED)
+  end
+
   before { allow(HelloWorldActivity).to receive(:execute!).and_call_original }
 
   it 'executes HelloWorldActivity' do

--- a/examples/spec/integration/serial_hello_world_workflow_spec.rb
+++ b/examples/spec/integration/serial_hello_world_workflow_spec.rb
@@ -1,7 +1,7 @@
 require 'workflows/serial_hello_world_workflow'
 
 describe SerialHelloWorldWorkflow, :integration do
-  it 'works' do
+  it 'completes' do
     result = run_workflow(described_class, 'Alice', 'Bob', 'John')
 
     expect(result.history.events.first.event_type).to eq(:EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED)

--- a/examples/spec/integration/serial_hello_world_workflow_spec.rb
+++ b/examples/spec/integration/serial_hello_world_workflow_spec.rb
@@ -1,50 +1,9 @@
 require 'workflows/serial_hello_world_workflow'
 
-describe SerialHelloWorldWorkflow do
-  subject { described_class }
-
+describe SerialHelloWorldWorkflow, :integration do
   it 'works' do
-    Temporal.configure do |config|
-      config.host = 'temporal'
-      config.port = 7233
-      config.namespace = 'ruby-samples'
-      config.task_queue = 'general'
-    end
-
-    workflow_id = SecureRandom.uuid
-    run_id = Temporal.start_workflow(
-      SerialHelloWorldWorkflow,
-      'Alice',
-      'Bob',
-      'John',
-      options: { workflow_id: workflow_id }
-    )
-
-    client = Temporal.send(:client)
-
-    result = client.get_workflow_execution_history(
-      namespace: Temporal.configuration.namespace,
-      workflow_id: workflow_id,
-      run_id: run_id,
-      next_page_token: nil,
-      wait_for_new_event: true,
-      event_type: :close
-    )
+    result = run_workflow(described_class, 'Alice', 'Bob', 'John')
 
     expect(result.history.events.first.event_type).to eq(:EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED)
-  end
-
-  before { allow(HelloWorldActivity).to receive(:execute!).and_call_original }
-
-  it 'executes HelloWorldActivity' do
-    subject.execute_locally('Alice', 'Bob', 'John')
-
-    expect(HelloWorldActivity).to have_received(:execute!).with('Alice').ordered
-    expect(HelloWorldActivity).to have_received(:execute!).with('Bob').ordered
-    expect(HelloWorldActivity).to have_received(:execute!).with('John').ordered
-  end
-
-  it 'returns nil' do
-    expect(subject.execute_locally).to eq(nil)
   end
 end

--- a/examples/spec/spec_helper.rb
+++ b/examples/spec/spec_helper.rb
@@ -20,6 +20,8 @@ require 'bundler'
 Bundler.require :default, :test
 
 require 'temporal/testing'
+require 'init'
+require 'helpers'
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
@@ -51,6 +53,8 @@ RSpec.configure do |config|
   # inherited by the metadata hash of host groups and examples, rather than
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
+
+  config.include Helpers, :integration
 
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.

--- a/lib/temporal/client/grpc_client.rb
+++ b/lib/temporal/client/grpc_client.rb
@@ -17,6 +17,11 @@ module Temporal
         reject: Temporal::Api::Enums::V1::WorkflowIdReusePolicy::WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE
       }.freeze
 
+      HISTORY_EVENT_FILTER = {
+        all: Temporal::Api::Enums::V1::HistoryEventFilterType::HISTORY_EVENT_FILTER_TYPE_ALL_EVENT,
+        close: Temporal::Api::Enums::V1::HistoryEventFilterType::HISTORY_EVENT_FILTER_TYPE_CLOSE_EVENT,
+      }.freeze
+
       def initialize(host, port, identity)
         @url = "#{host}:#{port}"
         @identity = identity
@@ -112,14 +117,23 @@ module Temporal
         raise Temporal::WorkflowExecutionAlreadyStartedFailure.new(e.details, run_id)
       end
 
-      def get_workflow_execution_history(namespace:, workflow_id:, run_id:, next_page_token: nil)
+      def get_workflow_execution_history(
+        namespace:,
+        workflow_id:,
+        run_id:,
+        next_page_token: nil,
+        wait_for_new_event: false,
+        event_type: :all
+      )
         request = Temporal::Api::WorkflowService::V1::GetWorkflowExecutionHistoryRequest.new(
           namespace: namespace,
           execution: Temporal::Api::Common::V1::WorkflowExecution.new(
             workflow_id: workflow_id,
             run_id: run_id
           ),
-          next_page_token: next_page_token
+          next_page_token: next_page_token,
+          wait_new_event: wait_for_new_event,
+          history_event_filter_type: HISTORY_EVENT_FILTER[event_type]
         )
 
         client.get_workflow_execution_history(request)

--- a/spec/unit/lib/temporal/grpc_client_spec.rb
+++ b/spec/unit/lib/temporal/grpc_client_spec.rb
@@ -1,28 +1,101 @@
 describe Temporal::Client::GRPCClient do
+  subject { Temporal::Client::GRPCClient.new(nil, nil, nil) }
   let(:grpc_stub) { double('grpc stub') }
+  let(:namespace) { 'test-namespace' }
+  let(:workflow_id) { SecureRandom.uuid }
+  let(:run_id) { SecureRandom.uuid }
+
+  before do
+    allow(subject).to receive(:client).and_return(grpc_stub)
+  end
 
   describe '#start_workflow_execution' do
     it 'provides the existing run_id when the workflow is already started' do
-      client = Temporal::Client::GRPCClient.new(nil, nil, nil)
-      allow(client).to receive(:client).and_return(grpc_stub)
       allow(grpc_stub).to receive(:start_workflow_execution).and_raise(
         GRPC::AlreadyExists,
         'Workflow execution already finished successfully. WorkflowId: TestWorkflow-1, RunId: baaf1d86-4459-4ecd-a288-47aeae55245d. Workflow Id reuse policy: allow duplicate workflow Id if last run failed.'
       )
 
-      expect {
-        client.start_workflow_execution(
-          namespace: 'test',
-          workflow_id: 'TestWorkflow-1',
+      expect do
+        subject.start_workflow_execution(
+          namespace: namespace,
+          workflow_id: workflow_id,
           workflow_name: 'Test',
           task_queue: 'test',
           execution_timeout: 0,
           run_timeout: 0,
           task_timeout: 0
         )
-      }.to raise_error(Temporal::WorkflowExecutionAlreadyStartedFailure) { |e|
+      end.to raise_error(Temporal::WorkflowExecutionAlreadyStartedFailure) do |e|
         expect(e.run_id).to eql('baaf1d86-4459-4ecd-a288-47aeae55245d')
-      }
+      end
+    end
+  end
+
+  describe '#get_workflow_execution_history' do
+    let(:response) do
+      Temporal::Api::WorkflowService::V1::GetWorkflowExecutionHistoryResponse.new(
+        history: Temporal::Api::History::V1::History.new,
+        next_page_token: nil
+      )
+    end
+
+    before { allow(grpc_stub).to receive(:get_workflow_execution_history).and_return(response) }
+
+    it 'calls GRPC service with supplied arguments' do
+      subject.get_workflow_execution_history(
+        namespace: namespace,
+        workflow_id: workflow_id,
+        run_id: run_id
+      )
+
+      expect(grpc_stub).to have_received(:get_workflow_execution_history) do |request|
+        expect(request).to be_an_instance_of(Temporal::Api::WorkflowService::V1::GetWorkflowExecutionHistoryRequest)
+        expect(request.namespace).to eq(namespace)
+        expect(request.execution.workflow_id).to eq(workflow_id)
+        expect(request.execution.run_id).to eq(run_id)
+        expect(request.next_page_token).to be_empty
+        expect(request.wait_new_event).to eq(false)
+        expect(request.history_event_filter_type).to eq(
+          Temporal::Api::Enums::V1::HistoryEventFilterType.lookup(
+            Temporal::Api::Enums::V1::HistoryEventFilterType::HISTORY_EVENT_FILTER_TYPE_ALL_EVENT
+          )
+        )
+      end
+    end
+
+    context 'when wait_for_new_event is true' do
+      it 'calls GRPC service' do
+        subject.get_workflow_execution_history(
+          namespace: namespace,
+          workflow_id: workflow_id,
+          run_id: run_id,
+          wait_for_new_event: true
+        )
+
+        expect(grpc_stub).to have_received(:get_workflow_execution_history) do |request|
+          expect(request.wait_new_event).to eq(true)
+        end
+      end
+    end
+
+    context 'when event_type is :close' do
+      it 'calls GRPC service' do
+        subject.get_workflow_execution_history(
+          namespace: namespace,
+          workflow_id: workflow_id,
+          run_id: run_id,
+          event_type: :close
+        )
+
+        expect(grpc_stub).to have_received(:get_workflow_execution_history) do |request|
+          expect(request.history_event_filter_type).to eq(
+            Temporal::Api::Enums::V1::HistoryEventFilterType.lookup(
+              Temporal::Api::Enums::V1::HistoryEventFilterType::HISTORY_EVENT_FILTER_TYPE_CLOSE_EVENT
+            )
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds support for running specs in CircleCI against a running Temporal server. This allows for implementing true end-to-end specs observing the result and history of the execution