### PR TITLE
Change describe_namespace integration spec to use the default namespace

### DIFF
--- a/examples/spec/helpers.rb
+++ b/examples/spec/helpers.rb
@@ -33,4 +33,8 @@ module Helpers
       }.merge(options)
     )
   end
+
+  def integration_spec_namespace
+    ENV.fetch('TEMPORAL_NAMESPACE', 'ruby-samples')
+  end
 end

--- a/examples/spec/integration/describe_namespace_spec.rb
+++ b/examples/spec/integration/describe_namespace_spec.rb
@@ -1,16 +1,19 @@
 require 'temporal/errors'
 
-describe 'Temporal.describe_namespace' do
+describe 'Temporal.describe_namespace', :integration do
   it 'returns a value' do
-    description = 'Namespace for temporal-ruby integration test'
+    namespace = integration_spec_namespace
+    rescued = false
     begin
-      Temporal.register_namespace('a_test_namespace', description)
+      Temporal.register_namespace(namespace)
     rescue Temporal::NamespaceAlreadyExistsFailure
+      rescued = true
     end
-    result = Temporal.describe_namespace('a_test_namespace')
+    expect(rescued).to eq(true)
+    result = Temporal.describe_namespace(namespace)
     expect(result).to be_an_instance_of(Temporal::Api::WorkflowService::V1::DescribeNamespaceResponse)
-    expect(result.namespace_info.name).to eq('a_test_namespace')
+    expect(result.namespace_info.name).to eq(namespace)
     expect(result.namespace_info.state).to eq(:NAMESPACE_STATE_REGISTERED)
-    expect(result.namespace_info.description).to eq(description)
+    expect(result.namespace_info.description).to_not eq(nil)
   end
 end

--- a/examples/spec/integration/metadata_workflow_spec.rb
+++ b/examples/spec/integration/metadata_workflow_spec.rb
@@ -1,6 +1,6 @@
 require 'workflows/metadata_workflow'
 
-describe MetadataWorkflow do
+describe MetadataWorkflow, :integration do
   subject { described_class }
 
   it 'gets task queue from running workflow' do
@@ -66,7 +66,7 @@ describe MetadataWorkflow do
     expect(actual_result.memo['foo']).to eq('bar')
 
     expect(Temporal.fetch_workflow_execution_info(
-      'ruby-samples', workflow_id, nil
+      integration_spec_namespace, workflow_id, nil
     ).memo).to eq({ 'foo' => 'bar' })
   end
 
@@ -85,7 +85,7 @@ describe MetadataWorkflow do
     )
     expect(actual_result.memo).to eq({})
     expect(Temporal.fetch_workflow_execution_info(
-      'ruby-samples', workflow_id, nil
+      integration_spec_namespace, workflow_id, nil
     ).memo).to eq({})
   end
 end


### PR DESCRIPTION
It can take some time between registering a namespace, and that namespace being available to describe. Moreover, the test as originally written can depend on the behavior of a previous run. The description passed on initial namespace registration will remain on the namespace indefinitely. If this value is changed in code, subsequent tests will fail when the description does not match.

Using ruby-samples (or whatever name has been overridden in an environment variable) ensures the same behavior each run and is not subject to the possible delay of creating a new namespace since this namespace must already exist to be able to start the test workers.

This fixes flaky CI failures such as https://app.circleci.com/pipelines/github/coinbase/temporal-ruby/352/workflows/171da02d-adb6-44f1-b203-ae1fcb7d755c/jobs/714