### PR TITLE
Fix documentation spelling and broken link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Odin
+# Contributing to Temporal-Ruby
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ Temporal::Testing.local! do
 end
 ```
 
-Make sure to check out [example integration specs](examples/specs/integration) for more details.
+Make sure to check out [example integration specs](examples/spec/integration) for more details.
 
 
 ## TODO

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Ruby Temporal Examples
 
-This directory contains examples demonstraiting different features or this library and Temporal.
+This directory contains examples demonstrating different features or this library and Temporal.
 
 To try these out you need to have a running Temporal service ([setup instructions](https://github.com/coinbase/temporal-ruby#installing-dependencies)).
 


### PR DESCRIPTION
Syncing https://github.com/coinbase/cadence-ruby/pull/44

This fixes a couple spelling mistakes and a broken link.