### PR TITLE
Fix serialization of retry policy

### DIFF
--- a/lib/temporal/client/serializer/retry_policy.rb
+++ b/lib/temporal/client/serializer/retry_policy.rb
@@ -13,7 +13,7 @@ module Temporal
             backoff_coefficient: object.backoff,
             maximum_interval: object.max_interval,
             maximum_attempts: object.max_attempts,
-            non_retriable_error_reasons: non_retriable_errors,
+            non_retryable_error_types: non_retriable_errors,
           }.compact
 
           Temporal::Api::Common::V1::RetryPolicy.new(options)

--- a/spec/unit/lib/temporal/client/serializer/retry_policy_spec.rb
+++ b/spec/unit/lib/temporal/client/serializer/retry_policy_spec.rb
@@ -1,0 +1,25 @@
+require 'temporal/retry_policy'
+require 'temporal/client/serializer/retry_policy'
+
+describe Temporal::Client::Serializer::RetryPolicy do
+  describe 'to_proto' do
+    let(:example_policy) do
+      Temporal::RetryPolicy.new(
+        interval: 1,
+        backoff: 1.5,
+        max_interval: 5,
+        max_attempts: 3,
+        non_retriable_errors: [StandardError]
+      )
+    end
+
+    it 'converts to proto' do
+      proto = described_class.new(example_policy).to_proto
+      expect(proto.initial_interval.seconds).to eq(1)
+      expect(proto.backoff_coefficient).to eq(1.5)
+      expect(proto.maximum_interval.seconds).to eq(5)
+      expect(proto.maximum_attempts).to eq(3)
+      expect(proto.non_retryable_error_types).to eq(['StandardError'])
+    end
+  end
+end

--- a/spec/unit/lib/temporal/retry_policy_spec.rb
+++ b/spec/unit/lib/temporal/retry_policy_spec.rb
@@ -10,7 +10,7 @@ describe Temporal::RetryPolicy do
         backoff: 1.5,
         max_interval: 5,
         max_attempts: 3,
-        non_retriable_errors: nil
+        non_retriable_errors: [StandardError]
       }
     end
 


### PR DESCRIPTION
Fixes a bug in the recent serialization changes when non-retriable errors are specified.

## Test Plan
`rspec spec/unit/lib/temporal/client/serializer/retry_policy_spec.rb`
