### PR TITLE
[Fix] Workflow scheduling using a String

### DIFF
--- a/examples/spec/integration/start_workflow_spec.rb
+++ b/examples/spec/integration/start_workflow_spec.rb
@@ -1,0 +1,36 @@
+require 'workflows/hello_world_workflow'
+
+describe 'Temporal.start_workflow' do
+  let(:workflow_id) { SecureRandom.uuid }
+
+  it 'starts a workflow using a class reference' do
+    run_id = Temporal.start_workflow(HelloWorldWorkflow, 'Test', options: {
+      workflow_id: workflow_id
+    })
+
+    result = Temporal.await_workflow_result(
+      HelloWorldWorkflow,
+      workflow_id: workflow_id,
+      run_id: run_id
+    )
+
+    expect(result).to eq('Hello World, Test')
+  end
+
+  it 'starts a workflow using a string reference' do
+    run_id = Temporal.start_workflow('HelloWorldWorkflow', 'Test', options: {
+      workflow_id: workflow_id,
+      namespace: Temporal.configuration.namespace,
+      task_queue: Temporal.configuration.task_queue
+    })
+
+    result = Temporal.await_workflow_result(
+      'HelloWorldWorkflow',
+      workflow_id: workflow_id,
+      run_id: run_id,
+      namespace: Temporal.configuration.namespace
+    )
+
+    expect(result).to eq('Hello World, Test')
+  end
+end

--- a/lib/temporal/execution_options.rb
+++ b/lib/temporal/execution_options.rb
@@ -49,7 +49,9 @@ module Temporal
     private
 
     def has_executable_concern?(object)
-      object.singleton_class.included_modules.include?(Concerns::Executable)
+      # NOTE: When object is a String .dup is needed since Object#singleton_class mutates
+      #       it and screws up C extension class detection (used by Protobufs)
+      object.dup.singleton_class.included_modules.include?(Concerns::Executable)
     rescue TypeError
       false
     end


### PR DESCRIPTION
Fixes #123 

This is a weird issue, but it seems that `Object#singleton_class` does something to the object and screws up class detection in C extensions (used by Protobufs). Here's an example:

```ruby
>> a = 'TestWorkflow'
=> "TestWorkflow"
>> a.singleton_class
=> #<Class:#<String:0x000000013320dc10>>
>> Temporal::Api::Common::V1::WorkflowType.new(name: a)
(irb):3:in `initialize': Invalid argument for string field 'name' (given String). (Google::Protobuf::TypeError)
	from (irb):3:in `new'
	from (irb):3:in `<main>'
	from /opt/homebrew/Cellar/rbenv/1.1.2/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.22/lib/bundler/cli/console.rb:19:in `run'
	from /opt/homebrew/Cellar/rbenv/1.1.2/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.22/lib/bundler/cli.rb:504:in `console'
	from /opt/homebrew/Cellar/rbenv/1.1.2/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.22/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	from /opt/homebrew/Cellar/rbenv/1.1.2/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.22/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from /opt/homebrew/Cellar/rbenv/1.1.2/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.22/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	from /opt/homebrew/Cellar/rbenv/1.1.2/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.22/lib/bundler/cli.rb:30:in `dispatch'
	from /opt/homebrew/Cellar/rbenv/1.1.2/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.22/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	from /opt/homebrew/Cellar/rbenv/1.1.2/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.22/lib/bundler/cli.rb:24:in `start'
	from /opt/homebrew/Cellar/rbenv/1.1.2/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.22/exe/bundle:49:in `block in <top (required)>'
	from /opt/homebrew/Cellar/rbenv/1.1.2/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.22/lib/bundler/friendly_errors.rb:128:in `with_friendly_errors'
	from /opt/homebrew/Cellar/rbenv/1.1.2/versions/3.0.1/lib/ruby/gems/3.0.0/gems/bundler-2.2.22/exe/bundle:37:in `<top (required)>'
	from /opt/homebrew/opt/rbenv/versions/3.0.1/bin/bundle:23:in `load'
	from /opt/homebrew/opt/rbenv/versions/3.0.1/bin/bundle:23:in `<main>'
```

Here's the root cause, but I'm not 100% sure of the underlying mechanics  — https://twitter.com/ANTStorm/status/1474038270657024001

The fix just calls `#singleton_method` on a duplicate object avoiding any modifications to the original one.

A new integration test exposing the issue is added.