### PR TITLE
Explicit docker-compose project name

### DIFF
--- a/examples/.env
+++ b/examples/.env
@@ -1,0 +1,1 @@
+COMPOSE_PROJECT_NAME=temporal-ruby-examples


### PR DESCRIPTION
By default docker-compose uses the name of the directory hosting the `docker-compose.yml` file (`examples` in this case), which can then generate ambiguous containers (it clashes with cadence-ruby/examples if you use both)