### PR TITLE
Retryer; Retries on activity completion/failure

### DIFF
--- a/examples/activities/sleep_activity.rb
+++ b/examples/activities/sleep_activity.rb
@@ -1,11 +1,10 @@
 class SleepActivity < Temporal::Activity
   timeouts(
-    schedule_to_close: 5,
-    schedule_to_start: 5,
-    start_to_close: 5,
-    heartbeat: 5
+    schedule_to_close: 300,
+    start_to_close: 300,
   )
 
+  # timeout can be up to schedule_to_close seconds
   def execute(timeout)
     sleep timeout
   end

--- a/lib/temporal/activity/poller.rb
+++ b/lib/temporal/activity/poller.rb
@@ -61,7 +61,6 @@ module Temporal
 
           task = poll_for_task
           next unless task&.activity_type
-
           thread_pool.schedule { process(task) }
         end
       end

--- a/lib/temporal/activity/poller.rb
+++ b/lib/temporal/activity/poller.rb
@@ -61,6 +61,7 @@ module Temporal
 
           task = poll_for_task
           next unless task&.activity_type
+
           thread_pool.schedule { process(task) }
         end
       end

--- a/lib/temporal/activity/task_processor.rb
+++ b/lib/temporal/activity/task_processor.rb
@@ -62,10 +62,7 @@ module Temporal
         log_retry = proc do
           Temporal.logger.debug("Failed to report activity task completion, retrying", metadata.to_h)
         end
-        Temporal::Client::Retryer.retry_for(
-          60.0,
-          on_retry: log_retry,
-        ) do
+        Temporal::Client::Retryer.with_retries(on_retry: log_retry) do
           client.respond_activity_task_completed(task_token: task_token, result: result)
         end
       rescue StandardError => error
@@ -79,10 +76,7 @@ module Temporal
         log_retry = proc do
           Temporal.logger.debug("Failed to report activity task failure, retrying", metadata.to_h)
         end
-        Temporal::Client::Retryer.retry_for(
-          60.0,
-          on_retry: log_retry,
-        ) do
+        Temporal::Client::Retryer.with_retries(on_retry: log_retry) do
           client.respond_activity_task_failed(task_token: task_token, exception: error)
         end
       rescue StandardError => error

--- a/lib/temporal/client/retryer.rb
+++ b/lib/temporal/client/retryer.rb
@@ -12,21 +12,17 @@ module Temporal
         # https://github.com/temporalio/sdk-java/blob/ad8831d4a4d9d257baf3482ab49f1aa681895c0e/temporal-serviceclient/src/main/java/io/temporal/serviceclient/RpcRetryOptions.java#L32
         current_interval_s = INITIAL_INTERVAL_S
         elapsed_s = 0.0
-        result = nil
         loop do
           begin
-            result = yield
+            return yield
           rescue
-            Temporal.logger.debug(retry_message, metadata_hash)
-            sleep(current_interval_s)
             elapsed_s += current_interval_s
             raise if elapsed_s >= give_up_after_s
+            Temporal.logger.debug(retry_message, metadata_hash)
+            sleep(current_interval_s)
             current_interval_s = [current_interval_s * BACKOFF_COEFFICIENT, MAX_INTERVAL_S].min
-          else
-            break
           end
         end
-        result
       end
     end
   end

--- a/lib/temporal/client/retryer.rb
+++ b/lib/temporal/client/retryer.rb
@@ -1,0 +1,33 @@
+module Temporal
+  module Client
+    module Retryer
+      INITIAL_INTERVAL_S = 0.2
+      MAX_INTERVAL_S = 6.0
+      BACKOFF_COEFFICIENT = 1.2
+
+      # Used for backoff retries in certain cases when calling temporal server.
+      # metadata_hash: for logging, pass in metadata.to_h
+      def self.retry_for(give_up_after_s, retry_message:, metadata_hash:, &block)
+        # Values taken from the Java SDK
+        # https://github.com/temporalio/sdk-java/blob/ad8831d4a4d9d257baf3482ab49f1aa681895c0e/temporal-serviceclient/src/main/java/io/temporal/serviceclient/RpcRetryOptions.java#L32
+        current_interval_s = INITIAL_INTERVAL_S
+        elapsed_s = 0.0
+        result = nil
+        loop do
+          begin
+            result = yield
+          rescue
+            Temporal.logger.debug(retry_message, metadata_hash)
+            sleep(current_interval_s)
+            elapsed_s += current_interval_s
+            raise if elapsed_s >= give_up_after_s
+            current_interval_s = [current_interval_s * BACKOFF_COEFFICIENT, MAX_INTERVAL_S].min
+          else
+            break
+          end
+        end
+        result
+      end
+    end
+  end
+end

--- a/lib/temporal/client/retryer.rb
+++ b/lib/temporal/client/retryer.rb
@@ -4,20 +4,21 @@ module Temporal
       INITIAL_INTERVAL_S = 0.2
       MAX_INTERVAL_S = 6.0
       BACKOFF_COEFFICIENT = 1.2
+      DEFAULT_RETRIES = 24 # gets us to about 60s given the other parameters, assuming 0 latency
 
       # Used for backoff retries in certain cases when calling temporal server.
       # on_retry - a proc that's executed each time you need to retry
-      def self.retry_for(give_up_after_s, on_retry: nil, &block)
+      def self.with_retries(times: DEFAULT_RETRIES, on_retry: nil, &block)
         # Values taken from the Java SDK
         # https://github.com/temporalio/sdk-java/blob/ad8831d4a4d9d257baf3482ab49f1aa681895c0e/temporal-serviceclient/src/main/java/io/temporal/serviceclient/RpcRetryOptions.java#L32
         current_interval_s = INITIAL_INTERVAL_S
-        elapsed_s = 0.0
+        retry_i = 0
         loop do
           begin
             return yield
           rescue
-            elapsed_s += current_interval_s
-            raise if elapsed_s >= give_up_after_s
+            raise if retry_i >= times
+            retry_i += 1
             on_retry.call if on_retry
             sleep(current_interval_s)
             current_interval_s = [current_interval_s * BACKOFF_COEFFICIENT, MAX_INTERVAL_S].min

--- a/lib/temporal/workflow/poller.rb
+++ b/lib/temporal/workflow/poller.rb
@@ -70,7 +70,6 @@ module Temporal
         client.poll_workflow_task_queue(namespace: namespace, task_queue: task_queue)
       rescue StandardError => error
         Temporal.logger.error("Unable to poll Workflow task queue", { namespace: namespace, task_queue: task_queue, error: error.inspect })
-
         Temporal::ErrorHandler.handle(error)
 
         nil

--- a/spec/unit/lib/temporal/client/retryer.rb
+++ b/spec/unit/lib/temporal/client/retryer.rb
@@ -5,14 +5,15 @@ require 'time'
 describe Temporal::Client::Retryer do
   it 'backs off and stops retrying eventually' do
     timestamps = []
-    max_wait = 5.0
+    max_wait = 2.0
     expect do
       result = described_class.retry_for(max_wait, retry_message: "Still trying", metadata_hash: {}) do
         timestamps << Time.now.to_f
         raise 'try again'
       end
     end.to raise_error(StandardError)
-    expect(timestamps.last - timestamps.first).to be <= max_wait
+    epsilon = 0.1 # fudge factor for execution time, which isn't tracked in Retryer.
+    expect(timestamps.last - timestamps.first).to be <= max_wait + epsilon
 
     # Test backoff
     initial_interval = 0.2

--- a/spec/unit/lib/temporal/client/retryer.rb
+++ b/spec/unit/lib/temporal/client/retryer.rb
@@ -4,22 +4,25 @@ require 'time'
 
 describe Temporal::Client::Retryer do
   it 'backs off and stops retrying eventually' do
-    timestamps = []
-    max_wait = 2.0
+    sleep_amounts = []
+    max_wait = 6.0
+    expect(described_class).to receive(:sleep).at_least(10).times do |amount|
+      sleep_amounts << amount
+    end
+
     expect do
       result = described_class.retry_for(max_wait, retry_message: "Still trying", metadata_hash: {}) do
-        timestamps << Time.now.to_f
         raise 'try again'
       end
     end.to raise_error(StandardError)
-    epsilon = 0.1 # fudge factor for execution time, which isn't tracked in Retryer.
-    expect(timestamps.last - timestamps.first).to be <= max_wait + epsilon
+    expect(sleep_amounts.sum).to be <= max_wait
 
     # Test backoff
     initial_interval = 0.2
     backoff = 1.2
-    (0..timestamps.length - 2).each do |i|
-      expect(timestamps[i + 1] - timestamps[i]).to be >= initial_interval * (backoff**i)
+
+    sleep_amounts.each_with_index do |sleep_amount, i|
+      expect(sleep_amount).to be_within(0.01).of(initial_interval * (backoff**i))
     end
   end
 

--- a/spec/unit/lib/temporal/client/retryer.rb
+++ b/spec/unit/lib/temporal/client/retryer.rb
@@ -1,0 +1,45 @@
+require 'temporal/client/retryer'
+require 'temporal/metadata'
+require 'time'
+
+describe Temporal::Client::Retryer do
+  it 'backs off and stops retrying eventually' do
+    timestamps = []
+    max_wait = 5.0
+    expect do
+      result = described_class.retry_for(max_wait, retry_message: "Still trying", metadata_hash: {}) do
+        timestamps << Time.now.to_f
+        raise 'try again'
+      end
+    end.to raise_error(StandardError)
+    expect(timestamps.last - timestamps.first).to be <= max_wait
+
+    # Test backoff
+    initial_interval = 0.2
+    backoff = 1.2
+    (0..timestamps.length - 2).each do |i|
+      expect(timestamps[i + 1] - timestamps[i]).to be >= initial_interval * (backoff**i)
+    end
+  end
+
+  it 'can succeed' do
+    result = described_class.retry_for(1, retry_message: "Still trying", metadata_hash: {}) do
+      5
+    end
+    expect(result).to eq(5)
+  end
+
+  it 'can succeed after retries' do
+    i = 0
+    result = described_class.retry_for(1, retry_message: "Still trying", metadata_hash: {}) do
+      if i < 2
+        i += 1
+        raise "keep trying"
+      else
+        6
+      end
+    end
+    expect(result).to eq(6)
+  end
+end
+

--- a/spec/unit/lib/temporal/client/retryer.rb
+++ b/spec/unit/lib/temporal/client/retryer.rb
@@ -23,6 +23,18 @@ describe Temporal::Client::Retryer do
     end
   end
 
+  it 'caps out amount slept' do
+    expect(described_class).to receive(:sleep).at_least(10).times do |amount|
+      expect(amount).to be <= 6.0 # At most 6 seconds between retries.
+    end
+    max_wait = 30
+    expect do
+      described_class.retry_for(max_wait, retry_message: "Still trying", metadata_hash: {}) do
+        raise 'try again'
+      end
+    end.to raise_error(StandardError)
+  end
+
   it 'can succeed' do
     result = described_class.retry_for(1, retry_message: "Still trying", metadata_hash: {}) do
       5


### PR DESCRIPTION
# Description
* Java SDK's workers retry when trying to report activity completion/failure.  This should increase reliability when the server is down.
* I tried to use the exact backoff policy parameters they use for their default [GrpcRetryer](https://github.com/temporalio/sdk-java/blob/ad8831d4a4d9d257baf3482ab49f1aa681895c0e/temporal-sdk/src/main/java/io/temporal/internal/common/GrpcRetryer.java#L36), see [RpcRetryOptions](https://github.com/temporalio/sdk-java/blob/ad8831d4a4d9d257baf3482ab49f1aa681895c0e/temporal-serviceclient/src/main/java/io/temporal/serviceclient/RpcRetryOptions.java#L32)

It will retry for a minute.  Note that if the retries are longer than the activity timeout, it will be hitting temporal-server fruitlessly.  Temporal handles this gracefully by complaining that the workflow has already finished.  We could in theory try to incorporate the activity timeout into the limit calculation, but I don't think the Java SDK does.

* SleepActivity was useless with such short timeouts.

# Test Plan
Unit test of the retryer logic:
`rspec spec/unit/lib/temporal/client/retryer.rb`
Manual:
```
cd examples
./bin/worker
# other terminal
./bin/trigger CancellingTimerWorkflow 15 1
```
Kill temporal-server before 15 seconds has elapsed, then restart the server.  Notice the retries followed by success:
```
I, [2021-05-14T09:29:10.263760 #68971]  INFO -- temporal_client: [EXAMPLE]: Finished {"metadata":{"namespace":"ruby-samples","workflow_id":"cbf5955b-c1e2-4806-a8da-248052711793","workflow_name":"CancellingTimerWorkflow","workflow_run_id":"e688fe0c-cf7c-4bd3-8fe4-81b42bc17638","activity_id":"6","activity_name":"SleepActivity","attempt":1}}
I, [2021-05-14T09:29:10.263905 #68971]  INFO -- temporal_client: Activity task completed {"namespace":"ruby-samples","workflow_id":"cbf5955b-c1e2-4806-a8da-248052711793","workflow_name":"CancellingTimerWorkflow","workflow_run_id":"e688fe0c-cf7c-4bd3-8fe4-81b42bc17638","activity_id":"6","activity_name":"SleepActivity","attempt":1}
D, [2021-05-14T09:29:10.813812 #68971] DEBUG -- temporal_client: Failed to report activity task completion, retrying {"namespace":"ruby-samples","workflow_id":"cbf5955b-c1e2-4806-a8da-248052711793","workflow_name":"CancellingTimerWorkflow","workflow_run_id":"e688fe0c-cf7c-4bd3-8fe4-81b42bc17638","activity_id":"6","activity_name":"SleepActivity","attempt":1}
D, [2021-05-14T09:29:11.014611 #68971] DEBUG -- temporal_client: Failed to report activity task completion, retrying {"namespace":"ruby-samples","workflow_id":"cbf5955b-c1e2-4806-a8da-248052711793","workflow_name":"CancellingTimerWorkflow","workflow_run_id":"e688fe0c-cf7c-4bd3-8fe4-81b42bc17638","activity_id":"6","activity_name":"SleepActivity","attempt":1}
D, [2021-05-14T09:29:11.258457 #68971] DEBUG -- temporal_client: Failed to report activity task completion, retrying {"namespace":"ruby-samples","workflow_id":"cbf5955b-c1e2-4806-a8da-248052711793","workflow_name":"CancellingTimerWorkflow","workflow_run_id":"e688fe0c-cf7c-4bd3-8fe4-81b42bc17638","activity_id":"6","activity_name":"SleepActivity","attempt":1}
D, [2021-05-14T09:29:11.549163 #68971] DEBUG -- temporal_client: Failed to report activity task completion, retrying {"namespace":"ruby-samples","workflow_id":"cbf5955b-c1e2-4806-a8da-248052711793","workflow_name":"CancellingTimerWorkflow","workflow_run_id":"e688fe0c-cf7c-4bd3-8fe4-81b42bc17638","activity_id":"6","activity_name":"SleepActivity","attempt":1}
D, [2021-05-14T09:29:14.136366 #68971] DEBUG -- temporal_client: Failed to report activity task completion, retrying {"namespace":"ruby-samples","workflow_id":"cbf5955b-c1e2-4806-a8da-248052711793","workflow_name":"CancellingTimerWorkflow","workflow_run_id":"e688fe0c-cf7c-4bd3-8fe4-81b42bc17638","activity_id":"6","activity_name":"SleepActivity","attempt":1}
D, [2021-05-14T09:29:15.000306 #68971] DEBUG -- temporal_client: Failed to report activity task completion, retrying {"namespace":"ruby-samples","workflow_id":"cbf5955b-c1e2-4806-a8da-248052711793","workflow_name":"CancellingTimerWorkflow","workflow_run_id":"e688fe0c-cf7c-4bd3-8fe4-81b42bc17638","activity_id":"6","activity_name":"SleepActivity","attempt":1}
D, [2021-05-14T09:29:16.085132 #68971] DEBUG -- metrics: activity_task.latency | timing | 25826 | activity:SleepActivity
D, [2021-05-14T09:29:16.085244 #68971] DEBUG -- temporal_client: Activity task processed {"namespace":"ruby-samples","workflow_id":"cbf5955b-c1e2-4806-a8da-248052711793","workflow_name":"CancellingTimerWorkflow","workflow_run_id":"e688fe0c-cf7c-4bd3-8fe4-81b42bc17638","activity_id":"6","activity_name":"SleepActivity","attempt":1,"execution_time":25826}
```
