### PR TITLE
Correct arguments to Future.fail by FutureRegistry.fail

### DIFF
--- a/lib/temporal/testing/future_registry.rb
+++ b/lib/temporal/testing/future_registry.rb
@@ -16,7 +16,7 @@ module Temporal
       end
 
       def fail(token, error)
-        store[token].fail(error.class.name, error.message)
+        store[token].fail(error)
       end
 
       private

--- a/spec/unit/lib/temporal/testing/local_workflow_context_spec.rb
+++ b/spec/unit/lib/temporal/testing/local_workflow_context_spec.rb
@@ -83,6 +83,23 @@ describe Temporal::Testing::LocalWorkflowContext do
 
         expect(f.get).to eq('async_ok')
       end
+
+      it 'failed asynchronous result' do
+        f = workflow_context.execute_activity(TestAsyncActivity)
+
+        expect(f.failed?).to be false
+        expect(f.finished?).to be false
+        expect(f.ready?).to be false
+
+        error = StandardError.new('crash')
+        execution.fail_activity(async_token, error)
+
+        expect(f.failed?).to be true
+        expect(f.finished?).to be true
+        expect(f.ready?).to be false
+
+        expect(f.get).to eq(error)
+      end
     end
   end
 


### PR DESCRIPTION
This fixes a bug in the FutureRegistry where it passes two arguments to Future.fail when this function takes only one argument. A new test case is also added to cover the case, which can be run with:

rspec spec/unit/lib/temporal/testing/local_workflow_context_spec.rb:87