### PR TITLE
Special case signal payloads.

### DIFF
--- a/examples/workflows/long_workflow.rb
+++ b/examples/workflows/long_workflow.rb
@@ -5,7 +5,7 @@ class LongWorkflow < Temporal::Workflow
     future = LongRunningActivity.execute(cycles, interval)
 
     workflow.on_signal do |signal, input|
-      logger.warn "Signal received", { signal: signal }
+      logger.warn "Signal received", { signal: signal, input: input }
       future.cancel
     end
 

--- a/lib/temporal/client/grpc_client.rb
+++ b/lib/temporal/client/grpc_client.rb
@@ -273,7 +273,7 @@ module Temporal
             run_id: run_id
           ),
           signal_name: signal,
-          input: to_payloads(input),
+          input: to_signal_payloads(input),
           identity: identity
         )
         client.signal_workflow_execution(request)

--- a/lib/temporal/concerns/payloads.rb
+++ b/lib/temporal/concerns/payloads.rb
@@ -17,6 +17,10 @@ module Temporal
         from_payloads(payloads)&.first
       end
 
+      def from_signal_payloads(payloads)
+        from_payloads(payloads)&.first
+      end
+
       def to_payloads(data)
         payload_converter.to_payloads(data)
       end
@@ -30,6 +34,10 @@ module Temporal
       end
 
       def to_details_payloads(data)
+        to_payloads([data])
+      end
+
+      def to_signal_payloads(data)
         to_payloads([data])
       end
 

--- a/lib/temporal/workflow/state_manager.rb
+++ b/lib/temporal/workflow/state_manager.rb
@@ -199,7 +199,7 @@ module Temporal
           handle_marker(event.id, event.attributes.marker_name, from_details_payloads(event.attributes.details['data']))
 
         when 'WORKFLOW_EXECUTION_SIGNALED'
-          dispatch(target, 'signaled', event.attributes.signal_name, from_payloads(event.attributes.input))
+          dispatch(target, 'signaled', event.attributes.signal_name, from_signal_payloads(event.attributes.input))
 
         when 'WORKFLOW_EXECUTION_TERMINATED'
           # todo


### PR DESCRIPTION
Other SDKs only use the first payload, as for details/results.