### PR TITLE
Allow configuring the drain grace period.

### DIFF
--- a/lib/temporal/worker.rb
+++ b/lib/temporal/worker.rb
@@ -7,9 +7,11 @@ require 'temporal/middleware/entry'
 
 module Temporal
   class Worker
+    DEFAULT_SHUTDOWN_GRACE_PERIOD = 25 # seconds
+
     # activity_thread_pool_size: number of threads that the poller can use to run activities.
     #   can be set to 1 if you want no paralellism in your activities, at the cost of throughput.
-    def initialize(activity_thread_pool_size: Temporal::Activity::Poller::DEFAULT_OPTIONS[:thread_pool_size])
+    def initialize(activity_thread_pool_size: Temporal::Activity::Poller::DEFAULT_OPTIONS[:thread_pool_size], shutdown_grace_period: DEFAULT_SHUTDOWN_GRACE_PERIOD)
       @workflows = Hash.new { |hash, key| hash[key] = ExecutableLookup.new }
       @activities = Hash.new { |hash, key| hash[key] = ExecutableLookup.new }
       @pollers = []
@@ -19,6 +21,7 @@ module Temporal
       @activity_poller_options = {
         thread_pool_size: activity_thread_pool_size,
       }
+      @shutdown_grace_period = shutdown_grace_period
     end
 
     def register_workflow(workflow_class, options = {})
@@ -67,7 +70,7 @@ module Temporal
         pollers.each(&:stop_polling)
         # allow workers to drain in-transit tasks.
         # https://github.com/temporalio/temporal/issues/1058
-        sleep 1
+        sleep @shutdown_grace_period
         pollers.each(&:cancel_pending_requests)
         pollers.each(&:wait)
       end.join


### PR DESCRIPTION
Defaults to 25 seconds to fit inside the default grace period for
kubernetes pod shutdown which is 30 seconds.