### PR TITLE
Pass config to the error handler

### DIFF
--- a/lib/temporal/activity/poller.rb
+++ b/lib/temporal/activity/poller.rb
@@ -78,7 +78,7 @@ module Temporal
       rescue StandardError => error
         Temporal.logger.error("Unable to poll activity task queue", { namespace: namespace, task_queue: task_queue, error: error.inspect })
 
-        Temporal::ErrorHandler.handle(error)
+        Temporal::ErrorHandler.handle(error, config)
 
         nil
       end

--- a/lib/temporal/activity/task_processor.rb
+++ b/lib/temporal/activity/task_processor.rb
@@ -41,7 +41,7 @@ module Temporal
         # Do not complete asynchronous activities, these should be completed manually
         respond_completed(result) unless context.async?
       rescue StandardError, ScriptError => error
-        Temporal::ErrorHandler.handle(error, metadata: metadata)
+        Temporal::ErrorHandler.handle(error, config, metadata: metadata)
 
         respond_failed(error)
       ensure
@@ -76,7 +76,7 @@ module Temporal
       rescue StandardError => error
         Temporal.logger.error("Unable to complete Activity", metadata.to_h.merge(error: error.inspect))
 
-        Temporal::ErrorHandler.handle(error, metadata: metadata)
+        Temporal::ErrorHandler.handle(error, config, metadata: metadata)
       end
 
       def respond_failed(error)
@@ -90,7 +90,7 @@ module Temporal
       rescue StandardError => error
         Temporal.logger.error("Unable to fail Activity task", metadata.to_h.merge(error: error.inspect))
 
-        Temporal::ErrorHandler.handle(error, metadata: metadata)
+        Temporal::ErrorHandler.handle(error, config, metadata: metadata)
       end
     end
   end

--- a/lib/temporal/error_handler.rb
+++ b/lib/temporal/error_handler.rb
@@ -1,7 +1,7 @@
 module Temporal
   module ErrorHandler
-    def self.handle(error, metadata: nil)
-      Temporal.configuration.error_handlers.each do |handler|
+    def self.handle(error, configuration, metadata: nil)
+      configuration.error_handlers.each do |handler|
         handler.call(error, metadata: metadata)
       rescue StandardError => e
         Temporal.logger.error("Error handler failed", { error: e.inspect })

--- a/lib/temporal/workflow.rb
+++ b/lib/temporal/workflow.rb
@@ -20,7 +20,7 @@ module Temporal
       Temporal.logger.error("Workflow execution failed", context.metadata.to_h.merge(error: error.inspect))
       Temporal.logger.debug(error.backtrace.join("\n"))
 
-      Temporal::ErrorHandler.handle(error, metadata: context.metadata)
+      Temporal::ErrorHandler.handle(error, @context.config, metadata: context.metadata)
 
       context.fail(error)
     ensure

--- a/lib/temporal/workflow/poller.rb
+++ b/lib/temporal/workflow/poller.rb
@@ -77,7 +77,7 @@ module Temporal
         connection.poll_workflow_task_queue(namespace: namespace, task_queue: task_queue)
       rescue StandardError => error
         Temporal.logger.error("Unable to poll Workflow task queue", { namespace: namespace, task_queue: task_queue, error: error.inspect })
-        Temporal::ErrorHandler.handle(error)
+        Temporal::ErrorHandler.handle(error, config)
 
         nil
       end

--- a/lib/temporal/workflow/task_processor.rb
+++ b/lib/temporal/workflow/task_processor.rb
@@ -40,7 +40,7 @@ module Temporal
 
         complete_task(commands)
       rescue StandardError => error
-        Temporal::ErrorHandler.handle(error, metadata: metadata)
+        Temporal::ErrorHandler.handle(error, config, metadata: metadata)
 
         fail_task(error)
       ensure
@@ -110,7 +110,7 @@ module Temporal
       rescue StandardError => error
         Temporal.logger.error("Unable to fail Workflow task", metadata.to_h.merge(error: error.inspect))
 
-        Temporal::ErrorHandler.handle(error, metadata: metadata)
+        Temporal::ErrorHandler.handle(error, config, metadata: metadata)
       end
     end
   end

--- a/spec/unit/lib/temporal/activity/task_processor_spec.rb
+++ b/spec/unit/lib/temporal/activity/task_processor_spec.rb
@@ -11,7 +11,7 @@ describe Temporal::Activity::TaskProcessor do
     Fabricate(
       :api_activity_task,
       activity_name: activity_name,
-      input: Temporal.configuration.converter.to_payloads(input)
+      input: config.converter.to_payloads(input)
     )
   end
   let(:metadata) { Temporal::Metadata.generate(Temporal::Metadata::ACTIVITY_TYPE, task) }
@@ -70,7 +70,7 @@ describe Temporal::Activity::TaskProcessor do
         reported_error = nil
         reported_metadata = nil
 
-        Temporal.configuration.on_error do |error, metadata: nil|
+        config.on_error do |error, metadata: nil|
           reported_error = error
           reported_metadata = metadata.to_h
         end
@@ -187,7 +187,7 @@ describe Temporal::Activity::TaskProcessor do
           reported_error = nil
           reported_metadata = nil
 
-          Temporal.configuration.on_error do |error, metadata: nil|
+          config.on_error do |error, metadata: nil|
             reported_error = error
             reported_metadata = metadata
           end

--- a/spec/unit/lib/temporal/workflow/task_processor_spec.rb
+++ b/spec/unit/lib/temporal/workflow/task_processor_spec.rb
@@ -44,7 +44,7 @@ describe Temporal::Workflow::TaskProcessor do
         reported_error = nil
         reported_metadata = nil
 
-        Temporal.configuration.on_error do |error, metadata: nil|
+        config.on_error do |error, metadata: nil|
           reported_error = error
           reported_metadata = metadata
         end
@@ -154,7 +154,7 @@ describe Temporal::Workflow::TaskProcessor do
           reported_error = nil
           reported_metadata = nil
 
-          Temporal.configuration.on_error do |error, metadata: nil|
+          config.on_error do |error, metadata: nil|
             reported_error = error
             reported_metadata = metadata
           end


### PR DESCRIPTION
Right now the error handler is using the global config, we want it to use the config that the client was created with.