### PR TITLE
Blocklist certain exceptions from task retries

### DIFF
--- a/lib/temporal/client/retryer.rb
+++ b/lib/temporal/client/retryer.rb
@@ -6,6 +6,23 @@ module Temporal
       BACKOFF_COEFFICIENT = 1.2
       DEFAULT_RETRIES = 24 # gets us to about 60s given the other parameters, assuming 0 latency
 
+      # List pulled from RpcRetryOptions in the Java SDK
+      # https://github.com/temporalio/sdk-java/blob/ad8831d4a4d9d257baf3482ab49f1aa681895c0e/temporal-serviceclient/src/main/java/io/temporal/serviceclient/RpcRetryOptions.java#L32
+      # No amount of retrying will help in these cases.
+      def self.do_not_retry_errors
+        [
+          GRPC::AlreadyExists,
+          GRPC::Cancelled,
+          GRPC::FailedPrecondition,
+          GRPC::InvalidArgument,
+          # If the activity has timed out, the server will return this and will never accept a retry
+          GRPC::NotFound,
+          GRPC::PermissionDenied,
+          GRPC::Unauthenticated,
+          GRPC::Unimplemented,
+        ]
+      end
+
       # Used for backoff retries in certain cases when calling temporal server.
       # on_retry - a proc that's executed each time you need to retry
       def self.with_retries(times: DEFAULT_RETRIES, on_retry: nil, &block)
@@ -16,8 +33,10 @@ module Temporal
         loop do
           begin
             return yield
-          rescue
-            raise if retry_i >= times
+          rescue *do_not_retry_errors
+            raise
+          rescue => e
+            raise e if retry_i >= times
             retry_i += 1
             on_retry.call if on_retry
             sleep(current_interval_s)


### PR DESCRIPTION
I noticed that we kept retrying activity task reporting even if the activity task had already timed out, which eats a thread for a considerable amount of time while it keeps retrying.
There are a lot of exceptions that there's no need to retry.

# Test Plan
New unit test:
```
drewhoskins/stripe/temporal-ruby $ bundle exec rspec -f d ./spec/unit/lib/temporal/client/retryer.rb

Temporal::Client::Retryer
  backs off and stops retrying eventually
  caps out amount slept
  can succeed
  can succeed after retries
  executes the on_retry callback
  does not retry GRPC::AlreadyExists
  does not retry GRPC::Cancelled
  does not retry GRPC::FailedPrecondition
  does not retry GRPC::InvalidArgument
  does not retry GRPC::NotFound
  does not retry GRPC::PermissionDenied
  does not retry GRPC::Unauthenticated
  does not retry GRPC::Unimplemented
  does retry StandardError
  does retry GRPC::Unknown
  does retry GRPC::Unavailable
```

end to end:
set `SleepActivity`'s  `schedule_to_close` timeout to 4
Run `./bin/trigger TimeoutWorkflow 1 5` (meaning 5 second activity timeout)
observer no extra retries:

```
I, [2021-06-26T14:31:38.148261 #16818]  INFO -- temporal_client: Activity task completed {"namespace":"ruby-samples","workflow_id":"6d43ad5d-b57e-4a99-8b92-25b8fc8a4cae","workflow_name":"TimeoutWorkflow","workflow_run_id":"23be21e4-c408-46fa-8d8d-ba8b1f4d3921","activity_id":"5","activity_name":"SleepActivity","attempt":1}
E, [2021-06-26T14:31:38.156923 #16818] ERROR -- temporal_client: Unable to complete Activity {"namespace":"ruby-samples","workflow_id":"6d43ad5d-b57e-4a99-8b92-25b8fc8a4cae","workflow_name":"TimeoutWorkflow","workflow_run_id":"23be21e4-c408-46fa-8d8d-ba8b1f4d3921","activity_id":"5","activity_name":"SleepActivity","attempt":1,"error":"#<GRPC::NotFound: 5:workflow execution already completed. debug_error_string:{\"created\":\"@1624743098.156510000\",\"description\":\"Error received from peer ipv6:[::1]:7233\",\"file\":\"src/core/lib/surface/call.cc\",\"file_line\":1068,\"grpc_message\":\"workflow execution already completed\",\"grpc_status\":5}>"}
```