### PR TITLE
`require 'set'` whenever `Set` is used.

### DIFF
--- a/lib/temporal/testing/workflow_override.rb
+++ b/lib/temporal/testing/workflow_override.rb
@@ -1,4 +1,5 @@
 require 'securerandom'
+require 'set'
 require 'temporal/testing/local_workflow_context'
 require 'temporal/testing/workflow_execution'
 require 'temporal/metadata/workflow'

--- a/lib/temporal/workflow/state_manager.rb
+++ b/lib/temporal/workflow/state_manager.rb
@@ -1,3 +1,4 @@
+require 'set'
 require 'temporal/json'
 require 'temporal/errors'
 require 'temporal/workflow/command'


### PR DESCRIPTION
* You need to `require 'set'` before using `Set`.
* This is actually needed, but you rarely run into it since usually *someone*
  has already done it.
* You'd run into this with extremely minimal examples though (I ran into it
  with a minimal worker, in `Workflow::StateManager`).