### PR TITLE
Improve header serialization and propagation

### DIFF
--- a/examples/spec/integration/continue_as_new_spec.rb
+++ b/examples/spec/integration/continue_as_new_spec.rb
@@ -6,12 +6,16 @@ describe LoopWorkflow do
     memo = {
         'my-memo' => 'foo',
     }
+    headers = {
+        'my-header' => 'bar',
+    }
     run_id = Temporal.start_workflow(
       LoopWorkflow,
       2, # it continues as new if this arg is > 1
       options: {
         workflow_id: workflow_id,
         memo: memo,
+        headers: headers,
       },
     )
 
@@ -38,7 +42,8 @@ describe LoopWorkflow do
 
     expect(final_result[:count]).to eq(1)
 
-    # memo should be copied to the next run automatically
+    # memo and headers should be copied to the next run automatically
     expect(final_result[:memo]).to eq(memo)
+    expect(final_result[:headers]).to eq(headers)
   end
 end

--- a/examples/spec/integration/metadata_workflow_spec.rb
+++ b/examples/spec/integration/metadata_workflow_spec.rb
@@ -26,7 +26,7 @@ describe MetadataWorkflow do
       MetadataWorkflow,
       options: {
           workflow_id: workflow_id,
-          headers: { 'foo' => Temporal.configuration.converter.to_payload('bar') },
+          headers: { 'foo' => 'bar' },
       }
     )
 

--- a/examples/workflows/loop_workflow.rb
+++ b/examples/workflows/loop_workflow.rb
@@ -11,6 +11,7 @@ class LoopWorkflow < Temporal::Workflow
     return {
       count: count,
       memo: workflow.metadata.memo,
+      headers: workflow.metadata.headers,
     }
   end
 end

--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -312,6 +312,16 @@ module Temporal
         signal_input:,
         memo: nil
       )
+        proto_header_fields = if headers.nil?
+            to_payload_map({})
+        elsif headers.class == Hash
+            to_payload_map(headers)
+        else
+          # Preserve backward compatability for headers specified using proto objects
+          warn '[DEPRECATION] Specify headers using a hash rather than protobuf objects'
+          headers
+        end
+
         request = Temporal::Api::WorkflowService::V1::SignalWithStartWorkflowExecutionRequest.new(
           identity: identity,
           namespace: namespace,
@@ -328,7 +338,7 @@ module Temporal
           workflow_task_timeout: task_timeout,
           request_id: SecureRandom.uuid,
           header: Temporal::Api::Common::V1::Header.new(
-            fields: to_payload_map(headers || {})
+            fields: proto_header_fields,
           ),
           cron_schedule: cron_schedule,
           signal_name: signal_name,

--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -100,7 +100,7 @@ module Temporal
           workflow_task_timeout: task_timeout,
           request_id: SecureRandom.uuid,
           header: Temporal::Api::Common::V1::Header.new(
-            fields: headers
+            fields: to_payload_map(headers || {})
           ),
           cron_schedule: cron_schedule,
           memo: Temporal::Api::Common::V1::Memo.new(
@@ -328,7 +328,7 @@ module Temporal
           workflow_task_timeout: task_timeout,
           request_id: SecureRandom.uuid,
           header: Temporal::Api::Common::V1::Header.new(
-            fields: headers
+            fields: to_payload_map(headers || {})
           ),
           cron_schedule: cron_schedule,
           signal_name: signal_name,

--- a/lib/temporal/connection/serializer/continue_as_new.rb
+++ b/lib/temporal/connection/serializer/continue_as_new.rb
@@ -30,7 +30,7 @@ module Temporal
         def serialize_headers(headers)
           return unless headers
 
-          Temporal::Api::Common::V1::Header.new(fields: object.headers)
+          Temporal::Api::Common::V1::Header.new(fields: to_payload_map(headers))
         end
 
         def serialize_memo(memo)

--- a/lib/temporal/connection/serializer/start_child_workflow.rb
+++ b/lib/temporal/connection/serializer/start_child_workflow.rb
@@ -33,7 +33,7 @@ module Temporal
         def serialize_headers(headers)
           return unless headers
 
-          Temporal::Api::Common::V1::Header.new(fields: object.headers)
+          Temporal::Api::Common::V1::Header.new(fields: to_payload_map(headers))
         end
 
         def serialize_memo(memo)

--- a/lib/temporal/workflow/context.rb
+++ b/lib/temporal/workflow/context.rb
@@ -195,9 +195,10 @@ module Temporal
         options = args.delete(:options) || {}
         input << args unless args.empty?
 
-        # If memo is not overridden, copy from current run
+        # If memo or headers are not overridden, use those from the current run
         options_from_metadata = {
           memo: metadata.memo,
+          headers: metadata.headers,
         }
         options = options_from_metadata.merge(options)
 

--- a/spec/unit/lib/temporal/connection/serializer/continue_as_new_spec.rb
+++ b/spec/unit/lib/temporal/connection/serializer/continue_as_new_spec.rb
@@ -9,6 +9,7 @@ describe Temporal::Connection::Serializer::ContinueAsNew do
         task_queue: 'my-task-queue',
         input: ['one', 'two'],
         timeouts: Temporal.configuration.timeouts,
+        headers: {'foo-header': 'bar'},
         memo: {'foo-memo': 'baz'},
       )
 
@@ -28,6 +29,7 @@ describe Temporal::Connection::Serializer::ContinueAsNew do
       expect(attribs.input.payloads[0].data).to eq('"one"')
       expect(attribs.input.payloads[1].data).to eq('"two"')
 
+      expect(attribs.header.fields['foo-header'].data).to eq('"bar"')
       expect(attribs.memo.fields['foo-memo'].data).to eq('"baz"')
     end
   end


### PR DESCRIPTION
### Summary
This contains two improvements to headers, both of which change the behavior of workflow headers:

First, headers are now by default propagated to the next run of a workflow on continue-as-new. This can be overridden by passing `options: {headers: overridden_headers}` to `workflow.continue_as_new` if desired.

Second, to set headers, you no longer need to use the generated proto classes. Instead, you can simply pass an ordinary hash, which will be automatically serialized into the proper proto. This makes the use of headers more ergonomic and eliminates the need to use the lower-level protobuf abstraction in code that uses temporal-ruby. However, **this is a breaking change**. If you are currently passing protobuf objects in for headers, you will need to instead pass a hash.

### Testing

The continue-as-new integration test will now check that headers are propagated to the next run, as it already did with memos. The metadata workflow test now passes headers in the new way.
```
pushd examples
rspec spec/integration/continue_as_new_spec.rb
rspec spec/integration/metadata_workflow_spec.rb
popd
```

Existing unit tests have been updated to work with passing an ordinary hash for headers:
```
rspec spec/unit/lib/temporal/connection/serializer/continue_as_new_spec.rb
```