### PR TITLE
Enable workflow poller thread pool

### DIFF
--- a/lib/temporal/activity/poller.rb
+++ b/lib/temporal/activity/poller.rb
@@ -77,7 +77,6 @@ module Temporal
       end
 
       def process(task)
-        client = Temporal::Client.generate
         middleware_chain = Middleware::Chain.new(middleware)
 
         TaskProcessor.new(task, namespace, activity_lookup, client, middleware_chain).process

--- a/lib/temporal/workflow/poller.rb
+++ b/lib/temporal/workflow/poller.rb
@@ -1,4 +1,5 @@
 require 'temporal/client'
+require 'temporal/thread_pool'
 require 'temporal/middleware/chain'
 require 'temporal/workflow/task_processor'
 require 'temporal/error_handler'
@@ -6,12 +7,17 @@ require 'temporal/error_handler'
 module Temporal
   class Workflow
     class Poller
-      def initialize(namespace, task_queue, workflow_lookup, middleware = [])
+      DEFAULT_OPTIONS = {
+        thread_pool_size: 10
+      }.freeze
+
+      def initialize(namespace, task_queue, workflow_lookup, middleware = [], options = {})
         @namespace = namespace
         @task_queue = task_queue
         @workflow_lookup = workflow_lookup
         @middleware = middleware
         @shutting_down = false
+        @options = DEFAULT_OPTIONS.merge(options)
       end
 
       def start
@@ -29,19 +35,16 @@ module Temporal
       end
 
       def wait
-        @thread.join
+        thread.join
+        thread_pool.shutdown
       end
 
       private
 
-      attr_reader :namespace, :task_queue, :client, :workflow_lookup, :middleware
+      attr_reader :namespace, :task_queue, :workflow_lookup, :middleware, :options, :thread
 
       def client
         @client ||= Temporal::Client.generate
-      end
-
-      def middleware_chain
-        @middleware_chain ||= Middleware::Chain.new(middleware)
       end
 
       def shutting_down?
@@ -49,11 +52,17 @@ module Temporal
       end
 
       def poll_loop
-        while !shutting_down? do
+        loop do
+          thread_pool.wait_for_available_threads
+
+          return if shutting_down?
+
           Temporal.logger.debug("Polling worklow task queue (#{namespace} / #{task_queue})")
 
           task = poll_for_task
-          process(task) if task&.workflow_type
+          next unless task&.workflow_type
+
+          thread_pool.schedule { process(task) }
         end
       end
 
@@ -68,7 +77,13 @@ module Temporal
       end
 
       def process(task)
+        middleware_chain = Middleware::Chain.new(middleware)
+
         TaskProcessor.new(task, namespace, workflow_lookup, client, middleware_chain).process
+      end
+
+      def thread_pool
+        @thread_pool ||= ThreadPool.new(options[:thread_pool_size])
       end
     end
   end

--- a/spec/unit/lib/temporal/worker_spec.rb
+++ b/spec/unit/lib/temporal/worker_spec.rb
@@ -134,22 +134,46 @@ describe Temporal::Worker do
 
       allow(Temporal::Workflow::Poller)
         .to receive(:new)
-        .with('default-namespace', 'default-task-queue', an_instance_of(Temporal::ExecutableLookup), [])
+        .with(
+          'default-namespace',
+          'default-task-queue',
+          an_instance_of(Temporal::ExecutableLookup),
+          [],
+          thread_pool_size: 10
+        )
         .and_return(workflow_poller_1)
 
       allow(Temporal::Workflow::Poller)
         .to receive(:new)
-        .with('other-namespace', 'default-task-queue', an_instance_of(Temporal::ExecutableLookup), [])
+        .with(
+          'other-namespace',
+          'default-task-queue',
+          an_instance_of(Temporal::ExecutableLookup),
+          [],
+          thread_pool_size: 10
+        )
         .and_return(workflow_poller_2)
 
       allow(Temporal::Activity::Poller)
         .to receive(:new)
-        .with('default-namespace', 'default-task-queue', an_instance_of(Temporal::ExecutableLookup), [], {thread_pool_size: 20})
+        .with(
+          'default-namespace',
+          'default-task-queue',
+          an_instance_of(Temporal::ExecutableLookup),
+          [],
+          thread_pool_size: 20
+        )
         .and_return(activity_poller_1)
 
       allow(Temporal::Activity::Poller)
         .to receive(:new)
-        .with('default-namespace', 'other-task-queue', an_instance_of(Temporal::ExecutableLookup), [], {thread_pool_size: 20})
+        .with(
+          'default-namespace',
+          'other-task-queue',
+          an_instance_of(Temporal::ExecutableLookup),
+          [],
+          thread_pool_size: 20
+        )
         .and_return(activity_poller_2)
 
       subject.register_workflow(TestWorkerWorkflow)
@@ -207,12 +231,24 @@ describe Temporal::Worker do
 
         allow(Temporal::Workflow::Poller)
           .to receive(:new)
-          .with('default-namespace', 'default-task-queue', an_instance_of(Temporal::ExecutableLookup), [entry_1])
+          .with(
+            'default-namespace',
+            'default-task-queue',
+            an_instance_of(Temporal::ExecutableLookup),
+            [entry_1],
+            thread_pool_size: 10
+          )
           .and_return(workflow_poller_1)
 
         allow(Temporal::Activity::Poller)
           .to receive(:new)
-          .with('default-namespace', 'default-task-queue', an_instance_of(Temporal::ExecutableLookup), [entry_2], thread_pool_size: 20)
+          .with(
+            'default-namespace',
+            'default-task-queue',
+            an_instance_of(Temporal::ExecutableLookup),
+            [entry_2],
+            thread_pool_size: 20
+          )
           .and_return(activity_poller_1)
 
         subject.register_workflow(TestWorkerWorkflow)


### PR DESCRIPTION
Make workflow poller use a thread pool similar to activity poller. In a high load scenario communication with the Temporal server can get slow which makes workflow poller quite inefficient. The workflow processing itself is CPU bound, however performance analysis has shown that majority of that time is spent sending the response back to Temporal.

This change will allow multiple workflow tasks to be processed concurrently increasing the efficiency.

Tested under heavy load against Temporal Cloud achieving a throughput of 1k workflows per second.