### PR TITLE
Speed up unit tests that hit the Retryer

### DIFF
--- a/spec/unit/lib/temporal/activity/task_processor_spec.rb
+++ b/spec/unit/lib/temporal/activity/task_processor_spec.rb
@@ -35,6 +35,9 @@ describe Temporal::Activity::TaskProcessor do
       allow(middleware_chain).to receive(:invoke).and_call_original
 
       allow(Temporal.metrics).to receive(:timing)
+
+      # Skip sleeps during retries to speed up the test.
+      allow(Temporal::Client::Retryer).to receive(:sleep).and_return(nil)
     end
 
     context 'when activity is not registered' do


### PR DESCRIPTION
## Description
https://github.com/coinbase/temporal-ruby/pull/74 regressed the speed because we added retries and `sleep` to certain code paths.

## Test Plan
Observe that this executes quickly:
```
GitHub/temporal-ruby $ bundle exec rspec spec/unit/
...................................................................................................................................................................................................................................................................................

Finished in 1.08 seconds (files took 0.9169 seconds to load)
275 examples, 0 failures
```
