### PR TITLE
[Fix] Non-started activity cancellation

### DIFF
--- a/examples/spec/integration/activity_cancellation_spec.rb
+++ b/examples/spec/integration/activity_cancellation_spec.rb
@@ -1,0 +1,39 @@
+require 'workflows/long_workflow'
+
+describe 'Activity cancellation' do
+  let(:workflow_id) { SecureRandom.uuid }
+
+  it 'cancels a running activity' do
+    run_id = Temporal.start_workflow(LongWorkflow, options: { workflow_id: workflow_id })
+
+    # Signal workflow after starting, allowing it to schedule the first activity
+    sleep 0.5
+    Temporal.signal_workflow(LongWorkflow, :CANCEL, workflow_id, run_id)
+
+    result = Temporal.await_workflow_result(
+      LongWorkflow,
+      workflow_id: workflow_id,
+      run_id: run_id,
+    )
+
+    expect(result).to be_a(LongRunningActivity::Canceled)
+    expect(result.message).to eq('cancel activity request received')
+  end
+
+  it 'cancels a non-started activity' do
+    # Workflow is started with a signal which will cancel an activity before it has started
+    run_id = Temporal.start_workflow(LongWorkflow, options: {
+      workflow_id: workflow_id,
+      signal_name: :CANCEL
+    })
+
+    result = Temporal.await_workflow_result(
+      LongWorkflow,
+      workflow_id: workflow_id,
+      run_id: run_id,
+    )
+
+    expect(result).to be_a(Temporal::ActivityCanceled)
+    expect(result.message).to eq('ACTIVITY_ID_NOT_STARTED')
+  end
+end

--- a/examples/workflows/long_workflow.rb
+++ b/examples/workflows/long_workflow.rb
@@ -9,6 +9,6 @@ class LongWorkflow < Temporal::Workflow
       future.cancel
     end
 
-    future.wait
+    future.get
   end
 end

--- a/lib/temporal/errors.rb
+++ b/lib/temporal/errors.rb
@@ -19,6 +19,9 @@ module Temporal
   # with the intent to propagate to a workflow
   class ActivityException < ClientError; end
 
+  # Represents cancellation of a non-started activity
+  class ActivityCanceled < ActivityException; end
+
   class ActivityNotRegistered < ClientError; end
   class WorkflowNotRegistered < ClientError; end
 

--- a/lib/temporal/workflow/history/event_target.rb
+++ b/lib/temporal/workflow/history/event_target.rb
@@ -19,7 +19,7 @@ module Temporal
 
         # NOTE: The order is important, first prefix match wins (will be a longer match)
         TARGET_TYPES = {
-          'ACTIVITY_TASK_CANCEL'                       => CANCEL_ACTIVITY_REQUEST_TYPE,
+          'ACTIVITY_TASK_CANCEL_REQUESTED'             => CANCEL_ACTIVITY_REQUEST_TYPE,
           'ACTIVITY_TASK'                              => ACTIVITY_TYPE,
           'REQUEST_CANCEL_ACTIVITY_TASK'               => CANCEL_ACTIVITY_REQUEST_TYPE,
           'TIMER_CANCELED'                             => CANCEL_TIMER_REQUEST_TYPE,

--- a/lib/temporal/workflow/state_manager.rb
+++ b/lib/temporal/workflow/state_manager.rb
@@ -162,7 +162,7 @@ module Temporal
 
         when 'ACTIVITY_TASK_CANCELED'
           state_machine.cancel
-          dispatch(target, 'failed', Temporal::Workflow::Errors.generate_error(event.attributes.failure))
+          dispatch(target, 'failed', Temporal::ActivityCanceled.new(from_details_payloads(event.attributes.details)))
 
         when 'TIMER_STARTED'
           state_machine.start

--- a/spec/fabricators/grpc/history_event_fabricator.rb
+++ b/spec/fabricators/grpc/history_event_fabricator.rb
@@ -1,5 +1,9 @@
 require 'securerandom'
 
+class TestSerializer
+  extend Temporal::Concerns::Payloads
+end
+
 Fabricator(:api_history_event, from: Temporal::Api::History::V1::HistoryEvent) do
   event_id { 1 }
   event_time { Time.now }
@@ -118,6 +122,28 @@ Fabricator(:api_activity_task_failed_event, from: :api_history_event) do
       scheduled_event_id: attrs[:event_id] - 2,
       started_event_id: attrs[:event_id] - 1,
       identity: 'test-worker@test-host'
+    )
+  end
+end
+
+Fabricator(:api_activity_task_canceled_event, from: :api_history_event) do
+  event_type { Temporal::Api::Enums::V1::EventType::EVENT_TYPE_ACTIVITY_TASK_CANCELED }
+  activity_task_canceled_event_attributes do |attrs|
+    Temporal::Api::History::V1::ActivityTaskCanceledEventAttributes.new(
+      details: TestSerializer.to_details_payloads('ACTIVITY_ID_NOT_STARTED'),
+      scheduled_event_id: attrs[:event_id] - 2,
+      started_event_id: nil,
+      identity: 'test-worker@test-host'
+    )
+  end
+end
+
+Fabricator(:api_activity_task_cancel_requested_event, from: :api_history_event) do
+  event_type { Temporal::Api::Enums::V1::EventType::EVENT_TYPE_ACTIVITY_TASK_CANCEL_REQUESTED }
+  activity_task_cancel_requested_event_attributes do |attrs|
+    Temporal::Api::History::V1::ActivityTaskCancelRequestedEventAttributes.new(
+      scheduled_event_id: attrs[:event_id] - 1,
+      workflow_task_completed_event_id: attrs[:event_id] - 2,
     )
   end
 end

--- a/spec/unit/lib/temporal/workflow/history/event_target_spec.rb
+++ b/spec/unit/lib/temporal/workflow/history/event_target_spec.rb
@@ -21,5 +21,21 @@ describe Temporal::Workflow::History::EventTarget do
         expect(subject.type).to eq(described_class::CANCEL_TIMER_REQUEST_TYPE)
       end
     end
+
+    context 'when event is ACTIVITY_CANCELED' do
+      let(:raw_event) { Fabricate(:api_activity_task_canceled_event) }
+
+      it 'sets type to timer' do
+        expect(subject.type).to eq(described_class::ACTIVITY_TYPE)
+      end
+    end
+
+    context 'when event is ACTIVITY_TASK_CANCEL_REQUESTED' do
+      let(:raw_event) { Fabricate(:api_activity_task_cancel_requested_event) }
+
+      it 'sets type to cancel_timer_request' do
+        expect(subject.type).to eq(described_class::CANCEL_ACTIVITY_REQUEST_TYPE)
+      end
+    end
   end
 end

--- a/spec/unit/lib/temporal/workflow/history/event_target_spec.rb
+++ b/spec/unit/lib/temporal/workflow/history/event_target_spec.rb
@@ -25,7 +25,7 @@ describe Temporal::Workflow::History::EventTarget do
     context 'when event is ACTIVITY_CANCELED' do
       let(:raw_event) { Fabricate(:api_activity_task_canceled_event) }
 
-      it 'sets type to timer' do
+      it 'sets type to activity' do
         expect(subject.type).to eq(described_class::ACTIVITY_TYPE)
       end
     end
@@ -33,7 +33,7 @@ describe Temporal::Workflow::History::EventTarget do
     context 'when event is ACTIVITY_TASK_CANCEL_REQUESTED' do
       let(:raw_event) { Fabricate(:api_activity_task_cancel_requested_event) }
 
-      it 'sets type to cancel_timer_request' do
+      it 'sets type to cancel_activity_request' do
         expect(subject.type).to eq(described_class::CANCEL_ACTIVITY_REQUEST_TYPE)
       end
     end


### PR DESCRIPTION
When an activity cancellation is requested before the activity had a chance to start Temporal will issue an `ACTIVITY_CANCELED` event. This PR fixed handling of this event.

Tested:
- Added both unit & integration specs to ensure it works as expected