### PR TITLE
Extend wait_for on workflow context to take multiple futures and a condition block

### DIFF
--- a/examples/bin/worker
+++ b/examples/bin/worker
@@ -42,6 +42,7 @@ worker.register_workflow(SideEffectWorkflow)
 worker.register_workflow(SimpleTimerWorkflow)
 worker.register_workflow(TimeoutWorkflow)
 worker.register_workflow(TripBookingWorkflow)
+worker.register_workflow(WaitForWorkflow)
 
 worker.register_activity(AsyncActivity)
 worker.register_activity(EchoActivity)

--- a/examples/spec/integration/wait_for_workflow_spec.rb
+++ b/examples/spec/integration/wait_for_workflow_spec.rb
@@ -1,0 +1,28 @@
+require 'workflows/wait_for_workflow'
+
+describe WaitForWorkflow do
+
+  it 'signals at workflow start time' do
+    workflow_id = SecureRandom.uuid
+    run_id = Temporal.start_workflow(
+      WaitForWorkflow,
+      10, # number of echo activities to run
+      2, # max activity parallelism
+      'signal_name',
+      options: { workflow_id: workflow_id }
+    )
+
+    Temporal.signal_workflow(WaitForWorkflow, 'signal_name', workflow_id, run_id)
+
+    result = Temporal.await_workflow_result(
+      WaitForWorkflow,
+      workflow_id: workflow_id,
+      run_id: run_id,
+    )
+
+    expect(result.length).to eq(3)
+    expect(result[:signal]).to eq(true)
+    expect(result[:timer]).to eq(true)
+    expect(result[:activity]).to eq(true)
+  end
+end

--- a/examples/workflows/wait_for_workflow.rb
+++ b/examples/workflows/wait_for_workflow.rb
@@ -1,0 +1,80 @@
+require 'activities/echo_activity'
+require 'activities/long_running_activity'
+
+# This example workflow exercises all three conditions that can change state that is being
+# awaited upon: activity completion, sleep completion, signal receieved.
+class WaitForWorkflow < Temporal::Workflow
+  def execute(total_echos, max_echos_at_once, expected_signal)
+    signals_received = {}
+
+    workflow.on_signal do |signal, input|
+      signals_received[signal] = input
+    end
+
+    workflow.wait_for do
+      workflow.logger.info("Awaiting #{expected_signal}, signals received so far: #{signals_received}")
+      signals_received.key?(expected_signal)
+    end
+
+    # Run an activity but with a max time limit by starting a timer. This activity
+    # will not complete before the timer, which may result in a failed activity task after the
+    # workflow is completed.
+    long_running_future = LongRunningActivity.execute(15, 0.1)
+    timeout_timer = workflow.start_timer(1)
+    workflow.wait_for(timeout_timer, long_running_future)
+
+    timer_beat_activity = timeout_timer.finished? && !long_running_future.finished?
+
+    # This should not wait further. The first future has already finished, and therefore
+    # the second one should not be awaited upon.
+    long_timeout_timer = workflow.start_timer(15)
+    workflow.wait_for(timeout_timer, long_timeout_timer)
+    raise 'The workflow should not have waited for this timer to complete' if long_timeout_timer.finished?
+
+    block_called = false
+    workflow.wait_for(timeout_timer) do
+      # This should never be called because the timeout_timer future was already
+      # finished before the wait was even called.
+      block_called = true
+    end
+    raise 'Block should not have been called' if block_called
+
+    workflow.wait_for(long_timeout_timer) do
+      # This condition will immediately be true and not result in any waiting or dispatching
+      true
+    end
+    raise 'The workflow should not have waited for this timer to complete' if long_timeout_timer.finished?
+
+    activity_futures = {}
+    echos_completed = 0
+
+    total_echos.times do |i|
+      workflow.wait_for do
+        workflow.logger.info("Activities in flight #{activity_futures.length}")
+        # Pause workflow until the number of active activity futures is less than 2. This
+        # will throttle new activities from being started, guaranteeing that only two of these
+        # activities are running at once.
+        activity_futures.length < max_echos_at_once
+      end
+
+      future = EchoActivity.execute("hi #{i}")
+      activity_futures[i] = future
+
+      future.done do
+        activity_futures.delete(i)
+        echos_completed += 1
+      end
+    end
+
+    workflow.wait_for do
+      workflow.logger.info("Waiting for queue to drain, size: #{activity_futures.length}")
+      activity_futures.empty?
+    end
+
+    {
+      signal: signals_received.key?(expected_signal),
+      timer: timer_beat_activity,
+      activity: echos_completed == total_echos
+    }
+  end
+end

--- a/lib/temporal/testing/local_workflow_context.rb
+++ b/lib/temporal/testing/local_workflow_context.rb
@@ -165,9 +165,16 @@ module Temporal
         return
       end
 
-      def wait_for(future)
-        # Point of communication
-        Fiber.yield while !future.finished?
+      def wait_for(*futures, &unblock_condition)
+        if futures.empty? && unblock_condition.nil?
+          raise 'You must pass either a future or an unblock condition block to wait_for'
+        end
+
+        while (futures.empty? || futures.none?(&:finished?)) && (!unblock_condition || !unblock_condition.call)
+          Fiber.yield
+        end
+
+        return
       end
 
       def now

--- a/lib/temporal/workflow/context.rb
+++ b/lib/temporal/workflow/context.rb
@@ -215,14 +215,54 @@ module Temporal
         return
       end
 
-      def wait_for(future)
-        fiber = Fiber.current
-
-        dispatcher.register_handler(future.target, Dispatcher::WILDCARD) do
-          fiber.resume if future.finished?
+      # Block workflow progress until any future is finished or any unblock_condition
+      # block evaluates to true.
+      def wait_for(*futures, &unblock_condition)
+        if futures.empty? && unblock_condition.nil?
+          raise 'You must pass either a future or an unblock condition block to wait_for'
         end
 
-        Fiber.yield
+        fiber = Fiber.current
+        should_yield = false
+        blocked = true
+
+        if futures.any?
+          if futures.any?(&:finished?)
+            blocked = false
+          else
+            should_yield = true
+            futures.each do |future|
+              dispatcher.register_handler(future.target, Dispatcher::WILDCARD) do
+                if blocked && future.finished?
+                  # Because this block can run for any dispatch, ensure the fiber is only
+                  # resumed one time by checking if it's already been unblocked.
+                  blocked = false
+                  fiber.resume
+                end
+              end
+            end
+          end
+        end
+
+        if blocked && unblock_condition
+          if unblock_condition.call
+            blocked = false
+            should_yield = false
+          else
+            should_yield = true
+
+            dispatcher.register_handler(Dispatcher::WILDCARD, Dispatcher::WILDCARD) do
+              # Because this block can run for any dispatch, ensure the fiber is only
+              # resumed one time by checking if it's already been unblocked.
+              if blocked && unblock_condition.call
+                blocked = false
+                fiber.resume
+              end
+            end
+          end
+        end
+
+        Fiber.yield if should_yield
 
         return
       end

--- a/lib/temporal/workflow/dispatcher.rb
+++ b/lib/temporal/workflow/dispatcher.rb
@@ -23,6 +23,7 @@ module Temporal
 
       def handlers_for(target, event_name)
         handlers[target]
+          .concat(handlers[WILDCARD])
           .select { |(name, _)| name == event_name || name == WILDCARD }
           .map(&:last)
       end

--- a/spec/unit/lib/temporal/workflow/dispatcher_spec.rb
+++ b/spec/unit/lib/temporal/workflow/dispatcher_spec.rb
@@ -62,7 +62,24 @@ describe Temporal::Workflow::Dispatcher do
 
         expect(handler_5).to have_received(:call)
       end
+    end
 
+    context 'with WILDCARD target handler' do
+      let(:handler_6) { -> { 'sixth block' } }
+      before do
+        allow(handler_6).to receive(:call)
+
+        subject.register_handler(described_class::WILDCARD, described_class::WILDCARD, &handler_6)
+      end
+
+      it 'calls the handler' do
+        subject.dispatch('target', 'completed')
+
+        # Target handlers still invoked
+        expect(handler_1).to have_received(:call).ordered
+        expect(handler_4).to have_received(:call).ordered
+        expect(handler_6).to have_received(:call).ordered
+      end
     end
   end
 end


### PR DESCRIPTION
### Summary

Extends the `wait_for` method on workflow context to take multiple futures and a condition block. This provides the equivalent to [`Workflow.await` in Java](https://github.com/temporalio/sdk-java/blob/master/temporal-sdk/src/main/java/io/temporal/workflow/Workflow.java#L822) and [`workflow.Await` in Go](https://pkg.go.dev/go.temporal.io/sdk@v1.11.0/workflow#Await) and a "wait for any" function. This function blocks workflow progress until one of the futures is finished or the block returns true. It can be used for a variety of cases where a workflow needs to wait for the completion of any combination of activities or timer completion, or receipt of a signal.

Also included:
- A new `WaitForWorkflow` example that demonstrates all three of these cases, along with an integration test to run it and verify its behavior
- Support in local workflow context testing mode
- Unit tests for changes to the dispatcher

### Testing

New new dispatcher unit tests: `rspec spec/unit/lib/temporal/workflow/dispatcher_spec.rb:78`
New integration test: `pushd examples && rspec spec/integration/wait_for_workflow_spec.rb && popd` (need to run `pushd examples && bin/worker` in another terminal)