### PR TITLE
[WIP] Correctly handle timer/activity cancelation events

### DIFF
--- a/lib/temporal/workflow/history/event_target.rb
+++ b/lib/temporal/workflow/history/event_target.rb
@@ -17,10 +17,12 @@ module Temporal
         WORKFLOW_TYPE                         = :workflow
         CANCEL_WORKFLOW_REQUEST_TYPE          = :cancel_workflow_request
 
+        # NOTE: The order is important, first prefix match wins (should correspond to a longer match)
         TARGET_TYPES = {
-          'ACTIVITY_TASK'                              => ACTIVITY_TYPE,
           'ACTIVITY_TASK_CANCEL'                       => CANCEL_ACTIVITY_REQUEST_TYPE,
+          'ACTIVITY_TASK'                              => ACTIVITY_TYPE,
           'REQUEST_CANCEL_ACTIVITY_TASK'               => CANCEL_ACTIVITY_REQUEST_TYPE,
+          'TIMER_CANCELED'                             => CANCEL_TIMER_REQUEST_TYPE,
           'TIMER'                                      => TIMER_TYPE,
           'CANCEL_TIMER'                               => CANCEL_TIMER_REQUEST_TYPE,
           'CHILD_WORKFLOW_EXECUTION'                   => CHILD_WORKFLOW_TYPE,
@@ -31,8 +33,8 @@ module Temporal
           'EXTERNAL_WORKFLOW_EXECUTION_CANCEL'         => CANCEL_EXTERNAL_WORKFLOW_REQUEST_TYPE,
           'REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION' => CANCEL_EXTERNAL_WORKFLOW_REQUEST_TYPE,
           'UPSERT_WORKFLOW_SEARCH_ATTRIBUTES'          => WORKFLOW_TYPE,
-          'WORKFLOW_EXECUTION'                         => WORKFLOW_TYPE,
           'WORKFLOW_EXECUTION_CANCEL'                  => CANCEL_WORKFLOW_REQUEST_TYPE,
+          'WORKFLOW_EXECUTION'                         => WORKFLOW_TYPE,
         }.freeze
 
         attr_reader :id, :type

--- a/lib/temporal/workflow/state_manager.rb
+++ b/lib/temporal/workflow/state_manager.rb
@@ -157,10 +157,12 @@ module Temporal
 
         when 'REQUEST_CANCEL_ACTIVITY_TASK_FAILED'
           state_machine.fail
+          discard_command(target)
           dispatch(target, 'failed', event.attributes.cause, nil)
 
         when 'ACTIVITY_TASK_CANCELED'
           state_machine.cancel
+          discard_command(target)
           dispatch(target, 'failed', parse_failure(event.attributes.failure))
 
         when 'TIMER_STARTED'
@@ -173,10 +175,12 @@ module Temporal
 
         when 'CANCEL_TIMER_FAILED'
           state_machine.failed
+          discard_command(target)
           dispatch(target, 'failed', event.attributes.cause, nil)
 
         when 'TIMER_CANCELED'
           state_machine.cancel
+          discard_command(target)
           dispatch(target, 'canceled')
 
         when 'WORKFLOW_EXECUTION_CANCEL_REQUESTED'


### PR DESCRIPTION
Fixes #75 

The non-determinism check depends on the class `EventTarget` that creates a canonical event that is used when matching commands to history events (schedule_activity -> activity_scheduled, etc). This allows to check the pending command (not yet sent to Temporal) and history events and remove the ones that are already in the history (in the same order as they were scheduled).

There were 2 bugs with this:
1. When creating an `EventTarget` from an event we did a prefix match favouring the first match. This means that between `ACTIVITY_TASK` and `ACTIVITY_TASK_CANCEL` the first one would win and will generate an incorrect event target (activity, instead of cancel_activity). Fixed by matching all and picking the last match.
2. TIMER_CANCELED event (along with ACTIVITY_TASK_CANCELED) was not discarding a pending command, which it should have. This should be fixed along with `REQUEST_CANCEL_ACTIVITY_TASK_FAILED` and `CANCEL_TIMER_FAILED` which should also remove the cancelation command from the pending list

How was it tested?
Manually by running workflows, proper specs pending