### PR TITLE
Fix EventTarget comparison with wildcard

### DIFF
--- a/lib/temporal/workflow/context.rb
+++ b/lib/temporal/workflow/context.rb
@@ -251,7 +251,7 @@ module Temporal
           else
             should_yield = true
 
-            dispatcher.register_handler(Dispatcher::WILDCARD, Dispatcher::WILDCARD) do
+            dispatcher.register_handler(Dispatcher::TARGET_WILDCARD, Dispatcher::WILDCARD) do
               # Because this block can run for any dispatch, ensure the fiber is only
               # resumed one time by checking if it's already been unblocked.
               if blocked && unblock_condition.call

--- a/lib/temporal/workflow/dispatcher.rb
+++ b/lib/temporal/workflow/dispatcher.rb
@@ -2,6 +2,7 @@ module Temporal
   class Workflow
     class Dispatcher
       WILDCARD = '*'.freeze
+      TARGET_WILDCARD = '*'.freeze
 
       def initialize
         @handlers = Hash.new { |hash, key| hash[key] = [] }
@@ -23,7 +24,7 @@ module Temporal
 
       def handlers_for(target, event_name)
         handlers[target]
-          .concat(handlers[WILDCARD])
+          .concat(handlers[TARGET_WILDCARD])
           .select { |(name, _)| name == event_name || name == WILDCARD }
           .map(&:last)
       end

--- a/lib/temporal/workflow/history/event_target.rb
+++ b/lib/temporal/workflow/history/event_target.rb
@@ -61,7 +61,7 @@ module Temporal
         end
 
         def ==(other)
-          id == other.id && type == other.type
+          self.class == other.class && id == other.id && type == other.type
         end
 
         def eql?(other)

--- a/spec/unit/lib/temporal/workflow/dispatcher_spec.rb
+++ b/spec/unit/lib/temporal/workflow/dispatcher_spec.rb
@@ -1,13 +1,17 @@
 require 'temporal/workflow/dispatcher'
+require 'temporal/workflow/history/event_target'
 
 describe Temporal::Workflow::Dispatcher do
+  let(:target) { Temporal::Workflow::History::EventTarget.new(1, Temporal::Workflow::History::EventTarget::ACTIVITY_TYPE) }
+  let(:other_target) { Temporal::Workflow::History::EventTarget.new(2, Temporal::Workflow::History::EventTarget::TIMER_TYPE) }
+
   describe '#register_handler' do
     it 'stores a given handler against the target' do
       block = -> { 'handler body' }
 
-      subject.register_handler('target', 'signaled', &block)
+      subject.register_handler(target, 'signaled', &block)
 
-      expect(subject.send(:handlers)).to include('target' => [['signaled', block]])
+      expect(subject.send(:handlers)).to include(target => [['signaled', block]])
     end
   end
 
@@ -22,14 +26,14 @@ describe Temporal::Workflow::Dispatcher do
         allow(handler).to receive(:call)
       end
 
-      subject.register_handler('target', 'completed', &handler_1)
-      subject.register_handler('other_target', 'completed', &handler_2)
-      subject.register_handler('target', 'failed', &handler_3)
-      subject.register_handler('target', 'completed', &handler_4)
+      subject.register_handler(target, 'completed', &handler_1)
+      subject.register_handler(other_target, 'completed', &handler_2)
+      subject.register_handler(target, 'failed', &handler_3)
+      subject.register_handler(target, 'completed', &handler_4)
     end
 
     it 'calls all matching handlers in the original order' do
-      subject.dispatch('target', 'completed')
+      subject.dispatch(target, 'completed')
 
       expect(handler_1).to have_received(:call).ordered
       expect(handler_4).to have_received(:call).ordered
@@ -39,7 +43,7 @@ describe Temporal::Workflow::Dispatcher do
     end
 
     it 'passes given arguments to the handlers' do
-      subject.dispatch('target', 'failed', ['TIME_OUT', 'Exceeded execution time'])
+      subject.dispatch(target, 'failed', ['TIME_OUT', 'Exceeded execution time'])
 
       expect(handler_3).to have_received(:call).with('TIME_OUT', 'Exceeded execution time')
 
@@ -54,31 +58,35 @@ describe Temporal::Workflow::Dispatcher do
       before do
         allow(handler_5).to receive(:call)
 
-        subject.register_handler('target', described_class::WILDCARD, &handler_5)
+        subject.register_handler(target, described_class::WILDCARD, &handler_5)
       end
 
       it 'calls the handler' do
-        subject.dispatch('target', 'completed')
+        subject.dispatch(target, 'completed')
 
         expect(handler_5).to have_received(:call)
       end
     end
 
-    context 'with WILDCARD target handler' do
+    context 'with TARGET_WILDCARD target handler' do
       let(:handler_6) { -> { 'sixth block' } }
       before do
         allow(handler_6).to receive(:call)
 
-        subject.register_handler(described_class::WILDCARD, described_class::WILDCARD, &handler_6)
+        subject.register_handler(described_class::TARGET_WILDCARD, described_class::WILDCARD, &handler_6)
       end
 
       it 'calls the handler' do
-        subject.dispatch('target', 'completed')
+        subject.dispatch(target, 'completed')
 
         # Target handlers still invoked
         expect(handler_1).to have_received(:call).ordered
         expect(handler_4).to have_received(:call).ordered
         expect(handler_6).to have_received(:call).ordered
+      end
+
+      it 'TARGET_WILDCARD can be compared to an EventTarget object' do
+        expect(target.eql?(described_class::TARGET_WILDCARD)).to be(false)
       end
     end
   end


### PR DESCRIPTION
### Motivation

During registration, the `Dispatcher` places all dispatch targets into a hash keyed on target. Before https://github.com/coinbase/temporal-ruby/pull/111, event targets were always of type `EventTarget`. With that change, event targets could also be of type `String` (i.e., `"*"`). In the implementation of `Hash`, objects of these two types can be compared using the `eql?` method when they end up in the same bucket behind the scenes. `EventTarget.eql?` can only compare objects that have an `id` and `type` field like itself. Because a `String` does not have these fields, it sometimes fails with a specific error while trying to register a dispatch handler:

```
Failure/Error: id == other.id && type == other.type

     NoMethodError:
       undefined method `id' for "*":String
     # ./lib/temporal/workflow/history/event_target.rb:65:in `=='
     # ./lib/temporal/workflow/history/event_target.rb:70:in `eql?'
     # ./spec/unit/lib/temporal/workflow/dispatcher_spec.rb:89:in `block (4 levels) in <top (required)>'
```

### Summary

- Modifies `EventTarget.eql?` to return `false` when called with an object that is not of its own type
- Separates `TARGET_WILDCARD` from `WILDCARD` to more clearly indicate their separate functions
- The dispatcher unit tests have been updated to use `EventTarget` objects rather than `Strings` to reflect the actual type used in the implementation outside of the tests
- A new unit test has been added to ensure `EventType` can be compared against `TARGET_WILDCARD`

### Testing

Updated and new tests can all be run with,
```
rspec spec/unit/lib/temporal/workflow/dispatcher_spec.rb
```