### PR TITLE
[Feature] Fail workflow task when empty history page was received

### DIFF
--- a/lib/temporal/errors.rb
+++ b/lib/temporal/errors.rb
@@ -58,5 +58,5 @@ module Temporal
   class NamespaceAlreadyExistsFailure < ApiError; end
   class CancellationAlreadyRequestedFailure < ApiError; end
   class QueryFailedFailure < ApiError; end
-
+  class UnexpectedResponse < ApiError; end
 end

--- a/lib/temporal/workflow/task_processor.rb
+++ b/lib/temporal/workflow/task_processor.rb
@@ -76,6 +76,10 @@ module Temporal
             next_page_token: next_page_token
           )
 
+          if response.history.events.empty?
+            raise Temporal::UnexpectedResponse, 'Received empty history page'
+          end
+
           events += response.history.events.to_a
           next_page_token = response.next_page_token
         end

--- a/lib/temporal/workflow/task_processor.rb
+++ b/lib/temporal/workflow/task_processor.rb
@@ -100,7 +100,7 @@ module Temporal
 
         connection.respond_workflow_task_failed(
           task_token: task_token,
-          cause: Temporal::Api::Enums::V1::WorkflowTaskFailedCause::WORKFLOW_TASK_FAILED_CAUSE_UNHANDLED_COMMAND,
+          cause: Temporal::Api::Enums::V1::WorkflowTaskFailedCause::WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED_FAILURE,
           exception: error
         )
       rescue StandardError => error

--- a/spec/fabricators/grpc/workflow_task_fabricator.rb
+++ b/spec/fabricators/grpc/workflow_task_fabricator.rb
@@ -1,7 +1,7 @@
 require 'securerandom'
 
 Fabricator(:api_workflow_task, from: Temporal::Api::WorkflowService::V1::PollWorkflowTaskQueueResponse) do
-  transient :task_token, :activity_name, :headers
+  transient :task_token, :activity_name, :headers, :events
 
   started_event_id { rand(100) }
   task_token { |attrs| attrs[:task_token] || SecureRandom.uuid }
@@ -9,4 +9,9 @@ Fabricator(:api_workflow_task, from: Temporal::Api::WorkflowService::V1::PollWor
   workflow_execution { Fabricate(:api_workflow_execution) }
   scheduled_time { Google::Protobuf::Timestamp.new.tap { |t| t.from_time(Time.now) } }
   started_time { Google::Protobuf::Timestamp.new.tap { |t| t.from_time(Time.now) } }
+  history { |attrs| Temporal::Api::History::V1::History.new(events: attrs[:events]) }
+end
+
+Fabricator(:api_paginated_workflow_task, from: :api_workflow_task) do
+  next_page_token 'page-1'
 end

--- a/spec/fabricators/workflow_execution_history_fabricator.rb
+++ b/spec/fabricators/workflow_execution_history_fabricator.rb
@@ -1,4 +1,5 @@
 Fabricator(:workflow_execution_history, from: Temporal::Api::WorkflowService::V1::GetWorkflowExecutionHistoryResponse) do
   transient :events
   history { |attrs| Temporal::Api::History::V1::History.new(events: attrs[:events]) }
+  next_page_token ''
 end

--- a/spec/unit/lib/temporal/workflow/task_processor_spec.rb
+++ b/spec/unit/lib/temporal/workflow/task_processor_spec.rb
@@ -134,7 +134,7 @@ describe Temporal::Workflow::TaskProcessor do
             .to have_received(:respond_workflow_task_failed)
             .with(
               task_token: task.task_token,
-              cause: Temporal::Api::Enums::V1::WorkflowTaskFailedCause::WORKFLOW_TASK_FAILED_CAUSE_UNHANDLED_COMMAND,
+              cause: Temporal::Api::Enums::V1::WorkflowTaskFailedCause::WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED_FAILURE,
               exception: exception
             )
         end

--- a/spec/unit/lib/temporal/workflow/task_processor_spec.rb
+++ b/spec/unit/lib/temporal/workflow/task_processor_spec.rb
@@ -7,12 +7,8 @@ describe Temporal::Workflow::TaskProcessor do
 
   let(:namespace) { 'test-namespace' }
   let(:lookup) { instance_double('Temporal::ExecutableLookup', find: nil) }
-  let(:task) do
-    Fabricate(
-      :api_workflow_task,
-      workflow_type: Fabricate(:api_workflow_type, name: workflow_name)
-    )
-  end
+  let(:task) { Fabricate(:api_workflow_task, workflow_type: api_workflow_type) }
+  let(:api_workflow_type) { Fabricate(:api_workflow_type, name: workflow_name) }
   let(:workflow_name) { 'TestWorkflow' }
   let(:connection) { instance_double('Temporal::Connection::GRPC') }
   let(:middleware_chain) { Temporal::Middleware::Chain.new }
@@ -67,7 +63,6 @@ describe Temporal::Workflow::TaskProcessor do
 
       before do
         allow(lookup).to receive(:find).with(workflow_name).and_return(workflow_class)
-        allow(subject).to receive(:fetch_full_history)
         allow(Temporal::Workflow::Executor).to receive(:new).and_return(executor)
         allow(executor).to receive(:run) { workflow_class.execute_in_context(context, input); commands }
       end
@@ -184,6 +179,48 @@ describe Temporal::Workflow::TaskProcessor do
           expect(Temporal.metrics)
             .to have_received(:timing)
             .with('workflow_task.latency', an_instance_of(Integer), workflow: workflow_name)
+        end
+      end
+
+      context 'when history is paginated' do
+        let(:task) { Fabricate(:api_paginated_workflow_task, workflow_type: api_workflow_type) }
+        let(:event) { Fabricate(:api_workflow_execution_started_event) }
+        let(:history_response) { Fabricate(:workflow_execution_history, events: [event]) }
+
+        before do
+          allow(connection)
+            .to receive(:get_workflow_execution_history)
+            .and_return(history_response)
+        end
+
+        it 'fetches additional pages' do
+          subject.process
+
+          expect(connection)
+            .to have_received(:get_workflow_execution_history)
+            .with(
+              namespace: namespace,
+              workflow_id: task.workflow_execution.workflow_id,
+              run_id: task.workflow_execution.run_id,
+              next_page_token: task.next_page_token
+            )
+            .once
+        end
+
+        context 'when a page has no events' do
+          let(:history_response) { Fabricate(:workflow_execution_history, events: []) }
+
+          it 'fails a workflow task' do
+            subject.process
+
+            expect(connection)
+              .to have_received(:respond_workflow_task_failed)
+              .with(
+                task_token: task.task_token,
+                cause: Temporal::Api::Enums::V1::WorkflowTaskFailedCause::WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED_FAILURE,
+                exception: an_instance_of(Temporal::UnexpectedResponse)
+              )
+          end
         end
       end
     end


### PR DESCRIPTION
We have observed a weird case when a workflow task was handled incorrectly resulting in non-deterministic commands getting sent back to Temporal and corrupting a workflow execution. Our suspicion is that Temporal API has responded with a blank history to one of the GetWorkflowExecutionHistory calls.

The added check should help us confirm the issue and protect from the negative side effects.

Tested by added new test cases.