### PR TITLE
Callback for when a future fails

### DIFF
--- a/examples/spec/integration/failing_activities_workflow_spec.rb
+++ b/examples/spec/integration/failing_activities_workflow_spec.rb
@@ -7,10 +7,15 @@ describe FailingActivitiesWorkflow do
     it 'counts are consistent with 2 as the right guess and 0 a terminal failure' do
       expect(FailingActivitiesWorkflow.execute_locally(count))
         .to match(
-          finished: a_value == count,
+          finished: count,
           successes: ['two'],
           terminal_guesses: 1,
-          wrong_guesses: 4
+          wrong_guesses: 4,
+          success_callbacks: { 'two' => Set.new([2]) },
+          fail_callbacks: {
+            GuessActivity::TerminalGuess => Set.new([0]),
+            GuessActivity::WrongGuess => Set.new([1, 3, 4, 5]),
+          }
         )
     end
   end

--- a/examples/workflows/failing_activities_workflow.rb
+++ b/examples/workflows/failing_activities_workflow.rb
@@ -2,7 +2,21 @@ require 'activities/guess_activity'
 
 class FailingActivitiesWorkflow < Temporal::Workflow
   def execute(count)
-    futures = (0..count - 1).map { |i| GuessActivity.execute(i) }
+    fail_callbacks = {}
+    success_callbacks = {}
+    futures = (0..count - 1).map do |i|
+      f = GuessActivity.execute(i)
+
+      f.done do |result|
+        success_callbacks[result] = (success_callbacks[result] || Set.new).add(i)
+      end
+
+      f.failed do |exception|
+        fail_callbacks[exception.class] = (fail_callbacks[exception.class] || Set.new).add(i)
+      end
+
+      f
+    end
     workflow.wait_for_all(*futures)
 
     logger.info("#{futures.count(&:failed?)} activites of #{count} failed")
@@ -11,7 +25,9 @@ class FailingActivitiesWorkflow < Temporal::Workflow
       finished: futures.count(&:finished?),
       successes: futures.select(&:ready?).map(&:get),
       terminal_guesses: futures.count { |f| f.get.class == GuessActivity::TerminalGuess },
-      wrong_guesses: futures.count { |f| f.get.class == GuessActivity::WrongGuess }
+      wrong_guesses: futures.count { |f| f.get.class == GuessActivity::WrongGuess },
+      success_callbacks: success_callbacks,
+      fail_callbacks: fail_callbacks
     }
   end
 end

--- a/examples/workflows/failing_activities_workflow.rb
+++ b/examples/workflows/failing_activities_workflow.rb
@@ -2,17 +2,17 @@ require 'activities/guess_activity'
 
 class FailingActivitiesWorkflow < Temporal::Workflow
   def execute(count)
-    fail_callbacks = {}
-    success_callbacks = {}
+    fail_callbacks = Hash.new { |_k, _v| Set.new }
+    success_callbacks = Hash.new { |_k, _v| Set.new }
     futures = (0..count - 1).map do |i|
       f = GuessActivity.execute(i)
 
       f.done do |result|
-        success_callbacks[result] = (success_callbacks[result] || Set.new).add(i)
+        success_callbacks[result] = success_callbacks[result].add(i)
       end
 
       f.failed do |exception|
-        fail_callbacks[exception.class] = (fail_callbacks[exception.class] || Set.new).add(i)
+        fail_callbacks[exception.class] = fail_callbacks[exception.class].add(i)
       end
 
       f

--- a/lib/temporal/workflow/context.rb
+++ b/lib/temporal/workflow/context.rb
@@ -59,11 +59,12 @@ module Temporal
 
         dispatcher.register_handler(target, 'completed') do |result|
           future.set(result)
-          future.callbacks.each { |callback| call_in_fiber(callback, result) }
+          future.callbacks.each { |callback| call_in_fiber(callback, result, nil) }
         end
 
         dispatcher.register_handler(target, 'failed') do |exception|
           future.fail(exception)
+          future.callbacks.each { |callback| call_in_fiber(callback, nil, exception) }
         end
 
         future
@@ -111,11 +112,12 @@ module Temporal
 
         dispatcher.register_handler(target, 'completed') do |result|
           future.set(result)
-          future.callbacks.each { |callback| call_in_fiber(callback, result) }
+          future.callbacks.each { |callback| call_in_fiber(callback, result, nil) }
         end
 
         dispatcher.register_handler(target, 'failed') do |exception|
           future.fail(exception)
+          future.callbacks.each { |callback| call_in_fiber(callback, nil, exception) }
         end
 
         future
@@ -152,11 +154,12 @@ module Temporal
 
         dispatcher.register_handler(target, 'fired') do |result|
           future.set(result)
-          future.callbacks.each { |callback| call_in_fiber(callback, result) }
+          future.callbacks.each { |callback| call_in_fiber(callback, result, nil) }
         end
 
         dispatcher.register_handler(target, 'canceled') do |exception|
           future.fail(exception)
+          future.callbacks.each { |callback| call_in_fiber(callback, nil, exception) }
         end
 
         future

--- a/lib/temporal/workflow/context.rb
+++ b/lib/temporal/workflow/context.rb
@@ -59,12 +59,12 @@ module Temporal
 
         dispatcher.register_handler(target, 'completed') do |result|
           future.set(result)
-          future.callbacks.each { |callback| call_in_fiber(callback, result, nil) }
+          future.success_callbacks.each { |callback| call_in_fiber(callback, result) }
         end
 
         dispatcher.register_handler(target, 'failed') do |exception|
           future.fail(exception)
-          future.callbacks.each { |callback| call_in_fiber(callback, nil, exception) }
+          future.failure_callbacks.each { |callback| call_in_fiber(callback, exception) }
         end
 
         future
@@ -112,12 +112,12 @@ module Temporal
 
         dispatcher.register_handler(target, 'completed') do |result|
           future.set(result)
-          future.callbacks.each { |callback| call_in_fiber(callback, result, nil) }
+          future.success_callbacks.each { |callback| call_in_fiber(callback, result) }
         end
 
         dispatcher.register_handler(target, 'failed') do |exception|
           future.fail(exception)
-          future.callbacks.each { |callback| call_in_fiber(callback, nil, exception) }
+          future.failure_callbacks.each { |callback| call_in_fiber(callback, exception) }
         end
 
         future
@@ -154,12 +154,12 @@ module Temporal
 
         dispatcher.register_handler(target, 'fired') do |result|
           future.set(result)
-          future.callbacks.each { |callback| call_in_fiber(callback, result, nil) }
+          future.success_callbacks.each { |callback| call_in_fiber(callback, result) }
         end
 
         dispatcher.register_handler(target, 'canceled') do |exception|
           future.fail(exception)
-          future.callbacks.each { |callback| call_in_fiber(callback, nil, exception) }
+          future.failure_callbacks.each { |callback| call_in_fiber(callback, exception) }
         end
 
         future

--- a/spec/unit/lib/temporal/workflow/future_spec.rb
+++ b/spec/unit/lib/temporal/workflow/future_spec.rb
@@ -1,0 +1,171 @@
+require 'temporal/workflow/future'
+
+describe Temporal::Workflow::Future do
+  let(:workflow_context) { instance_double('Temporal::Workflow::Context') }
+  let(:target) { 'dummy_target' }
+  let(:cancelation_id) { 'cancelation_id_1' }
+
+  subject { described_class.new(target, workflow_context, cancelation_id: cancelation_id) }
+
+  describe '#set' do
+    it 'failed?, ready?, finished? correct before and after' do
+      expect(subject.failed?).to be false
+      expect(subject.ready?).to be false
+      expect(subject.finished?).to be false
+
+      subject.set('success')
+      expect(subject.failed?).to be false
+      expect(subject.ready?).to be true
+      expect(subject.finished?).to be true
+    end
+  end
+
+  describe '#fail' do
+    it 'failed?, ready?, finished? correct before and after' do
+      expect(subject.failed?).to be false
+      expect(subject.ready?).to be false
+      expect(subject.finished?).to be false
+
+      subject.fail('failed')
+      expect(subject.failed?).to be true
+      expect(subject.ready?).to be false
+      expect(subject.finished?).to be true
+    end
+  end
+
+  describe '#get' do
+    it 'result if set' do
+      result = 'success'
+      subject.set(result)
+      expect(subject.get).to be result
+    end
+
+    it 'exception if fail' do
+      exception = StandardError.new('failed')
+      subject.fail(exception)
+      expect(subject.get).to be exception
+    end
+
+    it 'calls context.wait_for if not finished' do
+      allow(workflow_context).to receive(:wait_for).with(subject)
+      subject.get
+    end
+  end
+
+  describe '#wait' do
+    it 'does not wait if already done' do
+      subject.set('success')
+      subject.wait
+    end
+
+    it 'calls context.wait_for if not already done' do
+      allow(workflow_context).to receive(:wait_for).with(subject)
+      subject.wait
+    end
+  end
+
+  describe '#cancel' do
+    it 'does nothing, returns false if already finished' do
+      subject.set('already done')
+      expect(subject.cancel).to be false
+    end
+
+    it 'calls context if still pending and cancel succeeds' do
+      allow(workflow_context).to receive(:cancel).with(target, cancelation_id).and_return(true)
+      expect(subject.cancel).to be true
+    end
+
+    it 'calls context if still pending and cancel fails' do
+      allow(workflow_context).to receive(:cancel).with(target, cancelation_id).and_return(false)
+      expect(subject.cancel).to be false
+    end
+  end
+
+  describe '#done' do
+    it 'calls back immediately when already done' do
+      expected_result = 'success'
+      subject.set(expected_result)
+
+      called_with_result = nil
+      subject.done do |result|
+        called_with_result = result
+      end
+
+      expect(called_with_result).to be expected_result
+    end
+
+    it 'delays callback until done' do
+      called_with_result = nil
+      subject.done do |result|
+        called_with_result = result
+      end
+
+      expect(called_with_result).to be nil
+
+      expected_result = 'success'
+      subject.set(expected_result)
+
+      expect(called_with_result).to be nil
+      expect(subject.success_callbacks.length). to be 1
+
+      subject.success_callbacks[0].call(expected_result)
+      expect(called_with_result).to be expected_result
+    end
+
+    it 'does not call on failure' do
+      expected_exception = StandardError.new('failed')
+      subject.fail(expected_exception)
+
+      called_with_result = nil
+      subject.done do |result|
+        called_with_result = result
+      end
+
+      expect(called_with_result).to be nil
+    end
+  end
+
+  describe '#failed' do
+    it 'calls back immediately when already failed' do
+      expected_exception = StandardError.new('failure')
+      subject.fail(expected_exception)
+
+      called_with_exception = nil
+      subject.failed do |exception|
+        called_with_exception = exception
+      end
+
+      expect(called_with_exception).to be expected_exception
+    end
+
+    it 'delays callback until done' do
+      called_with_exception = nil
+      subject.failed do |exception|
+        called_with_exception = exception
+      end
+
+      expect(called_with_exception).to be nil
+
+      expected_exception = StandardError.new('failure')
+      subject.fail(expected_exception)
+
+      expect(called_with_exception).to be nil
+      expect(subject.failure_callbacks.length). to be 1
+
+      subject.failure_callbacks[0].call(expected_exception)
+      expect(called_with_exception).to be expected_exception
+    end
+
+    it 'does not call on success' do
+      expected_result = 'success'
+      subject.set(expected_result)
+
+      called_with_exception = nil
+      subject.failed do |exception|
+        called_with_exception = exception
+      end
+
+      expect(called_with_exception).to be nil
+    end
+  end
+end


### PR DESCRIPTION
Currently, the futures used for asynchronous execution of activities only call the block passed to `.done` when the activity succeeds. This change makes it possible to have a block called when the activity fails by calling `.failed`. This change is backward compatible with the existing API.

### Testing
Modified spec for a workflow that uses the activity futures

```
pushd examples
rspec spec/integration/failing_activities_workflow_spec.rb
popd
```