### PR TITLE
Reuse GRPC connection for Activity processing

### DIFF
--- a/lib/temporal/activity/poller.rb
+++ b/lib/temporal/activity/poller.rb
@@ -77,7 +77,6 @@ module Temporal
       end
 
       def process(task)
-        client = Temporal::Client.generate
         middleware_chain = Middleware::Chain.new(middleware)
 
         TaskProcessor.new(task, namespace, activity_lookup, client, middleware_chain).process


### PR DESCRIPTION
Reusing the same GRPC connection will increase the performance and reduce the load on the Temporal server — it gets created and goes through a handshake otherwise, which can be expensive. GRPC is thread-safe and expects connection reuse

Tested under load against the Temporal Cloud instance.