### PR TITLE
Workflow determinism check

### DIFF
--- a/lib/temporal/errors.rb
+++ b/lib/temporal/errors.rb
@@ -5,6 +5,10 @@ module Temporal
   # Superclass for errors specific to Temporal worker itself
   class InternalError < Error; end
 
+  # Indicates a non-deterministic workflow execution, might be due to
+  # a non-deterministic workflow implementation or the gem's bug
+  class NonDeterministicWorkflowError < InternalError; end
+
   # Superclass for misconfiguration/misuse on the client (user) side
   class ClientError < Error; end
 

--- a/lib/temporal/workflow/history/event_target.rb
+++ b/lib/temporal/workflow/history/event_target.rb
@@ -69,6 +69,10 @@ module Temporal
         def hash
           [id, type].hash
         end
+
+        def to_s
+          "#{type} (#{id})"
+        end
       end
     end
   end

--- a/lib/temporal/workflow/state_manager.rb
+++ b/lib/temporal/workflow/state_manager.rb
@@ -132,7 +132,7 @@ module Temporal
 
         when 'ACTIVITY_TASK_SCHEDULED'
           state_machine.schedule
-          discard_command(event.originating_event_id)
+          discard_command(target)
 
         when 'ACTIVITY_TASK_STARTED'
           state_machine.start
@@ -151,7 +151,7 @@ module Temporal
 
         when 'ACTIVITY_TASK_CANCEL_REQUESTED'
           state_machine.requested
-          discard_command(event.originating_event_id)
+          discard_command(target)
 
         when 'REQUEST_CANCEL_ACTIVITY_TASK_FAILED'
           state_machine.fail
@@ -163,7 +163,7 @@ module Temporal
 
         when 'TIMER_STARTED'
           state_machine.start
-          discard_command(event.originating_event_id)
+          discard_command(target)
 
         when 'TIMER_FIRED'
           state_machine.complete
@@ -207,7 +207,7 @@ module Temporal
 
         when 'START_CHILD_WORKFLOW_EXECUTION_INITIATED'
           state_machine.schedule
-          discard_command(event.originating_event_id)
+          discard_command(target)
 
         when 'START_CHILD_WORKFLOW_EXECUTION_FAILED'
           state_machine.fail
@@ -278,8 +278,18 @@ module Temporal
         dispatcher.dispatch(target, name, attributes)
       end
 
-      def discard_command(command_id)
-        commands.delete_if { |(id, _)| id == command_id }
+      def discard_command(target)
+        # Pop the first command from the list, it is expected to match
+        existing_command_id, existing_command = commands.shift
+
+        if !existing_command_id
+          raise NonDeterministicWorkflowError, "A command #{target} was not scheduled upon replay"
+        end
+
+        existing_target = event_target_from(existing_command_id, existing_command)
+        if target != existing_target
+          raise NonDeterministicWorkflowError, "Unexpected command #{existing_target} (expected #{target})"
+        end
       end
 
       def handle_marker(id, type, details)


### PR DESCRIPTION
This is a port of a bug fix from cadence-ruby: https://github.com/coinbase/cadence-ruby/pull/13

This change ensures that when a workflow is replayed all the commands match previously made ones. If not, a Temporal::NonDeterministicWorkflowError will be raised during execution which will fail the workflow task. While deterministic workflows remain running and enter a bad state, they can now be recovered from this state and the failure is logged in workflow history.

### Testing
- Existing specs continue to pass:
`rspec`
`pushd examples && rspec && popd`
- Manually tested that existing workflow worker continues to run as expected, verified that a non-deterministic workflow produces the expected error and can resume after code is corrected