### PR TITLE
Reduce workflow task failure reporting retries from 10 to 1

### DIFF
--- a/lib/temporal/workflow/task_processor.rb
+++ b/lib/temporal/workflow/task_processor.rb
@@ -7,7 +7,7 @@ require 'temporal/errors'
 module Temporal
   class Workflow
     class TaskProcessor
-      MAX_FAILED_ATTEMPTS = 10
+      MAX_FAILED_ATTEMPTS = 1
 
       def initialize(task, namespace, workflow_lookup, client, middleware_chain)
         @task = task
@@ -91,8 +91,10 @@ module Temporal
         Temporal.logger.error("Workflow task for #{workflow_name} failed with: #{error.inspect}")
         Temporal.logger.debug(error.backtrace.join("\n"))
 
-        # Stop from getting into infinite loop if the error persists
-        return if task.attempt >= MAX_FAILED_ATTEMPTS
+        # Only fail the workflow task on the first attempt. Subsequent failures of the same workflow task
+        # should timeout. This is to avoid spinning on the failed workflow task as the service doesn't
+        # yet exponentially backoff on retries.
+        return if task.attempt > MAX_FAILED_ATTEMPTS
 
         client.respond_workflow_task_failed(
           task_token: task_token,

--- a/spec/unit/lib/temporal/workflow/task_processor_spec.rb
+++ b/spec/unit/lib/temporal/workflow/task_processor_spec.rb
@@ -133,6 +133,14 @@ describe Temporal::Workflow::TaskProcessor do
             )
         end
 
+        it 'does not fail the task beyond the first attempt' do
+          task.attempt = 2
+          subject.process
+
+          expect(client)
+            .not_to have_received(:respond_workflow_task_failed)
+        end
+
         it 'ignores client exception' do
           allow(client)
             .to receive(:respond_workflow_task_failed)


### PR DESCRIPTION
### Summary

When a workflow task fails, only the first failure will now be reported to Temporal server. After the first attempt, subsequent failed tasks will instead time out, reducing how quickly failed tasks are retried to the workflow task timeout.

### Motivation

This reduces load on Temporal server and prevents the task queue from being overwhelmed by retries. This can occur when bad code is deployed that causes the tasks of many workflows to fail. This new retry limit is consistent with the [Go](https://github.com/temporalio/sdk-go/blob/6580cbe0aa41a8b515791f95c2c15bb37db1dab1/internal/internal_task_pollers.go#L380-L381) and [Java](https://github.com/temporalio/sdk-java/blob/master/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowTaskHandler.java#L142-L144) SDKs and is recommended by  Temporal.

### Testing

- New unit test covering a second workflow task attempt failing
  - `rspec spec/unit/lib/temporal/workflow/task_processor_spec.rb:136`
- Existing unit test covering the case of the first attempt continues to work
  - `rspec spec/unit/lib/temporal/workflow/task_processor_spec.rb:124`