### PR TITLE
Fix namespace creation issues in CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,10 @@ jobs:
           command: cd examples && bin/register_namespace ruby-samples
 
       - run:
+          name: Wait for Namespace to settle
+          command: sleep 15
+
+      - run:
           name: Boot up worker
           command: cd examples && bin/worker
           background: true

--- a/examples/bin/register_namespace
+++ b/examples/bin/register_namespace
@@ -6,14 +6,14 @@ description = ARGV[1]
 
 fail 'Missing namespace name, please run register_namespace <namespace_name>' unless namespace
 
-Temporal.register_namespace(namespace, description) rescue exit
+Temporal.register_namespace(namespace, description) rescue nil
 
 client = Temporal.send(:client)
 
 # wait for namespace to get created
 begin
-  client.describe_namespace(name: namespace)
-  Temporal.logger.info 'Namespace created', { namespace: namespace }
+  result = client.describe_namespace(name: namespace)
+  Temporal.logger.info 'Namespace created', result.to_h
 rescue
   Temporal.logger.debug 'Waiting for namespace to set up'
   sleep 1

--- a/examples/bin/register_namespace
+++ b/examples/bin/register_namespace
@@ -6,16 +6,11 @@ description = ARGV[1]
 
 fail 'Missing namespace name, please run register_namespace <namespace_name>' unless namespace
 
-Temporal.register_namespace(namespace, description) rescue nil
-
-client = Temporal.send(:client)
-
-# wait for namespace to get created
 begin
-  result = client.describe_namespace(name: namespace)
-  Temporal.logger.info 'Namespace created', result.to_h
-rescue
-  Temporal.logger.debug 'Waiting for namespace to set up'
-  sleep 1
-  retry
+  Temporal.register_namespace(namespace, description)
+  Temporal.logger.info 'Namespace created', { namespace: namespace }
+rescue Temporal::NamespaceAlreadyExistsFailure
+  Temporal.logger.info 'Namespace already exists', { namespace: namespace }
 end
+
+

--- a/examples/bin/register_namespace
+++ b/examples/bin/register_namespace
@@ -10,12 +10,11 @@ Temporal.register_namespace(namespace, description) rescue exit
 
 client = Temporal.send(:client)
 
-sleep 5
-
 # wait for namespace to get created
 loop do
   begin
     client.describe_namespace(name: namespace)
+    Temporal.logger.info 'Namespace created', { namespace: name }
   rescue
     p 'Waiting for namespace to set up'
     sleep 1

--- a/examples/bin/register_namespace
+++ b/examples/bin/register_namespace
@@ -11,15 +11,11 @@ Temporal.register_namespace(namespace, description) rescue exit
 client = Temporal.send(:client)
 
 # wait for namespace to get created
-loop do
-  begin
-    client.describe_namespace(name: namespace)
-    Temporal.logger.info 'Namespace created', { namespace: name }
-  rescue
-    p 'Waiting for namespace to set up'
-    sleep 1
-    next
-  end
-
-  break
+begin
+  client.describe_namespace(name: namespace)
+  Temporal.logger.info 'Namespace created', { namespace: namespace }
+rescue
+  Temporal.logger.debug 'Waiting for namespace to set up'
+  sleep 1
+  retry
 end


### PR DESCRIPTION
Temporal does not currently offer a way to ensure that a namespace registration is available on all shards.

https://community.temporal.io/t/how-to-tell-the-namespace-is-ready-to-be-polled-by-workers/1606

Unconditionally wait 15 seconds (which is the shard cache refresh time) after namespace registration to ensure it's ready when the workers attempt to use it.