### PR TITLE
Fix float serialization roundtrip

### DIFF
--- a/lib/temporal/json.rb
+++ b/lib/temporal/json.rb
@@ -4,7 +4,9 @@ require 'oj'
 module Temporal
   module JSON
     OJ_OPTIONS = {
-      mode: :object
+      mode: :object,
+      # use ruby's built-in serialization.  If nil, OJ seems to default to ~15 decimal places of precision
+      float_precision: 0
     }.freeze
 
     def self.serialize(value)

--- a/spec/unit/lib/temporal/client/converter/payload/json_spec.rb
+++ b/spec/unit/lib/temporal/client/converter/payload/json_spec.rb
@@ -9,5 +9,12 @@ describe Temporal::Client::Converter::Payload::JSON do
 
       expect(subject.from_payload(subject.to_payload(input))).to eq(input)
     end
+
+    it 'handles floats without loss of precision' do
+      input = { 'a_float' => 1626122510001.305986623 }
+      result = subject.from_payload(subject.to_payload(input))['a_float']
+      expect(result).to be_within(1e-8).of(input['a_float'])
+    end
+
   end
 end


### PR DESCRIPTION
# Description
Timestamps I was using for high-precision cursoring were getting truncated.
This approach gets the correct answer, the disadvantage being that when the numbers get weird enough, it switches to scientific notation.

e.g. `1626122511.3059866` becomes `0.16261225113059866e10`
Certainly an improvement over `1626122511.30599` which was what happened before.

# Test Plan
`bundle exec rspec spec/unit/lib/temporal/client/converter/payload/json_spec.rb`