### PR TITLE
Handle server timeouts in await_workflow_result

### DIFF
--- a/spec/unit/lib/temporal/client_spec.rb
+++ b/spec/unit/lib/temporal/client_spec.rb
@@ -326,8 +326,8 @@ describe Temporal::Client do
     # Unit test, rather than integration test, because we don't support cancellation via the SDK yet.
     # See integration test for other failure conditions.
     it 'raises when the workflow was canceled' do
-      completed_event = Fabricate(:workflow_canceled_event)
-      response = Fabricate(:workflow_execution_history, events: [completed_event])
+      canceled_event = Fabricate(:workflow_canceled_event)
+      response = Fabricate(:workflow_execution_history, events: [canceled_event])
 
       expect(connection)
         .to receive(:get_workflow_execution_history)
@@ -350,8 +350,7 @@ describe Temporal::Client do
       end.to raise_error(Temporal::WorkflowCanceled)
     end
 
-    it 'raises TimeoutError when the server times out' do 
-      response = Fabricate(:workflow_execution_history, events: [])
+    it 'raises TimeoutError when the client times out' do 
       expect(connection)
         .to receive(:get_workflow_execution_history)
         .with(
@@ -369,6 +368,31 @@ describe Temporal::Client do
             workflow_id: workflow_id,
             run_id: run_id,
             timeout: 3,
+          )
+        end.to raise_error(Temporal::TimeoutError)
+    end
+
+    it 'raises TimeoutError when the server times out' do 
+      # empty events list implies the server gave up before getting a closed event
+      empty_response = Fabricate(:workflow_execution_history, events: [])
+      expect(connection)
+        .to receive(:get_workflow_execution_history)
+        .with(
+          namespace: 'default-test-namespace',
+          workflow_id: workflow_id,
+          run_id: run_id,
+          wait_for_new_event: true,
+          event_type: :close,
+          timeout: 30,
+        )
+        .and_return(empty_response)
+
+        expect do
+          subject.await_workflow_result(
+            TestStartWorkflow,
+            workflow_id: workflow_id,
+            run_id: run_id,
+            timeout: 30,
           )
         end.to raise_error(Temporal::TimeoutError)
     end


### PR DESCRIPTION
# Description
Occasionally when leaving the timeout at thirty seconds on the client, we would see an error trying to access `type` on `nil` rather than the expected `TimeoutError`
This is because the server can give up first and return an empty list.
This handles that case gracefully and gives a better/more actionable error

# Test plan
`rspec ./spec/unit/lib/temporal/client_spec.rb`
integration tests:
`rspec ./spec/integration/await_workflow_result_spec.rb`
