### PR TITLE
Changes to retry policy validation

### DIFF
--- a/lib/temporal/retry_policy.rb
+++ b/lib/temporal/retry_policy.rb
@@ -1,8 +1,9 @@
 require 'temporal/errors'
 
 module Temporal
+  # See https://docs.temporal.io/docs/go/retries/ for go documentation of equivalent concepts.
   class RetryPolicy < Struct.new(:interval, :backoff, :max_interval, :max_attempts,
-    :expiration_interval, :non_retriable_errors, keyword_init: true)
+    :non_retriable_errors, keyword_init: true)
 
     class InvalidRetryPolicy < ClientError; end
 
@@ -11,15 +12,11 @@ module Temporal
         raise InvalidRetryPolicy, 'interval and backoff must be set if max_attempts != 1'
       end
 
-      unless max_attempts || expiration_interval
-        raise InvalidRetryPolicy, 'max_attempts or expiration_interval must be set'
-      end
-
-      unless [interval, max_interval, expiration_interval].compact.all? { |arg| arg.is_a?(Integer) }
+      unless [interval, max_interval].compact.all? { |arg| arg.is_a?(Integer) }
         raise InvalidRetryPolicy, 'All intervals must be specified in whole seconds'
       end
 
-      unless [interval, max_interval, expiration_interval].compact.all? { |arg| arg > 0 }
+      unless [interval, max_interval].compact.all? { |arg| arg > 0 }
         raise InvalidRetryPolicy, 'All intervals must be greater than 0'
       end
     end

--- a/lib/temporal/retry_policy.rb
+++ b/lib/temporal/retry_policy.rb
@@ -7,8 +7,8 @@ module Temporal
     class InvalidRetryPolicy < ClientError; end
 
     def validate!
-      unless interval && backoff
-        raise InvalidRetryPolicy, 'interval and backoff must be set'
+      unless max_attempts == 1 || (interval && backoff)
+        raise InvalidRetryPolicy, 'interval and backoff must be set if max_attempts != 1'
       end
 
       unless max_attempts || expiration_interval

--- a/spec/unit/lib/temporal/retry_policy_spec.rb
+++ b/spec/unit/lib/temporal/retry_policy_spec.rb
@@ -15,6 +15,17 @@ describe Temporal::RetryPolicy do
       }
     end
 
+    let(:no_retry_policy) do
+      {
+        interval: nil,
+        backoff: nil,
+        max_interval: nil,
+        max_attempts: 1,
+        expiration_interval: nil,
+        non_retriable_errors: nil
+      }
+    end
+
     shared_examples 'error' do |message|
       it 'raises InvalidRetryPolicy error' do
         expect { subject.validate! }.to raise_error(described_class::InvalidRetryPolicy, message)
@@ -29,17 +40,24 @@ describe Temporal::RetryPolicy do
       end
     end
 
+    context 'with no retries' do
+      let(:attributes) { no_retry_policy }
+      it 'does not raise' do
+        expect { subject.validate! }.not_to raise_error
+      end
+    end
+
     context 'with invalid attributes' do
       context 'with missing :interval' do
         let(:attributes) { valid_attributes.tap { |h| h.delete(:interval) } }
 
-        include_examples 'error', 'interval and backoff must be set'
+        include_examples 'error', 'interval and backoff must be set if max_attempts != 1'
       end
 
       context 'with missing :backoff' do
         let(:attributes) { valid_attributes.tap { |h| h.delete(:backoff) } }
 
-        include_examples 'error', 'interval and backoff must be set'
+        include_examples 'error', 'interval and backoff must be set if max_attempts != 1'
       end
 
       context 'with :max_attempts and :expiration_interval missing' do

--- a/spec/unit/lib/temporal/retry_policy_spec.rb
+++ b/spec/unit/lib/temporal/retry_policy_spec.rb
@@ -10,7 +10,6 @@ describe Temporal::RetryPolicy do
         backoff: 1.5,
         max_interval: 5,
         max_attempts: 3,
-        expiration_interval: nil,
         non_retriable_errors: nil
       }
     end
@@ -21,7 +20,16 @@ describe Temporal::RetryPolicy do
         backoff: nil,
         max_interval: nil,
         max_attempts: 1,
-        expiration_interval: nil,
+        non_retriable_errors: nil
+      }
+    end
+
+    let(:unlimited_attempts) do
+      {
+        interval: 1,
+        backoff: 2.0,
+        max_interval: 10,
+        max_attempts: nil,
         non_retriable_errors: nil
       }
     end
@@ -47,6 +55,13 @@ describe Temporal::RetryPolicy do
       end
     end
 
+    context 'with unlimited attempts' do
+      let(:attributes) { unlimited_attempts }
+      it 'does not raise' do
+        expect { subject.validate! }.not_to raise_error
+      end
+    end
+
     context 'with invalid attributes' do
       context 'with missing :interval' do
         let(:attributes) { valid_attributes.tap { |h| h.delete(:interval) } }
@@ -60,18 +75,7 @@ describe Temporal::RetryPolicy do
         include_examples 'error', 'interval and backoff must be set if max_attempts != 1'
       end
 
-      context 'with :max_attempts and :expiration_interval missing' do
-        let(:attributes) do
-          valid_attributes.tap do |h|
-            h.delete(:max_attempts)
-            h.delete(:expiration_interval)
-          end
-        end
-
-        include_examples 'error', 'max_attempts or expiration_interval must be set'
-      end
-
-      %i[interval max_interval expiration_interval].each do |attr|
+      %i[interval max_interval].each do |attr|
         context "with #{attr} set to a float" do
           let(:attributes) { valid_attributes.tap { |h| h[attr] = 1.5 } }
 


### PR DESCRIPTION
## Summary
* When there are no retries, it shouldn't be necessary to set the other retry policy parameters.  I think `nil` will be less confusing than a bunch of values that aren't actually used.
* `expiration_interval` is unused
* temporal allows max_attempts to be nil, see https://docs.temporal.io/docs/go/retries/

## Test Plan
New test of a "clean" no-retry policy and an unlimited-attempts policy:
```bundle exec rspec spec/unit/lib/temporal/retry_policy_spec.rb```