### PR TITLE
Make error deserialization more resilient

### DIFF
--- a/lib/temporal/workflow/errors.rb
+++ b/lib/temporal/workflow/errors.rb
@@ -25,7 +25,7 @@ module Temporal
 
           begin
             exception = exception_class.new(message)
-          rescue ArgumentError => deserialization_error
+          rescue => deserialization_error
             # We don't currently support serializing/deserializing exceptions with more than one argument.
             message = "#{exception_class}: #{message}"
             exception = default_exception_class.new(message)
@@ -33,6 +33,7 @@ module Temporal
               "Could not instantiate original error. Defaulting to StandardError.", 
               {
                 original_error: failure.application_failure_info.type,
+                instantiation_error_class: deserialization_error.class.to_s,
                 instantiation_error_message: deserialization_error.message,
               },
             ) 

--- a/spec/unit/lib/temporal/workflow/errors_spec.rb
+++ b/spec/unit/lib/temporal/workflow/errors_spec.rb
@@ -7,8 +7,9 @@ end
 class ErrorThatRaisesInInitialize < StandardError
   def initialize(message)
     # This class simulates an error class that has bugs in its initialize method, or where
-    # the arg isn't a string. It raises TypeError (String can't be coerced into Integer)
-    1 + message
+    # the arg isn't a string. It raises the sort of TypeError that would happen if you wrote
+    # 1 + message
+    raise TypeError.new("String can't be coerced into Integer")
   end
 end
 


### PR DESCRIPTION
## Description
https://github.com/coinbase/temporal-ruby/pull/103 lets temporal-ruby respond gracefully when it can't construct the correct exception from serialized data. This PR makes that logic kick in for any type of deserialization failure, not just ArgumentError

## Testing
I added a test to this unit: `bundle exec rspec ./spec/unit/lib/temporal/workflow/errors_spec.rb`

Integration, to check for regressions:

```
cd examples
./bin/worker &
USE_ENCRYPTION=1 ./bin/worker &
bundle exec rspec spec/integration
```