### PR TITLE
Allow heartbeats in local testing mode

### DIFF
--- a/lib/temporal/testing/local_activity_context.rb
+++ b/lib/temporal/testing/local_activity_context.rb
@@ -10,7 +10,7 @@ module Temporal
       end
 
       def heartbeat(details = nil)
-        raise NotImplementedError, 'not yet available for testing'
+        # behavior is not yet testable in local mode
       end
     end
   end

--- a/spec/unit/lib/temporal/testing/local_workflow_context_spec.rb
+++ b/spec/unit/lib/temporal/testing/local_workflow_context_spec.rb
@@ -25,6 +25,12 @@ describe Temporal::Testing::LocalWorkflowContext do
     )
   end
 
+  class TestHeartbeatingActivity < Temporal::Activity
+    def execute
+      activity.heartbeat
+    end
+  end
+
   class TestFailedActivity < Temporal::Activity
     def execute
       raise 'oops'
@@ -114,5 +120,10 @@ describe Temporal::Testing::LocalWorkflowContext do
       result = workflow_context.execute_activity!(TestActivity)
       expect(result).to eq('ok')
     end
+  end
+
+  it 'can heartbeat' do
+    # Heartbeat doesn't do anything in local mode, but at least it can be called.
+    workflow_context.execute_activity!(TestHeartbeatingActivity)
   end
 end


### PR DESCRIPTION
Unblocks product engineers calling activities that `heartbeat` in local testing mode.

## Test Plan
`bundle exec rspec spec/unit/lib/temporal/testing/local_workflow_context_spec.rb`