### PR TITLE
Add ParentClosePolicy

### DIFF
--- a/lib/temporal/connection/serializer/parent_close_policy.rb
+++ b/lib/temporal/connection/serializer/parent_close_policy.rb
@@ -1,0 +1,20 @@
+require 'temporal/connection/serializer/base'
+
+module Temporal
+  module Connection
+    module Serializer
+      class ParentClosePolicy < Base
+        def to_proto
+          return Temporal::Api::Enums::V1::ParentClosePolicy::PARENT_CLOSE_POLICY_UNSPECIFIED unless object
+          mapping = {
+            abandon: Temporal::Api::Enums::V1::ParentClosePolicy::PARENT_CLOSE_POLICY_ABANDON,
+            terminate: Temporal::Api::Enums::V1::ParentClosePolicy::PARENT_CLOSE_POLICY_TERMINATE,
+            request_cancel: Temporal::Api::Enums::V1::ParentClosePolicy::PARENT_CLOSE_POLICY_REQUEST_CANCEL,
+          }.compact
+
+          mapping[object.policy]
+        end
+      end
+    end
+  end
+end

--- a/lib/temporal/connection/serializer/start_child_workflow.rb
+++ b/lib/temporal/connection/serializer/start_child_workflow.rb
@@ -22,6 +22,7 @@ module Temporal
                 workflow_run_timeout: object.timeouts[:run],
                 workflow_task_timeout: object.timeouts[:task],
                 retry_policy: Temporal::Connection::Serializer::RetryPolicy.new(object.retry_policy).to_proto,
+                parent_close_policy: Temporal::Connection::Serializer::ParentClosePolicy.new(object.parent_close_policy).to_proto,
                 header: serialize_headers(object.headers)
               )
           )

--- a/lib/temporal/connection/serializer/start_child_workflow.rb
+++ b/lib/temporal/connection/serializer/start_child_workflow.rb
@@ -1,5 +1,6 @@
 require 'temporal/connection/serializer/base'
 require 'temporal/connection/serializer/retry_policy'
+require 'temporal/connection/serializer/parent_close_policy'
 require 'temporal/concerns/payloads'
 
 module Temporal

--- a/lib/temporal/execution_options.rb
+++ b/lib/temporal/execution_options.rb
@@ -1,5 +1,6 @@
 require 'temporal/concerns/executable'
 require 'temporal/retry_policy'
+require 'temporal/parent_close_policy'
 
 module Temporal
   class ExecutionOptions

--- a/lib/temporal/execution_options.rb
+++ b/lib/temporal/execution_options.rb
@@ -3,7 +3,7 @@ require 'temporal/retry_policy'
 
 module Temporal
   class ExecutionOptions
-    attr_reader :name, :namespace, :task_queue, :retry_policy, :timeouts, :headers
+    attr_reader :name, :namespace, :task_queue, :retry_policy, :parent_close_policy, :timeouts, :headers
 
     def initialize(object, options, defaults = nil)
       # Options are treated as overrides and take precedence
@@ -11,6 +11,7 @@ module Temporal
       @namespace = options[:namespace]
       @task_queue = options[:task_queue] || options[:task_list]
       @retry_policy = options[:retry_policy] || {}
+      @parent_close_policy = options[:parent_close_policy] || {}
       @timeouts = options[:timeouts] || {}
       @headers = options[:headers] || {}
 
@@ -36,6 +37,13 @@ module Temporal
       else
         @retry_policy = Temporal::RetryPolicy.new(@retry_policy)
         @retry_policy.validate!
+      end
+
+      if @parent_close_policy.empty?
+        @parent_close_policy = nil
+      else
+        @parent_close_policy = Temporal::ParentClosePolicy.new(@parent_close_policy)
+        @parent_close_policy.validate!
       end
 
       freeze

--- a/lib/temporal/parent_close_policy.rb
+++ b/lib/temporal/parent_close_policy.rb
@@ -1,0 +1,20 @@
+require 'temporal/errors'
+
+module Temporal
+  # See https://docs.temporal.io/docs/content/what-is-a-parent-close-policy/ for more information
+  class ParentClosePolicy
+    class InvalidParentClosePolicy < ClientError; end
+
+    attr_reader :policy
+
+    def initialize(policy)
+      @policy = policy
+    end
+
+    def validate!
+      unless %i[terminate abandon request_cancel].include?(@policy)
+        raise InvalidParentClosePolicy, 'Invalid parent close policy, only :abandon, :terminate, :request_cancel are allowed'
+      end
+    end
+  end
+end

--- a/lib/temporal/workflow/command.rb
+++ b/lib/temporal/workflow/command.rb
@@ -3,7 +3,7 @@ module Temporal
     module Command
       # TODO: Move these classes into their own directories under workflow/command/*
       ScheduleActivity = Struct.new(:activity_type, :activity_id, :input, :namespace, :task_queue, :retry_policy, :timeouts, :headers, keyword_init: true)
-      StartChildWorkflow = Struct.new(:workflow_type, :workflow_id, :input, :namespace, :task_queue, :retry_policy, :timeouts, :headers, keyword_init: true)
+      StartChildWorkflow = Struct.new(:workflow_type, :workflow_id, :input, :namespace, :task_queue, :retry_policy, :parent_close_policy, :timeouts, :headers, keyword_init: true)
       ContinueAsNew = Struct.new(:workflow_type, :task_queue, :input, :timeouts, :retry_policy, :headers, keyword_init: true)
       RequestActivityCancellation = Struct.new(:activity_id, keyword_init: true)
       RecordMarker = Struct.new(:name, :details, keyword_init: true)

--- a/lib/temporal/workflow/context.rb
+++ b/lib/temporal/workflow/context.rb
@@ -110,6 +110,7 @@ module Temporal
           namespace: execution_options.namespace,
           task_queue: execution_options.task_queue,
           retry_policy: execution_options.retry_policy,
+          parent_close_policy: execution_options.parent_close_policy,
           timeouts: execution_options.timeouts,
           headers: execution_options.headers
         )

--- a/spec/unit/lib/temporal/connection/serializer/parent_close_policy_spec.rb
+++ b/spec/unit/lib/temporal/connection/serializer/parent_close_policy_spec.rb
@@ -1,0 +1,24 @@
+require 'temporal/parent_close_policy'
+require 'temporal/connection/serializer/parent_close_policy'
+
+describe Temporal::Connection::Serializer::ParentClosePolicy do
+  describe 'to_proto' do
+    let(:terminate_policy) { Temporal::ParentClosePolicy.new(:terminate) }
+    let(:abandon_policy) { Temporal::ParentClosePolicy.new(:abandon) }
+    let(:request_cancel_policy) { Temporal::ParentClosePolicy.new(:request_cancel) }
+
+    it 'converts to proto' do
+      expect do
+        described_class.new(terminate_policy).to_proto
+      end.not_to raise_error
+
+      expect do
+        described_class.new(abandon_policy).to_proto
+      end.not_to raise_error
+
+      expect do
+        described_class.new(request_cancel_policy).to_proto
+      end.not_to raise_error
+    end
+  end
+end

--- a/spec/unit/lib/temporal/parent_close_policy_spec.rb
+++ b/spec/unit/lib/temporal/parent_close_policy_spec.rb
@@ -1,0 +1,27 @@
+require 'temporal/parent_close_policy'
+
+describe Temporal::ParentClosePolicy do
+  describe '#validate!' do
+    subject { described_class.new(param) }
+
+    context 'with valid param' do
+      %i[abandon terminate request_cancel].each do |policy|
+        context "with #{policy}" do
+          let(:param) { policy }
+
+          it 'does not raise' do
+            expect { subject.validate! }.not_to raise_error
+          end
+        end
+      end
+    end
+
+    context 'with invalid param' do
+      let(:param) { :coinbase }
+
+      it 'does not raise' do
+        expect { subject.validate! }.to raise_error(described_class::InvalidParentClosePolicy)
+      end
+    end
+  end
+end


### PR DESCRIPTION
I found [`ParentClosePolicy`](https://docs.temporal.io/docs/content/what-is-a-parent-close-policy/) is not supported. Here's the PR.

## Story
I am implementing proxy workflow pattern mention [HERE](https://community.temporal.io/t/sync-wait-a-workflow/3033)
I want to launch a child workflow and the main workflow will finish earlier then it's child. Due to default parent close policy. The child workflow will be killed as well. 


## Result
### without `parent_close_policy`
![image](https://user-images.githubusercontent.com/5507113/135428925-58b5f2cd-2354-40dd-bd36-961fe59c9560.png)


### with `parent_close_policy: :abandon`
![image](https://user-images.githubusercontent.com/5507113/135427974-30f8987c-936d-44ee-83f6-1eb6469bce45.png)

## Usage
```ruby
class ProxyWorkflow < Temporal::Workflow
  def execute(workflow_id)
    # copied from SDK example
    future = LongRunningActivity.execute(10, 1)
    workflow.execute_workflow(
      MainWorkflow,
      proxy_workflow_id: workflow_id,
      proxy_run_id: workflow.metadata.run_id,
      options: {
        parent_close_policy: :abandon,
      },
    )
    ret = nil
    workflow.on_signal do |signal, input|
      future.cancel
      ret = input
    end
    future.wait
    ret
  end
end
```

```ruby
class MainWorkflow < Temporal::Workflow
  def execute(proxy_workflow_id:, proxy_run_id:)
    workflow.sleep(5)
    SignalActivity.execute!(proxy_workflow_id: proxy_workflow_id, proxy_run_id: proxy_run_id, input: "succsss yeah")
    10.times do
      HelloActivity.execute!("hehehe")
      workflow.sleep(1)
    end
  end
end
```

By the way, how can I know my workflow id? Currently I explicitly names it.
```ruby
Temporal.start_workflow(TemporalWorkflow::ProxyWorkflow,  "hehehe", options: {workflow_id: "hehehe"})
```