### PR TITLE
Implement strategies for resetting workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ _yardoc/
 
 # rspec failure tracking
 .rspec_status
+
+.idea/*

--- a/lib/temporal/reset_strategy.rb
+++ b/lib/temporal/reset_strategy.rb
@@ -1,0 +1,7 @@
+module Temporal
+  module ResetStrategy
+    LAST_WORKFLOW_TASK = :last_workflow_task
+    FIRST_WORKFLOW_TASK = :first_workflow_task
+    LAST_FAILED_ACTIVITY = :last_failed_activity
+  end
+end

--- a/lib/temporal/workflow/history.rb
+++ b/lib/temporal/workflow/history.rb
@@ -11,8 +11,8 @@ module Temporal
         @iterator = @events.each
       end
 
-      def last_completed_workflow_task
-        events.select { |event| event.type == 'WORKFLOW_TASK_COMPLETED' }.last
+      def find_event_by_id(id)
+        events.find { |event| event.id == id }
       end
 
       # It is very important to replay the History window by window in order to

--- a/spec/fabricators/grpc/history_event_fabricator.rb
+++ b/spec/fabricators/grpc/history_event_fabricator.rb
@@ -34,10 +34,10 @@ Fabricator(:api_workflow_execution_completed_event, from: :api_history_event) do
   end
 end
 
-Fabricator(:api_decision_task_scheduled_event, from: :api_history_event) do
-  event_type { Temporal::Api::Enums::V1::EventType::EVENT_TYPE_DECISION_TASK_SCHEDULED }
-  decision_task_scheduled_event_attributes do |attrs|
-    Temporal::Api::History::V1::DecisionTaskScheduledEventAttributes.new(
+Fabricator(:api_workflow_task_scheduled_event, from: :api_history_event) do
+  event_type { Temporal::Api::Enums::V1::EventType::EVENT_TYPE_WORKFLOW_TASK_SCHEDULED }
+  workflow_task_scheduled_event_attributes do |attrs|
+    Temporal::Api::History::V1::WorkflowTaskScheduledEventAttributes.new(
       task_queue: Fabricate(:api_task_queue),
       start_to_close_timeout: 15,
       attempt: 0
@@ -45,10 +45,10 @@ Fabricator(:api_decision_task_scheduled_event, from: :api_history_event) do
   end
 end
 
-Fabricator(:api_decision_task_started_event, from: :api_history_event) do
-  event_type { Temporal::Api::Enums::V1::EventType::EVENT_TYPE_DECISION_TASK_STARTED }
-  decision_task_started_event_attributes do |attrs|
-    Temporal::Api::History::V1::DecisionTaskStartedEventAttributes.new(
+Fabricator(:api_workflow_task_started_event, from: :api_history_event) do
+  event_type { Temporal::Api::Enums::V1::EventType::EVENT_TYPE_WORKFLOW_TASK_STARTED }
+  workflow_task_started_event_attributes do |attrs|
+    Temporal::Api::History::V1::WorkflowTaskStartedEventAttributes.new(
       scheduled_event_id: attrs[:event_id] - 1,
       identity: 'test-worker@test-host',
       request_id: SecureRandom.uuid
@@ -56,10 +56,10 @@ Fabricator(:api_decision_task_started_event, from: :api_history_event) do
   end
 end
 
-Fabricator(:api_decision_task_completed_event, from: :api_history_event) do
-  event_type { Temporal::Api::Enums::V1::EventType::EVENT_TYPE_DECISION_TASK_COMPLETED }
-  decision_task_completed_event_attributes do |attrs|
-    Temporal::Api::History::V1::DecisionTaskCompletedEventAttributes.new(
+Fabricator(:api_workflow_task_completed_event, from: :api_history_event) do
+  event_type { Temporal::Api::Enums::V1::EventType::EVENT_TYPE_WORKFLOW_TASK_COMPLETED }
+  workflow_task_completed_event_attributes do |attrs|
+    Temporal::Api::History::V1::WorkflowTaskCompletedEventAttributes.new(
       scheduled_event_id: attrs[:event_id] - 2,
       started_event_id: attrs[:event_id] - 1,
       identity: 'test-worker@test-host'
@@ -71,10 +71,10 @@ Fabricator(:api_activity_task_scheduled_event, from: :api_history_event) do
   event_type { Temporal::Api::Enums::V1::EventType::EVENT_TYPE_ACTIVITY_TASK_SCHEDULED }
   activity_task_scheduled_event_attributes do |attrs|
     Temporal::Api::History::V1::ActivityTaskScheduledEventAttributes.new(
-      activity_id: attrs[:event_id],
-      activity_type: Temporal::Api::History::V1::ActivityType.new(name: 'TestActivity'),
+      activity_id: attrs[:event_id].to_s,
+      activity_type: Temporal::Api::Common::V1::ActivityType.new(name: 'TestActivity'),
       workflow_task_completed_event_id: attrs[:event_id] - 1,
-      domain: 'test-domain',
+      namespace: 'test-namespace',
       task_queue: Fabricate(:api_task_queue)
     )
   end
@@ -107,8 +107,7 @@ Fabricator(:api_activity_task_failed_event, from: :api_history_event) do
   event_type { Temporal::Api::Enums::V1::EventType::EVENT_TYPE_ACTIVITY_TASK_FAILED }
   activity_task_failed_event_attributes do |attrs|
     Temporal::Api::History::V1::ActivityTaskFailedEventAttributes.new(
-      reason: 'StandardError',
-      details: 'Activity failed',
+      failure: Temporal::Api::Failure::V1::Failure.new(message: "Activity failed"),
       scheduled_event_id: attrs[:event_id] - 2,
       started_event_id: attrs[:event_id] - 1,
       identity: 'test-worker@test-host'


### PR DESCRIPTION
Syncing [#48](https://github.com/coinbase/cadence-ruby/pull/48).

Original PR Description:
"
This change would allow specifying a strategy when resetting a workflow. This is very useful when resetting a batch of workflows that all might have failed at different points in history

~~Tested against a running server & specs updated to reflect the change~~
"