### PR TITLE
[Feature] Initializable Temporal client

### DIFF
--- a/examples/spec/helpers.rb
+++ b/examples/spec/helpers.rb
@@ -23,7 +23,7 @@ module Helpers
   end
 
   def fetch_history(workflow_id, run_id, options = {})
-    connection = Temporal.send(:connection)
+    connection = Temporal.send(:default_client).send(:connection)
 
     result = connection.get_workflow_execution_history(
       {

--- a/lib/temporal.rb
+++ b/lib/temporal.rb
@@ -2,204 +2,30 @@
 $LOAD_PATH << File.expand_path('./gen', __dir__)
 
 require 'securerandom'
+require 'forwardable'
 require 'temporal/configuration'
-require 'temporal/execution_options'
-require 'temporal/connection'
-require 'temporal/activity'
-require 'temporal/activity/async_token'
-require 'temporal/workflow'
-require 'temporal/workflow/history'
-require 'temporal/workflow/execution_info'
+require 'temporal/client'
 require 'temporal/metrics'
 require 'temporal/json'
 require 'temporal/errors'
 require 'temporal/workflow/errors'
 
 module Temporal
+  extend SingleForwardable
+
+  def_delegators :default_client, #target
+                 :start_workflow,
+                 :schedule_workflow,
+                 :register_namespace,
+                 :signal_workflow,
+                 :await_workflow_result,
+                 :reset_workflow,
+                 :terminate_workflow,
+                 :fetch_workflow_execution_info,
+                 :complete_activity,
+                 :fail_activity
+
   class << self
-    def start_workflow(workflow, *input, **args)
-      options = args.delete(:options) || {}
-      input << args unless args.empty?
-
-      execution_options = ExecutionOptions.new(workflow, options, config.default_execution_options)
-      workflow_id = options[:workflow_id] || SecureRandom.uuid
-
-      response = connection.start_workflow_execution(
-        namespace: execution_options.namespace,
-        workflow_id: workflow_id,
-        workflow_name: execution_options.name,
-        task_queue: execution_options.task_queue,
-        input: input,
-        execution_timeout: execution_options.timeouts[:execution],
-        # If unspecified, individual runs should have the full time for the execution (which includes retries).
-        run_timeout: execution_options.timeouts[:run] || execution_options.timeouts[:execution],
-        task_timeout: execution_options.timeouts[:task],
-        workflow_id_reuse_policy: options[:workflow_id_reuse_policy],
-        headers: execution_options.headers
-      )
-
-      response.run_id
-    end
-
-    def schedule_workflow(workflow, cron_schedule, *input, **args)
-      options = args.delete(:options) || {}
-      input << args unless args.empty?
-
-      execution_options = ExecutionOptions.new(workflow, options, config.default_execution_options)
-      workflow_id = options[:workflow_id] || SecureRandom.uuid
-
-      response = connection.start_workflow_execution(
-        namespace: execution_options.namespace,
-        workflow_id: workflow_id,
-        workflow_name: execution_options.name,
-        task_queue: execution_options.task_queue,
-        input: input,
-        execution_timeout: execution_options.timeouts[:execution],
-        # Execution timeout is across all scheduled jobs, whereas run is for an individual run.
-        # This default is here for backward compatibility.  Certainly, the run timeout shouldn't be higher
-        # than the execution timeout.
-        run_timeout: execution_options.timeouts[:run] || execution_options.timeouts[:execution],
-        task_timeout: execution_options.timeouts[:task],
-        workflow_id_reuse_policy: options[:workflow_id_reuse_policy],
-        headers: execution_options.headers,
-        cron_schedule: cron_schedule
-      )
-
-      response.run_id
-    end
-
-    def register_namespace(name, description = nil)
-      connection.register_namespace(name: name, description: description)
-    end
-
-    def signal_workflow(workflow, signal, workflow_id, run_id, input = nil)
-      execution_options = ExecutionOptions.new(workflow, {}, config.default_execution_options)
-
-      connection.signal_workflow_execution(
-        namespace: execution_options.namespace, # TODO: allow passing namespace instead
-        workflow_id: workflow_id,
-        run_id: run_id,
-        signal: signal,
-        input: input
-      )
-    end
-
-    # Long polls for a workflow to be completed and returns whatever the execute function
-    # returned.  This function times out after 30 seconds and throws Temporal::TimeoutError,
-    # not to be confused with Temporal::WorkflowTimedOut which reports that the workflow
-    # itself timed out.
-    # run_id of nil: await the entire workflow completion.  This can span multiple runs
-    # in the case where the workflow uses continue-as-new.
-    # timeout: seconds to wait for the result.  This cannot be longer than 30 seconds because
-    # that is the maximum the server supports.
-    # namespace: if nil, choose the one declared on the Workflow, or the global default
-    def await_workflow_result(workflow, workflow_id:, run_id: nil, timeout: nil, namespace: nil)
-      options = namespace ? {namespace: namespace} : {}
-      execution_options = ExecutionOptions.new(workflow, options, config.default_execution_options)
-      max_timeout = Temporal::Connection::GRPC::SERVER_MAX_GET_WORKFLOW_EXECUTION_HISTORY_POLL
-      history_response = nil
-      begin
-        history_response = connection.get_workflow_execution_history(
-          namespace: execution_options.namespace,
-          workflow_id: workflow_id,
-          run_id: run_id,
-          wait_for_new_event: true,
-          event_type: :close,
-          timeout: timeout || max_timeout,
-        )
-      rescue GRPC::DeadlineExceeded => e
-        message = if timeout 
-          "Timed out after your specified limit of timeout: #{timeout} seconds"
-        else
-          "Timed out after #{max_timeout} seconds, which is the maximum supported amount."
-        end
-        raise TimeoutError.new(message)
-      end
-      history = Workflow::History.new(history_response.history.events)
-      closed_event = history.events.first
-      case closed_event.type
-      when 'WORKFLOW_EXECUTION_COMPLETED'
-        payloads = closed_event.attributes.result
-        return ResultConverter.from_result_payloads(payloads)
-      when 'WORKFLOW_EXECUTION_TIMED_OUT'
-        raise Temporal::WorkflowTimedOut
-      when 'WORKFLOW_EXECUTION_TERMINATED'
-        raise Temporal::WorkflowTerminated
-      when 'WORKFLOW_EXECUTION_CANCELED'
-        raise Temporal::WorkflowCanceled
-      when 'WORKFLOW_EXECUTION_FAILED'
-        raise Temporal::Workflow::Errors.generate_error(closed_event.attributes.failure)
-      when 'WORKFLOW_EXECUTION_CONTINUED_AS_NEW'
-        new_run_id = closed_event.attributes.new_execution_run_id
-        # Throw to let the caller know they're not getting the result
-        # they wanted.  They can re-call with the new run_id to poll.
-        raise Temporal::WorkflowRunContinuedAsNew.new(new_run_id: new_run_id)
-      else
-        raise NotImplementedError, "Unexpected event type #{closed_event.type}."
-      end
-    end
-
-    def reset_workflow(namespace, workflow_id, run_id, workflow_task_id: nil, reason: 'manual reset')
-      workflow_task_id ||= get_last_completed_workflow_task_id(namespace, workflow_id, run_id)
-      raise Error, 'Could not find a completed workflow task event' unless workflow_task_id
-
-      response = connection.reset_workflow_execution(
-        namespace: namespace,
-        workflow_id: workflow_id,
-        run_id: run_id,
-        reason: reason,
-        workflow_task_event_id: workflow_task_id
-      )
-
-      response.run_id
-    end
-
-    def terminate_workflow(workflow_id, namespace: nil, run_id: nil, reason: nil, details: nil)
-      namespace ||= Temporal.configuration.namespace
-
-      connection.terminate_workflow_execution(
-        namespace: namespace,
-        workflow_id: workflow_id,
-        run_id: run_id,
-        reason: reason,
-        details: details
-      )
-    end
-
-    def fetch_workflow_execution_info(namespace, workflow_id, run_id)
-      response = connection.describe_workflow_execution(
-        namespace: namespace,
-        workflow_id: workflow_id,
-        run_id: run_id
-      )
-
-      Workflow::ExecutionInfo.generate_from(response.workflow_execution_info)
-    end
-
-    def complete_activity(async_token, result = nil)
-      details = Activity::AsyncToken.decode(async_token)
-
-      connection.respond_activity_task_completed_by_id(
-        namespace: details.namespace,
-        activity_id: details.activity_id,
-        workflow_id: details.workflow_id,
-        run_id: details.run_id,
-        result: result
-      )
-    end
-
-    def fail_activity(async_token, exception)
-      details = Activity::AsyncToken.decode(async_token)
-
-      connection.respond_activity_task_failed_by_id(
-        namespace: details.namespace,
-        activity_id: details.activity_id,
-        workflow_id: details.workflow_id,
-        run_id: details.run_id,
-        exception: exception
-      )
-    end
-
     def configure(&block)
       yield config
     end
@@ -217,30 +43,15 @@ module Temporal
       @metrics ||= Metrics.new(config.metrics_adapter)
     end
 
-    class ResultConverter
-      extend Concerns::Payloads
-    end
-    private_constant :ResultConverter
-
     private
+    
+    def default_client
+      @default_client ||= Client.new(config)
+    end
     
     def config
       @config ||= Configuration.new
     end
 
-    def connection
-      @connection ||= Temporal::Connection.generate(config.for_connection)
-    end
-
-    def get_last_completed_workflow_task_id(namespace, workflow_id, run_id)
-      history_response = connection.get_workflow_execution_history(
-        namespace: namespace,
-        workflow_id: workflow_id,
-        run_id: run_id
-      )
-      history = Workflow::History.new(history_response.history.events)
-      workflow_task_event = history.get_last_completed_workflow_task
-      workflow_task_event&.id
-    end
   end
 end

--- a/lib/temporal/client.rb
+++ b/lib/temporal/client.rb
@@ -1,0 +1,222 @@
+require 'temporal/execution_options'
+require 'temporal/connection'
+require 'temporal/activity'
+require 'temporal/activity/async_token'
+require 'temporal/workflow'
+require 'temporal/workflow/history'
+require 'temporal/workflow/execution_info'
+
+module Temporal
+  class Client
+    def initialize(config)
+      @config = config
+    end
+
+    def start_workflow(workflow, *input, **args)
+      options = args.delete(:options) || {}
+      input << args unless args.empty?
+
+      execution_options = ExecutionOptions.new(workflow, options, config.default_execution_options)
+      workflow_id = options[:workflow_id] || SecureRandom.uuid
+
+      response = connection.start_workflow_execution(
+        namespace: execution_options.namespace,
+        workflow_id: workflow_id,
+        workflow_name: execution_options.name,
+        task_queue: execution_options.task_queue,
+        input: input,
+        execution_timeout: execution_options.timeouts[:execution],
+        # If unspecified, individual runs should have the full time for the execution (which includes retries).
+        run_timeout: execution_options.timeouts[:run] || execution_options.timeouts[:execution],
+        task_timeout: execution_options.timeouts[:task],
+        workflow_id_reuse_policy: options[:workflow_id_reuse_policy],
+        headers: execution_options.headers
+      )
+
+      response.run_id
+    end
+
+    def schedule_workflow(workflow, cron_schedule, *input, **args)
+      options = args.delete(:options) || {}
+      input << args unless args.empty?
+
+      execution_options = ExecutionOptions.new(workflow, options, config.default_execution_options)
+      workflow_id = options[:workflow_id] || SecureRandom.uuid
+
+      response = connection.start_workflow_execution(
+        namespace: execution_options.namespace,
+        workflow_id: workflow_id,
+        workflow_name: execution_options.name,
+        task_queue: execution_options.task_queue,
+        input: input,
+        execution_timeout: execution_options.timeouts[:execution],
+        # Execution timeout is across all scheduled jobs, whereas run is for an individual run.
+        # This default is here for backward compatibility.  Certainly, the run timeout shouldn't be higher
+        # than the execution timeout.
+        run_timeout: execution_options.timeouts[:run] || execution_options.timeouts[:execution],
+        task_timeout: execution_options.timeouts[:task],
+        workflow_id_reuse_policy: options[:workflow_id_reuse_policy],
+        headers: execution_options.headers,
+        cron_schedule: cron_schedule
+      )
+
+      response.run_id
+    end
+
+    def register_namespace(name, description = nil)
+      connection.register_namespace(name: name, description: description)
+    end
+
+    def signal_workflow(workflow, signal, workflow_id, run_id, input = nil)
+      execution_options = ExecutionOptions.new(workflow, {}, config.default_execution_options)
+
+      connection.signal_workflow_execution(
+        namespace: execution_options.namespace, # TODO: allow passing namespace instead
+        workflow_id: workflow_id,
+        run_id: run_id,
+        signal: signal,
+        input: input
+      )
+    end
+
+    # Long polls for a workflow to be completed and returns whatever the execute function
+    # returned.  This function times out after 30 seconds and throws Temporal::TimeoutError,
+    # not to be confused with Temporal::WorkflowTimedOut which reports that the workflow
+    # itself timed out.
+    # run_id of nil: await the entire workflow completion.  This can span multiple runs
+    # in the case where the workflow uses continue-as-new.
+    # timeout: seconds to wait for the result.  This cannot be longer than 30 seconds because
+    # that is the maximum the server supports.
+    # namespace: if nil, choose the one declared on the Workflow, or the global default
+    def await_workflow_result(workflow, workflow_id:, run_id: nil, timeout: nil, namespace: nil)
+      options = namespace ? {namespace: namespace} : {}
+      execution_options = ExecutionOptions.new(workflow, options, config.default_execution_options)
+      max_timeout = Temporal::Connection::GRPC::SERVER_MAX_GET_WORKFLOW_EXECUTION_HISTORY_POLL
+      history_response = nil
+      begin
+        history_response = connection.get_workflow_execution_history(
+          namespace: execution_options.namespace,
+          workflow_id: workflow_id,
+          run_id: run_id,
+          wait_for_new_event: true,
+          event_type: :close,
+          timeout: timeout || max_timeout,
+        )
+      rescue GRPC::DeadlineExceeded => e
+        message = if timeout 
+          "Timed out after your specified limit of timeout: #{timeout} seconds"
+        else
+          "Timed out after #{max_timeout} seconds, which is the maximum supported amount."
+        end
+        raise TimeoutError.new(message)
+      end
+      history = Workflow::History.new(history_response.history.events)
+      closed_event = history.events.first
+      case closed_event.type
+      when 'WORKFLOW_EXECUTION_COMPLETED'
+        payloads = closed_event.attributes.result
+        return ResultConverter.from_result_payloads(payloads)
+      when 'WORKFLOW_EXECUTION_TIMED_OUT'
+        raise Temporal::WorkflowTimedOut
+      when 'WORKFLOW_EXECUTION_TERMINATED'
+        raise Temporal::WorkflowTerminated
+      when 'WORKFLOW_EXECUTION_CANCELED'
+        raise Temporal::WorkflowCanceled
+      when 'WORKFLOW_EXECUTION_FAILED'
+        raise Temporal::Workflow::Errors.generate_error(closed_event.attributes.failure)
+      when 'WORKFLOW_EXECUTION_CONTINUED_AS_NEW'
+        new_run_id = closed_event.attributes.new_execution_run_id
+        # Throw to let the caller know they're not getting the result
+        # they wanted.  They can re-call with the new run_id to poll.
+        raise Temporal::WorkflowRunContinuedAsNew.new(new_run_id: new_run_id)
+      else
+        raise NotImplementedError, "Unexpected event type #{closed_event.type}."
+      end
+    end
+
+    def reset_workflow(namespace, workflow_id, run_id, workflow_task_id: nil, reason: 'manual reset')
+      workflow_task_id ||= get_last_completed_workflow_task_id(namespace, workflow_id, run_id)
+      raise Error, 'Could not find a completed workflow task event' unless workflow_task_id
+
+      response = connection.reset_workflow_execution(
+        namespace: namespace,
+        workflow_id: workflow_id,
+        run_id: run_id,
+        reason: reason,
+        workflow_task_event_id: workflow_task_id
+      )
+
+      response.run_id
+    end
+
+    def terminate_workflow(workflow_id, namespace: nil, run_id: nil, reason: nil, details: nil)
+      namespace ||= Temporal.configuration.namespace
+
+      connection.terminate_workflow_execution(
+        namespace: namespace,
+        workflow_id: workflow_id,
+        run_id: run_id,
+        reason: reason,
+        details: details
+      )
+    end
+
+    def fetch_workflow_execution_info(namespace, workflow_id, run_id)
+      response = connection.describe_workflow_execution(
+        namespace: namespace,
+        workflow_id: workflow_id,
+        run_id: run_id
+      )
+
+      Workflow::ExecutionInfo.generate_from(response.workflow_execution_info)
+    end
+
+    def complete_activity(async_token, result = nil)
+      details = Activity::AsyncToken.decode(async_token)
+
+      connection.respond_activity_task_completed_by_id(
+        namespace: details.namespace,
+        activity_id: details.activity_id,
+        workflow_id: details.workflow_id,
+        run_id: details.run_id,
+        result: result
+      )
+    end
+
+    def fail_activity(async_token, exception)
+      details = Activity::AsyncToken.decode(async_token)
+
+      connection.respond_activity_task_failed_by_id(
+        namespace: details.namespace,
+        activity_id: details.activity_id,
+        workflow_id: details.workflow_id,
+        run_id: details.run_id,
+        exception: exception
+      )
+    end
+
+    class ResultConverter
+      extend Concerns::Payloads
+    end
+    private_constant :ResultConverter
+
+    private
+
+    attr_reader :config
+
+    def connection
+      @connection ||= Temporal::Connection.generate(config.for_connection)
+    end
+
+    def get_last_completed_workflow_task_id(namespace, workflow_id, run_id)
+      history_response = connection.get_workflow_execution_history(
+        namespace: namespace,
+        workflow_id: workflow_id,
+        run_id: run_id
+      )
+      history = Workflow::History.new(history_response.history.events)
+      workflow_task_event = history.get_last_completed_workflow_task
+      workflow_task_event&.id
+    end
+  end
+end

--- a/lib/temporal/testing.rb
+++ b/lib/temporal/testing.rb
@@ -47,5 +47,5 @@ module Temporal
   end
 end
 
-Temporal.singleton_class.prepend Temporal::Testing::TemporalOverride
+Temporal::Client.prepend Temporal::Testing::TemporalOverride
 Temporal::Workflow.extend Temporal::Testing::WorkflowOverride

--- a/spec/unit/lib/temporal/client_spec.rb
+++ b/spec/unit/lib/temporal/client_spec.rb
@@ -1,0 +1,515 @@
+require 'temporal/client'
+require 'temporal/configuration'
+require 'temporal/workflow'
+require 'temporal/connection/grpc'
+
+describe Temporal::Client do
+  subject { described_class.new(config) }
+
+  let(:config) { Temporal::Configuration.new }
+  let(:connection) { instance_double(Temporal::Connection::GRPC) }
+
+  class TestStartWorkflow < Temporal::Workflow
+    namespace 'default-test-namespace'
+    task_queue 'default-test-task-queue'
+  end
+
+  before do
+    allow(Temporal::Connection)
+    .to receive(:generate)
+    .with(config.for_connection)
+    .and_return(connection)
+  end
+  after { subject.remove_instance_variable(:@connection) }
+
+  describe '#start_workflow' do
+    let(:temporal_response) do
+      Temporal::Api::WorkflowService::V1::StartWorkflowExecutionResponse.new(run_id: 'xxx')
+    end
+
+    before { allow(connection).to receive(:start_workflow_execution).and_return(temporal_response) }
+
+    context 'using a workflow class' do
+      it 'returns run_id' do
+        result = subject.start_workflow(TestStartWorkflow, 42)
+
+        expect(result).to eq(temporal_response.run_id)
+      end
+
+      it 'starts a workflow using the default options' do
+        subject.start_workflow(TestStartWorkflow, 42)
+
+        expect(connection)
+          .to have_received(:start_workflow_execution)
+          .with(
+            namespace: 'default-test-namespace',
+            workflow_id: an_instance_of(String),
+            workflow_name: 'TestStartWorkflow',
+            task_queue: 'default-test-task-queue',
+            input: [42],
+            task_timeout: Temporal.configuration.timeouts[:task],
+            run_timeout: Temporal.configuration.timeouts[:run],
+            execution_timeout: Temporal.configuration.timeouts[:execution],
+            workflow_id_reuse_policy: nil,
+            headers: {}
+          )
+      end
+
+      it 'starts a workflow using the options specified' do
+        subject.start_workflow(
+          TestStartWorkflow,
+          42,
+          options: {
+            name: 'test-workflow',
+            namespace: 'test-namespace',
+            task_queue: 'test-task-queue',
+            headers: { 'Foo' => 'Bar' }
+          }
+        )
+
+        expect(connection)
+          .to have_received(:start_workflow_execution)
+          .with(
+            namespace: 'test-namespace',
+            workflow_id: an_instance_of(String),
+            workflow_name: 'test-workflow',
+            task_queue: 'test-task-queue',
+            input: [42],
+            task_timeout: Temporal.configuration.timeouts[:task],
+            run_timeout: Temporal.configuration.timeouts[:run],
+            execution_timeout: Temporal.configuration.timeouts[:execution],
+            workflow_id_reuse_policy: nil,
+            headers: { 'Foo' => 'Bar' }
+          )
+      end
+
+      it 'starts a workflow using a mix of input, keyword arguments and options' do
+        subject.start_workflow(
+          TestStartWorkflow,
+          42,
+          arg_1: 1,
+          arg_2: 2,
+          options: { name: 'test-workflow' }
+        )
+
+        expect(connection)
+          .to have_received(:start_workflow_execution)
+          .with(
+            namespace: 'default-test-namespace',
+            workflow_id: an_instance_of(String),
+            workflow_name: 'test-workflow',
+            task_queue: 'default-test-task-queue',
+            input: [42, { arg_1: 1, arg_2: 2 }],
+            task_timeout: Temporal.configuration.timeouts[:task],
+            run_timeout: Temporal.configuration.timeouts[:run],
+            execution_timeout: Temporal.configuration.timeouts[:execution],
+            workflow_id_reuse_policy: nil,
+            headers: {}
+          )
+      end
+
+      it 'starts a workflow using specified workflow_id' do
+        subject.start_workflow(TestStartWorkflow, 42, options: { workflow_id: '123' })
+
+        expect(connection)
+          .to have_received(:start_workflow_execution)
+          .with(
+            namespace: 'default-test-namespace',
+            workflow_id: '123',
+            workflow_name: 'TestStartWorkflow',
+            task_queue: 'default-test-task-queue',
+            input: [42],
+            task_timeout: Temporal.configuration.timeouts[:task],
+            run_timeout: Temporal.configuration.timeouts[:run],
+            execution_timeout: Temporal.configuration.timeouts[:execution],
+            workflow_id_reuse_policy: nil,
+            headers: {}
+          )
+      end
+
+      it 'starts a workflow with a workflow id reuse policy' do
+        subject.start_workflow(
+          TestStartWorkflow, 42, options: { workflow_id_reuse_policy: :allow }
+        )
+
+        expect(connection)
+          .to have_received(:start_workflow_execution)
+          .with(
+            namespace: 'default-test-namespace',
+            workflow_id: an_instance_of(String),
+            workflow_name: 'TestStartWorkflow',
+            task_queue: 'default-test-task-queue',
+            input: [42],
+            task_timeout: Temporal.configuration.timeouts[:task],
+            run_timeout: Temporal.configuration.timeouts[:run],
+            execution_timeout: Temporal.configuration.timeouts[:execution],
+            workflow_id_reuse_policy: :allow,
+            headers: {}
+          )
+      end
+    end
+
+    context 'using a string reference' do
+      it 'starts a workflow' do
+        subject.start_workflow(
+          'test-workflow',
+          42,
+          options: { namespace: 'test-namespace', task_queue: 'test-task-queue' }
+        )
+
+        expect(connection)
+          .to have_received(:start_workflow_execution)
+          .with(
+            namespace: 'test-namespace',
+            workflow_id: an_instance_of(String),
+            workflow_name: 'test-workflow',
+            task_queue: 'test-task-queue',
+            input: [42],
+            task_timeout: Temporal.configuration.timeouts[:task],
+            run_timeout: Temporal.configuration.timeouts[:run],
+            execution_timeout: Temporal.configuration.timeouts[:execution],
+            workflow_id_reuse_policy: nil,
+            headers: {}
+          )
+      end
+    end
+  end
+
+  describe '#schedule_workflow' do
+    let(:temporal_response) do
+      Temporal::Api::WorkflowService::V1::StartWorkflowExecutionResponse.new(run_id: 'xxx')
+    end
+
+    before { allow(connection).to receive(:start_workflow_execution).and_return(temporal_response) }
+
+    it 'starts a cron workflow' do
+      subject.schedule_workflow(TestStartWorkflow, '* * * * *', 42)
+
+      expect(connection)
+        .to have_received(:start_workflow_execution)
+        .with(
+          namespace: 'default-test-namespace',
+          workflow_id: an_instance_of(String),
+          workflow_name: 'TestStartWorkflow',
+          task_queue: 'default-test-task-queue',
+          cron_schedule: '* * * * *',
+          input: [42],
+          task_timeout: Temporal.configuration.timeouts[:task],
+          run_timeout: Temporal.configuration.timeouts[:run],
+          execution_timeout: Temporal.configuration.timeouts[:execution],
+          workflow_id_reuse_policy: nil,
+          headers: {}
+        )
+    end
+  end
+
+  describe '#terminate_workflow' do
+    let(:temporal_response) do
+      Temporal::Api::WorkflowService::V1::TerminateWorkflowExecutionResponse.new
+    end
+
+    before { allow(connection).to receive(:terminate_workflow_execution).and_return(temporal_response) }
+
+    it 'terminates a workflow' do
+      subject.terminate_workflow('my-workflow', reason: 'just stop it')
+
+      expect(connection)
+        .to have_received(:terminate_workflow_execution)
+        .with(
+          namespace: 'default-namespace',
+          workflow_id: 'my-workflow',
+          reason: 'just stop it',
+          details: nil,
+          run_id: nil
+        )
+    end
+  end
+
+  describe '#register_namespace' do
+    before { allow(connection).to receive(:register_namespace).and_return(nil) }
+
+    it 'registers namespace with the specified name' do
+      subject.register_namespace('new-namespace')
+
+      expect(connection)
+        .to have_received(:register_namespace)
+        .with(name: 'new-namespace', description: nil)
+    end
+
+    it 'registers namespace with the specified name and description' do
+      subject.register_namespace('new-namespace', 'namespace description')
+
+      expect(connection)
+        .to have_received(:register_namespace)
+        .with(name: 'new-namespace', description: 'namespace description')
+    end
+  end
+
+  describe '#await_workflow_result' do
+    class NamespacedWorkflow < Temporal::Workflow
+      namespace 'some-namespace'
+      task_queue 'some-task-queue'
+    end
+
+    let(:workflow_id) {'dummy_worklfow_id'}
+    let(:run_id) {'dummy_run_id'}
+
+    it 'looks up history in the correct namespace for namespaced workflows' do
+      completed_event = Fabricate(:workflow_completed_event, result: nil)
+      response = Fabricate(:workflow_execution_history, events: [completed_event])
+
+      expect(connection)
+        .to receive(:get_workflow_execution_history)
+        .with(
+          namespace: 'some-namespace',
+          workflow_id: workflow_id,
+          run_id: run_id,
+          wait_for_new_event: true,
+          event_type: :close,
+          timeout: 30,
+        )
+        .and_return(response)
+
+        subject.await_workflow_result(
+        NamespacedWorkflow,
+        workflow_id: workflow_id,
+        run_id: run_id,
+      )
+    end
+
+    it 'can override the namespace' do 
+      completed_event = Fabricate(:workflow_completed_event, result: nil)
+      response = Fabricate(:workflow_execution_history, events: [completed_event])
+
+      expect(connection)
+        .to receive(:get_workflow_execution_history)
+        .with(
+          namespace: 'some-other-namespace',
+          workflow_id: workflow_id,
+          run_id: run_id,
+          wait_for_new_event: true,
+          event_type: :close,
+          timeout: 30,
+        )
+        .and_return(response)
+
+        subject.await_workflow_result(
+        NamespacedWorkflow,
+        workflow_id: workflow_id,
+        run_id: run_id,
+        namespace: 'some-other-namespace'
+      )
+    end
+
+    [
+      {type: 'hash', expected_result: { 'key' => 'value' }},
+      {type: 'integer', expected_result: 5},
+      {type: 'nil', expected_result: nil},
+      {type: 'string', expected_result: 'a result'},
+    ].each do |type:, expected_result:|
+      it "completes and returns a #{type}" do
+        payload = Temporal::Api::Common::V1::Payloads.new(
+          payloads: [
+            Temporal.configuration.converter.to_payload(expected_result)
+          ],
+        )
+        completed_event = Fabricate(:workflow_completed_event, result: payload)
+        response = Fabricate(:workflow_execution_history, events: [completed_event])
+        expect(connection)
+          .to receive(:get_workflow_execution_history)
+          .with(
+            namespace: 'default-test-namespace',
+            workflow_id: workflow_id,
+            run_id: nil,
+            wait_for_new_event: true,
+            event_type: :close,
+            timeout: 30,
+          )
+          .and_return(response)
+
+        actual_result = subject.await_workflow_result(
+          TestStartWorkflow,
+          workflow_id: workflow_id,
+        )
+        expect(actual_result).to eq(expected_result)
+      end
+    end
+
+    # Unit test, rather than integration test, because we don't support cancellation via the SDK yet.
+    # See integration test for other failure conditions.
+    it 'raises when the workflow was canceled' do
+      completed_event = Fabricate(:workflow_canceled_event)
+      response = Fabricate(:workflow_execution_history, events: [completed_event])
+
+      expect(connection)
+        .to receive(:get_workflow_execution_history)
+        .with(
+          namespace: 'default-test-namespace',
+          workflow_id: workflow_id,
+          run_id: run_id,
+          wait_for_new_event: true,
+          event_type: :close,
+          timeout: 30,
+        )
+        .and_return(response)
+
+      expect do
+        subject.await_workflow_result(
+          TestStartWorkflow,
+          workflow_id: workflow_id,
+          run_id: run_id,
+        )
+      end.to raise_error(Temporal::WorkflowCanceled)
+    end
+
+    it 'raises TimeoutError when the server times out' do 
+      response = Fabricate(:workflow_execution_history, events: [])
+      expect(connection)
+        .to receive(:get_workflow_execution_history)
+        .with(
+          namespace: 'default-test-namespace',
+          workflow_id: workflow_id,
+          run_id: run_id,
+          wait_for_new_event: true,
+          event_type: :close,
+          timeout: 3,
+        )
+        .and_raise(GRPC::DeadlineExceeded)
+        expect do
+          subject.await_workflow_result(
+            TestStartWorkflow,
+            workflow_id: workflow_id,
+            run_id: run_id,
+            timeout: 3,
+          )
+        end.to raise_error(Temporal::TimeoutError)
+    end
+  end
+
+  describe '#fetch_workflow_execution_info' do
+    let(:response) do
+      Temporal::Api::WorkflowService::V1::DescribeWorkflowExecutionResponse.new(
+        workflow_execution_info: api_info
+      )
+    end
+    let(:api_info) { Fabricate(:api_workflow_execution_info) }
+
+    before { allow(connection).to receive(:describe_workflow_execution).and_return(response) }
+
+    it 'requests execution info from Temporal' do
+      subject.fetch_workflow_execution_info('namespace', '111', '222')
+
+      expect(connection)
+        .to have_received(:describe_workflow_execution)
+        .with(namespace: 'namespace', workflow_id: '111', run_id: '222')
+    end
+
+    it 'returns Workflow::ExecutionInfo' do
+      info = subject.fetch_workflow_execution_info('namespace', '111', '222')
+
+      expect(info).to be_a(Temporal::Workflow::ExecutionInfo)
+    end
+  end
+
+  describe '#reset_workflow' do
+    let(:temporal_response) do
+      Temporal::Api::WorkflowService::V1::ResetWorkflowExecutionResponse.new(run_id: 'xxx')
+    end
+
+    before { allow(connection).to receive(:reset_workflow_execution).and_return(temporal_response) }
+
+    context 'when workflow_task_id is provided' do
+      let(:workflow_task_id) { 42 }
+
+      it 'calls connection reset_workflow_execution' do
+        subject.reset_workflow(
+          'default-test-namespace',
+          '123',
+          '1234',
+          workflow_task_id: workflow_task_id,
+          reason: 'Test reset'
+        )
+
+        expect(connection).to have_received(:reset_workflow_execution).with(
+          namespace: 'default-test-namespace',
+          workflow_id: '123',
+          run_id: '1234',
+          reason: 'Test reset',
+          workflow_task_event_id: workflow_task_id
+        )
+      end
+
+      it 'returns the new run_id' do
+        result = subject.reset_workflow(
+          'default-test-namespace',
+          '123',
+          '1234',
+          workflow_task_id: workflow_task_id
+        )
+
+        expect(result).to eq('xxx')
+      end
+    end
+  end
+
+  context 'activity operations' do
+    let(:namespace) { 'test-namespace' }
+    let(:activity_id) { rand(100).to_s }
+    let(:workflow_id) { SecureRandom.uuid }
+    let(:run_id) { SecureRandom.uuid }
+    let(:async_token) do
+      Temporal::Activity::AsyncToken.encode(namespace, activity_id, workflow_id, run_id)
+    end
+
+    describe '#complete_activity' do
+      before { allow(connection).to receive(:respond_activity_task_completed_by_id).and_return(nil) }
+
+      it 'completes activity with a result' do
+        subject.complete_activity(async_token, 'all work completed')
+
+        expect(connection)
+          .to have_received(:respond_activity_task_completed_by_id)
+          .with(
+            namespace: namespace,
+            activity_id: activity_id,
+            workflow_id: workflow_id,
+            run_id: run_id,
+            result: 'all work completed'
+          )
+      end
+
+      it 'completes activity without a result' do
+        subject.complete_activity(async_token)
+
+        expect(connection)
+          .to have_received(:respond_activity_task_completed_by_id)
+          .with(
+            namespace: namespace,
+            activity_id: activity_id,
+            workflow_id: workflow_id,
+            run_id: run_id,
+            result: nil
+          )
+      end
+    end
+
+    describe '#fail_activity' do
+      before { allow(connection).to receive(:respond_activity_task_failed_by_id).and_return(nil) }
+
+      it 'fails activity with a provided error' do
+        exception = StandardError.new('something went wrong')
+        subject.fail_activity(async_token, exception)
+
+        expect(connection)
+          .to have_received(:respond_activity_task_failed_by_id)
+          .with(
+            namespace: namespace,
+            activity_id: activity_id,
+            workflow_id: workflow_id,
+            run_id: run_id,
+            exception: exception
+          )
+      end
+    end
+  end
+end

--- a/spec/unit/lib/temporal/client_spec.rb
+++ b/spec/unit/lib/temporal/client_spec.rb
@@ -203,28 +203,6 @@ describe Temporal::Client do
     end
   end
 
-  describe '#terminate_workflow' do
-    let(:temporal_response) do
-      Temporal::Api::WorkflowService::V1::TerminateWorkflowExecutionResponse.new
-    end
-
-    before { allow(connection).to receive(:terminate_workflow_execution).and_return(temporal_response) }
-
-    it 'terminates a workflow' do
-      subject.terminate_workflow('my-workflow', reason: 'just stop it')
-
-      expect(connection)
-        .to have_received(:terminate_workflow_execution)
-        .with(
-          namespace: 'default-namespace',
-          workflow_id: 'my-workflow',
-          reason: 'just stop it',
-          details: nil,
-          run_id: nil
-        )
-    end
-  end
-
   describe '#register_namespace' do
     before { allow(connection).to receive(:register_namespace).and_return(nil) }
 
@@ -386,31 +364,6 @@ describe Temporal::Client do
     end
   end
 
-  describe '#fetch_workflow_execution_info' do
-    let(:response) do
-      Temporal::Api::WorkflowService::V1::DescribeWorkflowExecutionResponse.new(
-        workflow_execution_info: api_info
-      )
-    end
-    let(:api_info) { Fabricate(:api_workflow_execution_info) }
-
-    before { allow(connection).to receive(:describe_workflow_execution).and_return(response) }
-
-    it 'requests execution info from Temporal' do
-      subject.fetch_workflow_execution_info('namespace', '111', '222')
-
-      expect(connection)
-        .to have_received(:describe_workflow_execution)
-        .with(namespace: 'namespace', workflow_id: '111', run_id: '222')
-    end
-
-    it 'returns Workflow::ExecutionInfo' do
-      info = subject.fetch_workflow_execution_info('namespace', '111', '222')
-
-      expect(info).to be_a(Temporal::Workflow::ExecutionInfo)
-    end
-  end
-
   describe '#reset_workflow' do
     let(:temporal_response) do
       Temporal::Api::WorkflowService::V1::ResetWorkflowExecutionResponse.new(run_id: 'xxx')
@@ -449,6 +402,53 @@ describe Temporal::Client do
 
         expect(result).to eq('xxx')
       end
+    end
+  end
+
+  describe '#terminate_workflow' do
+    let(:temporal_response) do
+      Temporal::Api::WorkflowService::V1::TerminateWorkflowExecutionResponse.new
+    end
+
+    before { allow(connection).to receive(:terminate_workflow_execution).and_return(temporal_response) }
+
+    it 'terminates a workflow' do
+      subject.terminate_workflow('my-workflow', reason: 'just stop it')
+
+      expect(connection)
+        .to have_received(:terminate_workflow_execution)
+        .with(
+          namespace: 'default-namespace',
+          workflow_id: 'my-workflow',
+          reason: 'just stop it',
+          details: nil,
+          run_id: nil
+        )
+    end
+  end
+
+  describe '#fetch_workflow_execution_info' do
+    let(:response) do
+      Temporal::Api::WorkflowService::V1::DescribeWorkflowExecutionResponse.new(
+        workflow_execution_info: api_info
+      )
+    end
+    let(:api_info) { Fabricate(:api_workflow_execution_info) }
+
+    before { allow(connection).to receive(:describe_workflow_execution).and_return(response) }
+
+    it 'requests execution info from Temporal' do
+      subject.fetch_workflow_execution_info('namespace', '111', '222')
+
+      expect(connection)
+        .to have_received(:describe_workflow_execution)
+        .with(namespace: 'namespace', workflow_id: '111', run_id: '222')
+    end
+
+    it 'returns Workflow::ExecutionInfo' do
+      info = subject.fetch_workflow_execution_info('namespace', '111', '222')
+
+      expect(info).to be_a(Temporal::Workflow::ExecutionInfo)
     end
   end
 

--- a/spec/unit/lib/temporal/testing/temporal_override_spec.rb
+++ b/spec/unit/lib/temporal/testing/temporal_override_spec.rb
@@ -3,6 +3,9 @@ require 'temporal/workflow'
 require 'temporal/api/errordetails/v1/message_pb'
 
 describe Temporal::Testing::TemporalOverride do
+  let(:client) { Temporal::Client.new(config) }
+  let(:config) { Temporal::Configuration.new }
+
   class TestTemporalOverrideWorkflow < Temporal::Workflow
     namespace 'default-namespace'
     task_queue 'default-task-queue'
@@ -16,12 +19,12 @@ describe Temporal::Testing::TemporalOverride do
       let(:response) { Temporal::Api::WorkflowService::V1::StartWorkflowExecutionResponse.new(run_id: 'xxx') }
 
       before { allow(Temporal::Connection).to receive(:generate).and_return(connection) }
-      after { Temporal.remove_instance_variable(:@connection) rescue NameError }
+      after { client.remove_instance_variable(:@connection) rescue NameError }
 
       it 'invokes original implementation' do
         allow(connection).to receive(:start_workflow_execution).and_return(response)
 
-        Temporal.start_workflow(TestTemporalOverrideWorkflow)
+        client.start_workflow(TestTemporalOverrideWorkflow)
 
         expect(connection)
           .to have_received(:start_workflow_execution)
@@ -43,8 +46,8 @@ describe Temporal::Testing::TemporalOverride do
 
         allow(workflow).to receive(:execute)
         allow(workflow2).to receive(:execute)
-        Temporal.schedule_workflow(TestTemporalOverrideWorkflow, '* * * * *')
-        Temporal.schedule_workflow(TestTemporalOverrideWorkflow, '1 */5 * * *')
+        client.schedule_workflow(TestTemporalOverrideWorkflow, '* * * * *')
+        client.schedule_workflow(TestTemporalOverrideWorkflow, '1 */5 * * *')
         expect(workflow).not_to have_received(:execute)
         expect(workflow2).not_to have_received(:execute)
 
@@ -57,7 +60,7 @@ describe Temporal::Testing::TemporalOverride do
         workflow = TestTemporalOverrideWorkflow.new(nil)
         allow(TestTemporalOverrideWorkflow).to receive(:new).and_return(workflow)
         allow(workflow).to receive(:execute)
-        Temporal.schedule_workflow(TestTemporalOverrideWorkflow, '*/3 * * * *', options: { workflow_id: 'my_id' })
+        client.schedule_workflow(TestTemporalOverrideWorkflow, '*/3 * * * *', options: { workflow_id: 'my_id' })
         expect(workflow).not_to have_received(:execute)
         expect(Temporal::Testing::ScheduledWorkflows.cron_schedules['my_id']).to eq('*/3 * * * *')
 
@@ -78,7 +81,7 @@ describe Temporal::Testing::TemporalOverride do
         workflow = TestTemporalOverrideWorkflow.new(nil)
         allow(TestTemporalOverrideWorkflow).to receive(:new).and_return(workflow)
         allow(workflow).to receive(:execute)
-        Temporal.schedule_workflow(TestTemporalOverrideWorkflow, '* * * * *')
+        client.schedule_workflow(TestTemporalOverrideWorkflow, '* * * * *')
         expect(workflow).not_to have_received(:execute)
         expect(Temporal::Testing::ScheduledWorkflows.cron_schedules).not_to be_empty
 
@@ -125,7 +128,7 @@ describe Temporal::Testing::TemporalOverride do
       it 'calls the workflow directly' do
         allow(workflow).to receive(:execute)
 
-        Temporal.start_workflow(TestTemporalOverrideWorkflow)
+        client.start_workflow(TestTemporalOverrideWorkflow)
 
         expect(workflow).to have_received(:execute)
         expect(TestTemporalOverrideWorkflow)
@@ -135,7 +138,7 @@ describe Temporal::Testing::TemporalOverride do
 
       describe 'execution control' do
         subject do
-          Temporal.start_workflow(
+          client.start_workflow(
             TestTemporalOverrideWorkflow,
             options: { workflow_id: workflow_id, workflow_id_reuse_policy: policy }
           )
@@ -149,7 +152,7 @@ describe Temporal::Testing::TemporalOverride do
         # Simulate existing execution
         before do
           if execution
-            Temporal.send(:executions)[[workflow_id, run_id]] = execution
+            client.send(:executions)[[workflow_id, run_id]] = execution
           end
         end
 

--- a/spec/unit/lib/temporal_spec.rb
+++ b/spec/unit/lib/temporal_spec.rb
@@ -1,509 +1,62 @@
 require 'temporal'
-require 'temporal/workflow'
-require 'temporal/connection/grpc'
 
 describe Temporal do
-  describe 'client operations' do
-    let(:connection) { instance_double(Temporal::Connection::GRPC) }
+  describe 'public method forwarding' do
+    let(:client) { instance_double(Temporal::Client) }
 
-    class TestStartWorkflow < Temporal::Workflow
-      namespace 'default-test-namespace'
-      task_queue 'default-test-task-queue'
+    before { allow(Temporal::Client).to receive(:new).and_return(client) }
+    after { described_class.remove_instance_variable(:@default_client) rescue NameError }
+
+    shared_examples 'a forwarded method' do |method, *args, kwargs|
+      it 'forwards a method call to the default client instance' do
+        allow(client).to receive(method)
+
+        described_class.public_send(method, *args, kwargs)
+
+        expect(client).to have_received(method).with(*args, kwargs)
+      end
     end
-
-    before { allow(Temporal::Connection).to receive(:generate).and_return(connection) }
-    after { described_class.remove_instance_variable(:@connection) rescue NameError }
-
+    
     describe '.start_workflow' do
-      let(:temporal_response) do
-        Temporal::Api::WorkflowService::V1::StartWorkflowExecutionResponse.new(run_id: 'xxx')
-      end
-
-      before { allow(connection).to receive(:start_workflow_execution).and_return(temporal_response) }
-
-      context 'using a workflow class' do
-        it 'returns run_id' do
-          result = described_class.start_workflow(TestStartWorkflow, 42)
-
-          expect(result).to eq(temporal_response.run_id)
-        end
-
-        it 'starts a workflow using the default options' do
-          described_class.start_workflow(TestStartWorkflow, 42)
-
-          expect(connection)
-            .to have_received(:start_workflow_execution)
-            .with(
-              namespace: 'default-test-namespace',
-              workflow_id: an_instance_of(String),
-              workflow_name: 'TestStartWorkflow',
-              task_queue: 'default-test-task-queue',
-              input: [42],
-              task_timeout: Temporal.configuration.timeouts[:task],
-              run_timeout: Temporal.configuration.timeouts[:run],
-              execution_timeout: Temporal.configuration.timeouts[:execution],
-              workflow_id_reuse_policy: nil,
-              headers: {}
-            )
-        end
-
-        it 'starts a workflow using the options specified' do
-          described_class.start_workflow(
-            TestStartWorkflow,
-            42,
-            options: {
-              name: 'test-workflow',
-              namespace: 'test-namespace',
-              task_queue: 'test-task-queue',
-              headers: { 'Foo' => 'Bar' }
-            }
-          )
-
-          expect(connection)
-            .to have_received(:start_workflow_execution)
-            .with(
-              namespace: 'test-namespace',
-              workflow_id: an_instance_of(String),
-              workflow_name: 'test-workflow',
-              task_queue: 'test-task-queue',
-              input: [42],
-              task_timeout: Temporal.configuration.timeouts[:task],
-              run_timeout: Temporal.configuration.timeouts[:run],
-              execution_timeout: Temporal.configuration.timeouts[:execution],
-              workflow_id_reuse_policy: nil,
-              headers: { 'Foo' => 'Bar' }
-            )
-        end
-
-        it 'starts a workflow using a mix of input, keyword arguments and options' do
-          described_class.start_workflow(
-            TestStartWorkflow,
-            42,
-            arg_1: 1,
-            arg_2: 2,
-            options: { name: 'test-workflow' }
-          )
-
-          expect(connection)
-            .to have_received(:start_workflow_execution)
-            .with(
-              namespace: 'default-test-namespace',
-              workflow_id: an_instance_of(String),
-              workflow_name: 'test-workflow',
-              task_queue: 'default-test-task-queue',
-              input: [42, { arg_1: 1, arg_2: 2 }],
-              task_timeout: Temporal.configuration.timeouts[:task],
-              run_timeout: Temporal.configuration.timeouts[:run],
-              execution_timeout: Temporal.configuration.timeouts[:execution],
-              workflow_id_reuse_policy: nil,
-              headers: {}
-            )
-        end
-
-        it 'starts a workflow using specified workflow_id' do
-          described_class.start_workflow(TestStartWorkflow, 42, options: { workflow_id: '123' })
-
-          expect(connection)
-            .to have_received(:start_workflow_execution)
-            .with(
-              namespace: 'default-test-namespace',
-              workflow_id: '123',
-              workflow_name: 'TestStartWorkflow',
-              task_queue: 'default-test-task-queue',
-              input: [42],
-              task_timeout: Temporal.configuration.timeouts[:task],
-              run_timeout: Temporal.configuration.timeouts[:run],
-              execution_timeout: Temporal.configuration.timeouts[:execution],
-              workflow_id_reuse_policy: nil,
-              headers: {}
-            )
-        end
-
-        it 'starts a workflow with a workflow id reuse policy' do
-          described_class.start_workflow(
-            TestStartWorkflow, 42, options: { workflow_id_reuse_policy: :allow }
-          )
-
-          expect(connection)
-            .to have_received(:start_workflow_execution)
-            .with(
-              namespace: 'default-test-namespace',
-              workflow_id: an_instance_of(String),
-              workflow_name: 'TestStartWorkflow',
-              task_queue: 'default-test-task-queue',
-              input: [42],
-              task_timeout: Temporal.configuration.timeouts[:task],
-              run_timeout: Temporal.configuration.timeouts[:run],
-              execution_timeout: Temporal.configuration.timeouts[:execution],
-              workflow_id_reuse_policy: :allow,
-              headers: {}
-            )
-        end
-      end
-
-      context 'using a string reference' do
-        it 'starts a workflow' do
-          described_class.start_workflow(
-            'test-workflow',
-            42,
-            options: { namespace: 'test-namespace', task_queue: 'test-task-queue' }
-          )
-
-          expect(connection)
-            .to have_received(:start_workflow_execution)
-            .with(
-              namespace: 'test-namespace',
-              workflow_id: an_instance_of(String),
-              workflow_name: 'test-workflow',
-              task_queue: 'test-task-queue',
-              input: [42],
-              task_timeout: Temporal.configuration.timeouts[:task],
-              run_timeout: Temporal.configuration.timeouts[:run],
-              execution_timeout: Temporal.configuration.timeouts[:execution],
-              workflow_id_reuse_policy: nil,
-              headers: {}
-            )
-        end
-      end
+      it_behaves_like 'a forwarded method', :start_workflow, 'TestWorkflow', 42
+    end    
+    
+    describe '.schedule_workflow' do
+      it_behaves_like 'a forwarded method', :schedule_workflow, 'TestWorkflow', '* * * * *', 42
+    end    
+    
+    describe '.register_namespace' do
+      it_behaves_like 'a forwarded method', :register_namespace, 'test-namespace', 'This is a test namespace'
+    end
+    
+    describe '.signal_workflow' do
+      it_behaves_like 'a forwarded method', :signal_workflow, 'TestWorkflow', 'TST_SIGNAL', 'x', 'y'
+    end
+    
+    describe '.await_workflow_result' do
+      it_behaves_like 'a forwarded method', :await_workflow_result, 'TestWorkflow', workflow_id: 'x'
+    end
+    
+    describe '.reset_workflow' do
+      it_behaves_like 'a forwarded method', :reset_workflow, 'test-namespace', 'x', 'y'
     end
 
     describe '.terminate_workflow' do
-      let(:temporal_response) do
-        Temporal::Api::WorkflowService::V1::TerminateWorkflowExecutionResponse.new
-      end
-
-      before { allow(connection).to receive(:terminate_workflow_execution).and_return(temporal_response) }
-
-      it 'terminates a workflow' do
-        described_class.terminate_workflow('my-workflow', reason: 'just stop it')
-
-        expect(connection)
-          .to have_received(:terminate_workflow_execution)
-          .with(
-            namespace: 'default-namespace',
-            workflow_id: 'my-workflow',
-            reason: 'just stop it',
-            details: nil,
-            run_id: nil
-          )
-      end
-    end
-
-    describe '.schedule_workflow' do
-      let(:temporal_response) do
-        Temporal::Api::WorkflowService::V1::StartWorkflowExecutionResponse.new(run_id: 'xxx')
-      end
-
-      before { allow(connection).to receive(:start_workflow_execution).and_return(temporal_response) }
-
-      it 'starts a cron workflow' do
-        described_class.schedule_workflow(TestStartWorkflow, '* * * * *', 42)
-
-        expect(connection)
-          .to have_received(:start_workflow_execution)
-          .with(
-            namespace: 'default-test-namespace',
-            workflow_id: an_instance_of(String),
-            workflow_name: 'TestStartWorkflow',
-            task_queue: 'default-test-task-queue',
-            cron_schedule: '* * * * *',
-            input: [42],
-            task_timeout: Temporal.configuration.timeouts[:task],
-            run_timeout: Temporal.configuration.timeouts[:run],
-            execution_timeout: Temporal.configuration.timeouts[:execution],
-            workflow_id_reuse_policy: nil,
-            headers: {}
-          )
-      end
-    end
-
-    describe '.register_namespace' do
-      before { allow(connection).to receive(:register_namespace).and_return(nil) }
-
-      it 'registers namespace with the specified name' do
-        described_class.register_namespace('new-namespace')
-
-        expect(connection)
-          .to have_received(:register_namespace)
-          .with(name: 'new-namespace', description: nil)
-      end
-
-      it 'registers namespace with the specified name and description' do
-        described_class.register_namespace('new-namespace', 'namespace description')
-
-        expect(connection)
-          .to have_received(:register_namespace)
-          .with(name: 'new-namespace', description: 'namespace description')
-      end
+      it_behaves_like 'a forwarded method', :terminate_workflow, 'x'
     end
 
     describe '.fetch_workflow_execution_info' do
-      let(:response) do
-        Temporal::Api::WorkflowService::V1::DescribeWorkflowExecutionResponse.new(
-          workflow_execution_info: api_info
-        )
-      end
-      let(:api_info) { Fabricate(:api_workflow_execution_info) }
-
-      before { allow(connection).to receive(:describe_workflow_execution).and_return(response) }
-
-      it 'requests execution info from Temporal' do
-        described_class.fetch_workflow_execution_info('namespace', '111', '222')
-
-        expect(connection)
-          .to have_received(:describe_workflow_execution)
-          .with(namespace: 'namespace', workflow_id: '111', run_id: '222')
-      end
-
-      it 'returns Workflow::ExecutionInfo' do
-        info = described_class.fetch_workflow_execution_info('namespace', '111', '222')
-
-        expect(info).to be_a(Temporal::Workflow::ExecutionInfo)
-      end
+      it_behaves_like 'a forwarded method', :fetch_workflow_execution_info, 'test-namespace', 'x', 'y'
     end
 
-    describe '.reset_workflow' do
-      let(:temporal_response) do
-        Temporal::Api::WorkflowService::V1::ResetWorkflowExecutionResponse.new(run_id: 'xxx')
-      end
-
-      before { allow(connection).to receive(:reset_workflow_execution).and_return(temporal_response) }
-
-      context 'when workflow_task_id is provided' do
-        let(:workflow_task_id) { 42 }
-
-        it 'calls connection reset_workflow_execution' do
-          described_class.reset_workflow(
-            'default-test-namespace',
-            '123',
-            '1234',
-            workflow_task_id: workflow_task_id,
-            reason: 'Test reset'
-          )
-
-          expect(connection).to have_received(:reset_workflow_execution).with(
-            namespace: 'default-test-namespace',
-            workflow_id: '123',
-            run_id: '1234',
-            reason: 'Test reset',
-            workflow_task_event_id: workflow_task_id
-          )
-        end
-
-        it 'returns the new run_id' do
-          result = described_class.reset_workflow(
-            'default-test-namespace',
-            '123',
-            '1234',
-            workflow_task_id: workflow_task_id
-          )
-
-          expect(result).to eq('xxx')
-        end
-      end
+    describe '.complete_activity' do
+      it_behaves_like 'a forwarded method', :complete_activity, 'test-token', 'result'
     end
 
-    context 'activity operations' do
-      let(:namespace) { 'test-namespace' }
-      let(:activity_id) { rand(100).to_s }
-      let(:workflow_id) { SecureRandom.uuid }
-      let(:run_id) { SecureRandom.uuid }
-      let(:async_token) do
-        Temporal::Activity::AsyncToken.encode(namespace, activity_id, workflow_id, run_id)
-      end
-
-      describe '.complete_activity' do
-        before { allow(connection).to receive(:respond_activity_task_completed_by_id).and_return(nil) }
-
-        it 'completes activity with a result' do
-          described_class.complete_activity(async_token, 'all work completed')
-
-          expect(connection)
-            .to have_received(:respond_activity_task_completed_by_id)
-            .with(
-              namespace: namespace,
-              activity_id: activity_id,
-              workflow_id: workflow_id,
-              run_id: run_id,
-              result: 'all work completed'
-            )
-        end
-
-        it 'completes activity without a result' do
-          described_class.complete_activity(async_token)
-
-          expect(connection)
-            .to have_received(:respond_activity_task_completed_by_id)
-            .with(
-              namespace: namespace,
-              activity_id: activity_id,
-              workflow_id: workflow_id,
-              run_id: run_id,
-              result: nil
-            )
-        end
-      end
-
-      describe '.fail_activity' do
-        before { allow(connection).to receive(:respond_activity_task_failed_by_id).and_return(nil) }
-
-        it 'fails activity with a provided error' do
-          exception = StandardError.new('something went wrong')
-          described_class.fail_activity(async_token, exception)
-
-          expect(connection)
-            .to have_received(:respond_activity_task_failed_by_id)
-            .with(
-              namespace: namespace,
-              activity_id: activity_id,
-              workflow_id: workflow_id,
-              run_id: run_id,
-              exception: exception
-            )
-        end
-      end
+    describe '.fail_activity' do
+      it_behaves_like 'a forwarded method', :complete_activity, 'test-token', StandardError.new
     end
 
-    describe '.await_workflow_result' do
-      class NamespacedWorkflow < Temporal::Workflow
-        namespace 'some-namespace'
-        task_queue 'some-task-queue'
-      end
-
-      let(:workflow_id) {'dummy_worklfow_id'}
-      let(:run_id) {'dummy_run_id'}
-
-      it 'looks up history in the correct namespace for namespaced workflows' do
-        completed_event = Fabricate(:workflow_completed_event, result: nil)
-        response = Fabricate(:workflow_execution_history, events: [completed_event])
-
-        expect(connection)
-          .to receive(:get_workflow_execution_history)
-          .with(
-            namespace: 'some-namespace',
-            workflow_id: workflow_id,
-            run_id: run_id,
-            wait_for_new_event: true,
-            event_type: :close,
-            timeout: 30,
-          )
-          .and_return(response)
-
-        Temporal.await_workflow_result(
-          NamespacedWorkflow,
-          workflow_id: workflow_id,
-          run_id: run_id,
-        )
-      end
-
-      it 'can override the namespace' do 
-        completed_event = Fabricate(:workflow_completed_event, result: nil)
-        response = Fabricate(:workflow_execution_history, events: [completed_event])
-
-        expect(connection)
-          .to receive(:get_workflow_execution_history)
-          .with(
-            namespace: 'some-other-namespace',
-            workflow_id: workflow_id,
-            run_id: run_id,
-            wait_for_new_event: true,
-            event_type: :close,
-            timeout: 30,
-          )
-          .and_return(response)
-
-        Temporal.await_workflow_result(
-          NamespacedWorkflow,
-          workflow_id: workflow_id,
-          run_id: run_id,
-          namespace: 'some-other-namespace'
-        )
-      end
-
-      [
-        {type: 'hash', expected_result: { 'key' => 'value' }},
-        {type: 'integer', expected_result: 5},
-        {type: 'nil', expected_result: nil},
-        {type: 'string', expected_result: 'a result'},
-      ].each do |type:, expected_result:|
-        it "completes and returns a #{type}" do
-          payload = Temporal::Api::Common::V1::Payloads.new(
-            payloads: [
-              Temporal.configuration.converter.to_payload(expected_result)
-            ],
-          )
-          completed_event = Fabricate(:workflow_completed_event, result: payload)
-          response = Fabricate(:workflow_execution_history, events: [completed_event])
-          expect(connection)
-            .to receive(:get_workflow_execution_history)
-            .with(
-              namespace: 'default-test-namespace',
-              workflow_id: workflow_id,
-              run_id: nil,
-              wait_for_new_event: true,
-              event_type: :close,
-              timeout: 30,
-            )
-            .and_return(response)
-
-          actual_result = Temporal.await_workflow_result(
-            TestStartWorkflow,
-            workflow_id: workflow_id,
-          )
-          expect(actual_result).to eq(expected_result)
-        end
-      end
-
-      # Unit test, rather than integration test, because we don't support cancellation via the SDK yet.
-      # See integration test for other failure conditions.
-      it 'raises when the workflow was canceled' do
-        completed_event = Fabricate(:workflow_canceled_event)
-        response = Fabricate(:workflow_execution_history, events: [completed_event])
-
-        expect(connection)
-          .to receive(:get_workflow_execution_history)
-          .with(
-            namespace: 'default-test-namespace',
-            workflow_id: workflow_id,
-            run_id: run_id,
-            wait_for_new_event: true,
-            event_type: :close,
-            timeout: 30,
-          )
-          .and_return(response)
-
-        expect do
-          Temporal.await_workflow_result(
-            TestStartWorkflow,
-            workflow_id: workflow_id,
-            run_id: run_id,
-          )
-        end.to raise_error(Temporal::WorkflowCanceled)
-      end
-
-      it 'raises TimeoutError when the server times out' do 
-        response = Fabricate(:workflow_execution_history, events: [])
-        expect(connection)
-          .to receive(:get_workflow_execution_history)
-          .with(
-            namespace: 'default-test-namespace',
-            workflow_id: workflow_id,
-            run_id: run_id,
-            wait_for_new_event: true,
-            event_type: :close,
-            timeout: 3,
-          )
-          .and_raise(GRPC::DeadlineExceeded)
-          expect do
-            Temporal.await_workflow_result(
-              TestStartWorkflow,
-              workflow_id: workflow_id,
-              run_id: run_id,
-              timeout: 3,
-            )
-          end.to raise_error(Temporal::TimeoutError)
-      end
-    end
   end
 
   describe '.configure' do
@@ -523,6 +76,12 @@ describe Temporal do
   describe '.logger' do
     it 'returns preconfigured Temporal logger' do
       expect(described_class.logger).to eq(described_class.configuration.logger)
+    end
+  end
+  
+  describe '.metrics' do
+    it 'returns preconfigured Temporal metrics' do
+      expect(described_class.metrics).to an_instance_of(Temporal::Metrics)
     end
   end
 end


### PR DESCRIPTION
This is syncing https://github.com/coinbase/cadence-ruby/pull/42.

Quoting Anthony's PR description:
"
This turns ~~`Cadence`~~ Temporal into an initializable ~~`Cadence::Client`~~ `Temporal::Client` allowing to connect to multiple clusters:

```
config_1 = Temporal::Configuration.new
config_1.host = 'xxx'

client_1 = Temporal::Client.new(config_1)
client_1.start_workflow(TestWorkflow)

config_2 = Temporal::Configuration.new
config_2.host = 'xxx'

client_2 = Temporal::Client.new(config_2)
client_2.start_workflow(TestWorkflow)
```

This change is backwards compatible and ~~`Cadence.*`~~ `Temporal.*` class methods are simply delegated to a default client.

The "meat" of this PR is moving ~~`Cadence`~~ `Temporal` methods into ~~`Cadence::Client`~~ `Temporal::Client` and moving specs
"