### PR TITLE
Support signaling workflows in a namespace

### DIFF
--- a/lib/temporal/client.rb
+++ b/lib/temporal/client.rb
@@ -68,11 +68,11 @@ module Temporal
       connection.register_namespace(name: name, description: description)
     end
 
-    def signal_workflow(workflow, signal, workflow_id, run_id, input = nil)
+    def signal_workflow(workflow, signal, workflow_id, run_id, input = nil, namespace: nil)
       execution_options = ExecutionOptions.new(workflow, {}, config.default_execution_options)
 
       connection.signal_workflow_execution(
-        namespace: execution_options.namespace, # TODO: allow passing namespace instead
+        namespace: namespace || execution_options.namespace,
         workflow_id: workflow_id,
         run_id: run_id,
         signal: signal,

--- a/spec/unit/lib/temporal/client_spec.rb
+++ b/spec/unit/lib/temporal/client_spec.rb
@@ -233,6 +233,53 @@ describe Temporal::Client do
     end
   end
 
+
+  describe '#signal_workflow' do
+    before { allow(connection).to receive(:signal_workflow_execution).and_return(nil) }
+
+    it 'signals workflow with a specified class' do
+      subject.signal_workflow(TestStartWorkflow, 'signal', 'workflow_id', 'run_id')
+
+      expect(connection)
+        .to have_received(:signal_workflow_execution)
+        .with(
+          namespace: 'default-test-namespace',
+          signal: 'signal', 
+          workflow_id: 'workflow_id',
+          run_id: 'run_id',
+          input: nil,
+        )
+    end
+
+    it 'signals workflow with input' do
+      subject.signal_workflow(TestStartWorkflow, 'signal', 'workflow_id', 'run_id', 'input')
+
+      expect(connection)
+        .to have_received(:signal_workflow_execution)
+        .with(
+          namespace: 'default-test-namespace',
+          signal: 'signal', 
+          workflow_id: 'workflow_id',
+          run_id: 'run_id',
+          input: 'input',
+        )
+    end
+
+    it 'signals workflow with a specified namespace' do
+      subject.signal_workflow(TestStartWorkflow, 'signal', 'workflow_id', 'run_id', namespace: 'other-test-namespace')
+
+      expect(connection)
+        .to have_received(:signal_workflow_execution)
+        .with(
+          namespace: 'other-test-namespace',
+          signal: 'signal', 
+          workflow_id: 'workflow_id',
+          run_id: 'run_id',
+          input: nil,
+        )
+    end
+  end
+
   describe '#await_workflow_result' do
     class NamespacedWorkflow < Temporal::Workflow
       namespace 'some-namespace'


### PR DESCRIPTION
# Description
Allow a namespace to be specified when signalling a workflow.

# Test Plan
There was no CI test coverage of signal_workflow, so we added a basic test as well as one with a namespace.
`rspec ./spec/unit/lib/temporal/client_spec.rb`
