### PR TITLE
Pull workflow_id and namespace into Workflow metadata for better logging

### DIFF
--- a/lib/temporal/activity/task_processor.rb
+++ b/lib/temporal/activity/task_processor.rb
@@ -14,7 +14,7 @@ module Temporal
       def initialize(task, namespace, activity_lookup, middleware_chain, config)
         @task = task
         @namespace = namespace
-        @metadata = Metadata.generate(Metadata::ACTIVITY_TYPE, task, namespace)
+        @metadata = Metadata.generate_activity_metadata(task, namespace)
         @task_token = task.task_token
         @activity_name = task.activity_type.name
         @activity_class = activity_lookup.find(activity_name)

--- a/lib/temporal/metadata.rb
+++ b/lib/temporal/metadata.rb
@@ -10,7 +10,7 @@ module Temporal
     class << self
       include Concerns::Payloads
 
-      def generate_activity_metadata(task, namespace=nil)
+      def generate_activity_metadata(task, namespace)
         Metadata::Activity.new(
           namespace: namespace,
           id: task.activity_id,
@@ -25,7 +25,7 @@ module Temporal
         )
       end
 
-      def generate_workflow_task_metadata(task, namespace=nil)
+      def generate_workflow_task_metadata(task, namespace)
         Metadata::WorkflowTask.new(
           namespace: namespace,
           id: task.started_event_id,

--- a/lib/temporal/metadata/activity.rb
+++ b/lib/temporal/metadata/activity.rb
@@ -29,7 +29,7 @@ module Temporal
           'namespace' => namespace,
           'workflow_id' => workflow_id,
           'workflow_name' => workflow_name,
-          'workflow_run_id' => workflow_run_id,
+          'run_id' => workflow_run_id,
           'activity_id' => id,
           'activity_name' => name,
           'attempt' => attempt

--- a/lib/temporal/metadata/workflow.rb
+++ b/lib/temporal/metadata/workflow.rb
@@ -23,7 +23,7 @@ module Temporal
         {
           'workflow_name' => name,
           'workflow_id' => workflow_id,
-          'workflow_run_id' => run_id,
+          'run_id' => run_id,
           'attempt' => attempt,
           'namespace' => namespace,
         }

--- a/lib/temporal/metadata/workflow.rb
+++ b/lib/temporal/metadata/workflow.rb
@@ -3,14 +3,15 @@ require 'temporal/metadata/base'
 module Temporal
   module Metadata
     class Workflow < Base
-      attr_reader :name, :run_id, :attempt, :headers
+      attr_reader :name, :workflow_id, :run_id, :attempt, :headers, :namespace
 
-      def initialize(name:, run_id:, attempt:, headers: {})
+      def initialize(name:, workflow_id:, run_id:, attempt:, namespace:, headers: {})
         @name = name
+        @workflow_id = workflow_id
         @run_id = run_id
         @attempt = attempt
+        @namespace = namespace
         @headers = headers
-
         freeze
       end
 
@@ -21,8 +22,10 @@ module Temporal
       def to_h
         {
           'workflow_name' => name,
+          'workflow_id' => workflow_id,
           'workflow_run_id' => run_id,
-          'attempt' => attempt
+          'attempt' => attempt,
+          'namespace' => namespace,
         }
       end
     end

--- a/lib/temporal/metadata/workflow_task.rb
+++ b/lib/temporal/metadata/workflow_task.rb
@@ -27,7 +27,7 @@ module Temporal
           'workflow_task_id' => id,
           'workflow_name' => workflow_name,
           'workflow_id' => workflow_id,
-          'workflow_run_id' => workflow_run_id,
+          'run_id' => workflow_run_id,
           'attempt' => attempt
         }
       end

--- a/lib/temporal/testing/temporal_override.rb
+++ b/lib/temporal/testing/temporal_override.rb
@@ -89,7 +89,12 @@ module Temporal
 
         execution_options = ExecutionOptions.new(workflow, options)
         metadata = Metadata::Workflow.new(
-          name: workflow_id, run_id: run_id, attempt: 1, headers: execution_options.headers
+          name: workflow_id, 
+          workflow_id: workflow_id, 
+          run_id: run_id, 
+          attempt: 1, 
+          namespace: execution_options.namespace, 
+          headers: execution_options.headers,
         )
         context = Temporal::Testing::LocalWorkflowContext.new(
           execution, workflow_id, run_id, workflow.disabled_releases, metadata

--- a/lib/temporal/testing/workflow_override.rb
+++ b/lib/temporal/testing/workflow_override.rb
@@ -28,7 +28,7 @@ module Temporal
         run_id = SecureRandom.uuid
         execution = WorkflowExecution.new
         metadata = Temporal::Metadata::Workflow.new(
-          name: workflow_id, run_id: run_id, attempt: 1
+          name: workflow_id, workflow_id: workflow_id, run_id: run_id, attempt: 1, namespace: 'unit-test-local'
         )
         context = Temporal::Testing::LocalWorkflowContext.new(
           execution, workflow_id, run_id, disabled_releases, metadata

--- a/lib/temporal/workflow/executor.rb
+++ b/lib/temporal/workflow/executor.rb
@@ -8,11 +8,13 @@ require 'temporal/workflow/history/event_target'
 module Temporal
   class Workflow
     class Executor
-      def initialize(workflow_class, history, config)
+      # metadata: Metadata::WorkflowTask
+      def initialize(workflow_class, history, config, task_metadata)
         @workflow_class = workflow_class
         @dispatcher = Dispatcher.new
-        @state_manager = StateManager.new(dispatcher)
+        @state_manager = StateManager.new(dispatcher, task_metadata)
         @history = history
+        @task_metadata = task_metadata
         @config = config
       end
 

--- a/lib/temporal/workflow/state_manager.rb
+++ b/lib/temporal/workflow/state_manager.rb
@@ -20,8 +20,9 @@ module Temporal
 
       attr_reader :commands, :local_time
 
-      def initialize(dispatcher)
+      def initialize(dispatcher, task_metadata)
         @dispatcher = dispatcher
+        @task_metadata = task_metadata
         @commands = []
         @marker_ids = Set.new
         @releases = {}
@@ -89,7 +90,7 @@ module Temporal
 
       private
 
-      attr_reader :dispatcher, :command_tracker, :marker_ids, :side_effects, :releases
+      attr_reader :dispatcher, :command_tracker, :marker_ids, :side_effects, :releases, :task_metadata
 
       def next_event_id
         @last_event_id += 1
@@ -106,7 +107,7 @@ module Temporal
             History::EventTarget.workflow,
             'started',
             from_payloads(event.attributes.input),
-            Metadata.generate(Metadata::WORKFLOW_TYPE, event.attributes)
+            Metadata.generate_workflow_metadata(event.attributes, task_metadata),
           )
 
         when 'WORKFLOW_EXECUTION_COMPLETED'

--- a/lib/temporal/workflow/task_processor.rb
+++ b/lib/temporal/workflow/task_processor.rb
@@ -12,7 +12,7 @@ module Temporal
       def initialize(task, namespace, workflow_lookup, middleware_chain, config)
         @task = task
         @namespace = namespace
-        @metadata = Metadata.generate(Metadata::WORKFLOW_TASK_TYPE, task, namespace)
+        @metadata = Metadata.generate_workflow_task_metadata(task, namespace)
         @task_token = task.task_token
         @workflow_name = task.workflow_type.name
         @workflow_class = workflow_lookup.find(workflow_name)
@@ -32,7 +32,7 @@ module Temporal
 
         history = fetch_full_history
         # TODO: For sticky workflows we need to cache the Executor instance
-        executor = Workflow::Executor.new(workflow_class, history, config)
+        executor = Workflow::Executor.new(workflow_class, history, config, @metadata)
 
         commands = middleware_chain.invoke(metadata) do
           executor.run

--- a/spec/fabricators/workflow_metadata_fabricator.rb
+++ b/spec/fabricators/workflow_metadata_fabricator.rb
@@ -2,7 +2,9 @@ require 'securerandom'
 
 Fabricator(:workflow_metadata, from: :open_struct) do
   name 'TestWorkflow'
+  workflow_id { "some_workflow_id:#{SecureRandom.uuid}" }
   run_id { SecureRandom.uuid }
   attempt 1
   headers { {} }
+  namespace { 'ruby_samples'}
 end

--- a/spec/unit/lib/temporal/activity/task_processor_spec.rb
+++ b/spec/unit/lib/temporal/activity/task_processor_spec.rb
@@ -14,7 +14,7 @@ describe Temporal::Activity::TaskProcessor do
       input: Temporal.configuration.converter.to_payloads(input)
     )
   end
-  let(:metadata) { Temporal::Metadata.generate(Temporal::Metadata::ACTIVITY_TYPE, task) }
+  let(:metadata) { Temporal::Metadata.generate_activity_metadata(task) }
   let(:activity_name) { 'TestActivity' }
   let(:connection) { instance_double('Temporal::Connection::GRPC') }
   let(:middleware_chain) { Temporal::Middleware::Chain.new }
@@ -30,8 +30,8 @@ describe Temporal::Activity::TaskProcessor do
         .with(config.for_connection)
         .and_return(connection)
       allow(Temporal::Metadata)
-        .to receive(:generate)
-        .with(Temporal::Metadata::ACTIVITY_TYPE, task, namespace)
+        .to receive(:generate_activity_metadata)
+        .with(task, namespace)
         .and_return(metadata)
       allow(Temporal::Activity::Context).to receive(:new).with(connection, metadata).and_return(context)
 

--- a/spec/unit/lib/temporal/activity/task_processor_spec.rb
+++ b/spec/unit/lib/temporal/activity/task_processor_spec.rb
@@ -14,7 +14,7 @@ describe Temporal::Activity::TaskProcessor do
       input: Temporal.configuration.converter.to_payloads(input)
     )
   end
-  let(:metadata) { Temporal::Metadata.generate_activity_metadata(task) }
+  let(:metadata) { Temporal::Metadata.generate_activity_metadata(task, namespace) }
   let(:activity_name) { 'TestActivity' }
   let(:connection) { instance_double('Temporal::Connection::GRPC') }
   let(:middleware_chain) { Temporal::Middleware::Chain.new }

--- a/spec/unit/lib/temporal/metadata/activity_spec.rb
+++ b/spec/unit/lib/temporal/metadata/activity_spec.rb
@@ -36,7 +36,7 @@ describe Temporal::Metadata::Activity do
         'namespace' => subject.namespace,
         'workflow_id' => subject.workflow_id,
         'workflow_name' => subject.workflow_name,
-        'workflow_run_id' => subject.workflow_run_id
+        'run_id' => subject.workflow_run_id
       })
     end
   end

--- a/spec/unit/lib/temporal/metadata/workflow_spec.rb
+++ b/spec/unit/lib/temporal/metadata/workflow_spec.rb
@@ -30,7 +30,7 @@ describe Temporal::Metadata::Workflow do
         'attempt' => subject.attempt,
         'workflow_id' => subject.workflow_id,
         'workflow_name' => subject.name,
-        'workflow_run_id' => subject.run_id,
+        'run_id' => subject.run_id,
         'namespace' => subject.namespace,
       })
     end

--- a/spec/unit/lib/temporal/metadata/workflow_spec.rb
+++ b/spec/unit/lib/temporal/metadata/workflow_spec.rb
@@ -7,8 +7,10 @@ describe Temporal::Metadata::Workflow do
 
     it 'sets the attributes' do
       expect(subject.name).to eq(args.name)
+      expect(subject.workflow_id).to eq(args.workflow_id)
       expect(subject.run_id).to eq(args.run_id)
       expect(subject.attempt).to eq(args.attempt)
+      expect(subject.namespace).to eq(args.namespace)
       expect(subject.headers).to eq(args.headers)
     end
 
@@ -26,8 +28,10 @@ describe Temporal::Metadata::Workflow do
     it 'returns a hash' do
       expect(subject.to_h).to eq({
         'attempt' => subject.attempt,
+        'workflow_id' => subject.workflow_id,
         'workflow_name' => subject.name,
-        'workflow_run_id' => subject.run_id
+        'workflow_run_id' => subject.run_id,
+        'namespace' => subject.namespace,
       })
     end
   end

--- a/spec/unit/lib/temporal/metadata/workflow_task_spec.rb
+++ b/spec/unit/lib/temporal/metadata/workflow_task_spec.rb
@@ -32,7 +32,7 @@ describe Temporal::Metadata::WorkflowTask do
         'namespace' => subject.namespace,
         'workflow_id' => subject.workflow_id,
         'workflow_name' => subject.workflow_name,
-        'workflow_run_id' => subject.workflow_run_id,
+        'run_id' => subject.workflow_run_id,
       })
     end
   end

--- a/spec/unit/lib/temporal/metadata_spec.rb
+++ b/spec/unit/lib/temporal/metadata_spec.rb
@@ -1,80 +1,71 @@
 require 'temporal/metadata'
 
 describe Temporal::Metadata do
-  describe '.generate' do
-    subject { described_class.generate(type, data, namespace) }
+  describe '.generate_activity_metadata' do
+    subject { described_class.generate_activity_metadata(data, namespace) }
 
-    context 'with activity type' do
-      let(:type) { described_class::ACTIVITY_TYPE }
-      let(:data) { Fabricate(:api_activity_task) }
-      let(:namespace) { 'test-namespace' }
+    let(:data) { Fabricate(:api_activity_task) }
+    let(:namespace) { 'test-namespace' }
 
-      it 'generates metadata' do
-        expect(subject.namespace).to eq(namespace)
-        expect(subject.id).to eq(data.activity_id)
-        expect(subject.name).to eq(data.activity_type.name)
-        expect(subject.task_token).to eq(data.task_token)
-        expect(subject.attempt).to eq(data.attempt)
-        expect(subject.workflow_run_id).to eq(data.workflow_execution.run_id)
-        expect(subject.workflow_id).to eq(data.workflow_execution.workflow_id)
-        expect(subject.workflow_name).to eq(data.workflow_type.name)
-        expect(subject.headers).to eq({})
-      end
-
-      context 'with headers' do
-        let(:data) { Fabricate(:api_activity_task, headers: { 'Foo' => 'Bar' }) }
-
-        it 'assigns headers' do
-          expect(subject.headers).to eq('Foo' => 'Bar')
-        end
-      end
+    it 'generates metadata' do
+      expect(subject.namespace).to eq(namespace)
+      expect(subject.id).to eq(data.activity_id)
+      expect(subject.name).to eq(data.activity_type.name)
+      expect(subject.task_token).to eq(data.task_token)
+      expect(subject.attempt).to eq(data.attempt)
+      expect(subject.workflow_run_id).to eq(data.workflow_execution.run_id)
+      expect(subject.workflow_id).to eq(data.workflow_execution.workflow_id)
+      expect(subject.workflow_name).to eq(data.workflow_type.name)
+      expect(subject.headers).to eq({})
     end
 
-    context 'with workflow task type' do
-      let(:type) { described_class::WORKFLOW_TASK_TYPE }
-      let(:data) { Fabricate(:api_workflow_task) }
-      let(:namespace) { 'test-namespace' }
+    context 'with headers' do
+      let(:data) { Fabricate(:api_activity_task, headers: { 'Foo' => 'Bar' }) }
 
-      it 'generates metadata' do
-        expect(subject.namespace).to eq(namespace)
-        expect(subject.id).to eq(data.started_event_id)
-        expect(subject.task_token).to eq(data.task_token)
-        expect(subject.attempt).to eq(data.attempt)
-        expect(subject.workflow_run_id).to eq(data.workflow_execution.run_id)
-        expect(subject.workflow_id).to eq(data.workflow_execution.workflow_id)
-        expect(subject.workflow_name).to eq(data.workflow_type.name)
+      it 'assigns headers' do
+        expect(subject.headers).to eq('Foo' => 'Bar')
       end
     end
+  end
+  
+  describe '.generate_workflow_task_metadata' do
+    subject { described_class.generate_workflow_task_metadata(data, namespace) }
 
-    context 'with workflow type' do
-      let(:type) { described_class::WORKFLOW_TYPE }
-      let(:data) { Fabricate(:api_workflow_execution_started_event_attributes) }
-      let(:namespace) { nil }
+    let(:data) { Fabricate(:api_workflow_task) }
+    let(:namespace) { 'test-namespace' }
 
-      it 'generates metadata' do
-        expect(subject.run_id).to eq(data.original_execution_run_id)
-        expect(subject.attempt).to eq(data.attempt)
-        expect(subject.headers).to eq({})
-      end
+    it 'generates metadata' do
+      expect(subject.namespace).to eq(namespace)
+      expect(subject.id).to eq(data.started_event_id)
+      expect(subject.task_token).to eq(data.task_token)
+      expect(subject.attempt).to eq(data.attempt)
+      expect(subject.workflow_run_id).to eq(data.workflow_execution.run_id)
+      expect(subject.workflow_id).to eq(data.workflow_execution.workflow_id)
+      expect(subject.workflow_name).to eq(data.workflow_type.name)
+    end
+  end
 
-      context 'with headers' do
-        let(:data) do
-          Fabricate(:api_workflow_execution_started_event_attributes, headers: { 'Foo' => 'Bar' })
-        end
+  context '.generate_workflow_metadata' do
+    subject { described_class.generate_workflow_metadata(event, task_metadata) }
+    let(:event) { Fabricate(:api_workflow_execution_started_event_attributes) }
+    let(:task_metadata) { Fabricate(:workflow_task_metadata) }
+    let(:namespace) { nil }
 
-        it 'assigns headers' do
-          expect(subject.headers).to eq('Foo' => 'Bar')
-        end
-      end
+    it 'generates metadata' do
+      expect(subject.run_id).to eq(event.original_execution_run_id)
+      expect(subject.workflow_id).to eq(task_metadata.workflow_id)
+      expect(subject.attempt).to eq(event.attempt)
+      expect(subject.headers).to eq({})
+      expect(subject.namespace).to eq(task_metadata.namespace)
     end
 
-    context 'with unknown type' do
-      let(:type) { :unknown }
-      let(:data) { nil }
-      let(:namespace) { nil }
+    context 'with headers' do
+      let(:event) do
+        Fabricate(:api_workflow_execution_started_event_attributes, headers: { 'Foo' => 'Bar' })
+      end
 
-      it 'raises' do
-        expect { subject }.to raise_error(Temporal::InternalError, 'Unsupported metadata type')
+      it 'assigns headers' do
+        expect(subject.headers).to eq('Foo' => 'Bar')
       end
     end
   end

--- a/spec/unit/lib/temporal/testing/local_workflow_context_spec.rb
+++ b/spec/unit/lib/temporal/testing/local_workflow_context_spec.rb
@@ -12,7 +12,7 @@ describe Temporal::Testing::LocalWorkflowContext do
       workflow_id,
       run_id,
       [],
-      Temporal::Metadata::Workflow.new(name: workflow_id, run_id: run_id, attempt: 1)
+      Temporal::Metadata::Workflow.new(name: workflow_id, workflow_id: workflow_id, run_id: run_id, attempt: 1, namespace: 'unit-test-local')
     )
   end
   let(:async_token) do


### PR DESCRIPTION
# Description
Unlike activities, I noticed our workflow logging didn't have access to the workflow_id or namespace, nor did the underlying context.
This will give user-defined loggers access so they can log consistency for the entire duration of a workflow.

Also
* I'm renaming workflow_run_id to run_id in the logs, as that's the canonical term used everywhere and can be used for log filter queries.  The only place it's slightly weird is in activities, but they do not have their own concept of run_id, so it should be unambiguous.
* Implementation detail: I removed a layer of indirection for creating metadata that was getting in the way.

# Test Plan
Some unit tests:
```
bundle exec rspec spec/unit/lib/temporal/metadata/workflow_spec.rb
bundle exec rspec ./spec/unit/lib/temporal/metadata_spec.rb
```
Plus the ambient integration tests
```
cd examples
# Terminal 1
./bin/worker
# Terminal 2
USE_ENCRYPTION = 1 ./bin/worker
# Terminal 3
bundle exec rspec spec/integration/
```
And manual inspection of logging.
