### PR TITLE
Expose workflow name in activity metadata in temporal-ruby's unit tester

### DIFF
--- a/lib/temporal/testing/local_workflow_context.rb
+++ b/lib/temporal/testing/local_workflow_context.rb
@@ -133,8 +133,8 @@ module Temporal
           name: execution_options.name, # Workflow class name
           run_id: run_id,
           attempt: 1,
-          task_queue: 'unit-test-task-queue',
-          headers: {},
+          task_queue: execution_options.task_queue,
+          headers: execution_options.headers,
           run_started_at: Time.now,
           memo: {},
         )

--- a/lib/temporal/testing/local_workflow_context.rb
+++ b/lib/temporal/testing/local_workflow_context.rb
@@ -57,7 +57,7 @@ module Temporal
           attempt: 1,
           workflow_run_id: run_id,
           workflow_id: workflow_id,
-          workflow_name: nil, # not yet used, but will be in the future
+          workflow_name: self.metadata.name,
           headers: execution_options.headers,
           heartbeat_details: nil
         )
@@ -105,7 +105,7 @@ module Temporal
           attempt: 1,
           workflow_run_id: run_id,
           workflow_id: workflow_id,
-          workflow_name: nil, # not yet used, but will be in the future
+          workflow_name: self.metadata.name,
           headers: execution_options.headers,
           heartbeat_details: nil
         )
@@ -126,8 +126,20 @@ module Temporal
         workflow_id = SecureRandom.uuid
         run_id = SecureRandom.uuid
         execution_options = ExecutionOptions.new(workflow_class, options, config.default_execution_options)
+
+        child_metadata = Temporal::Metadata::Workflow.new(
+          namespace: execution_options.namespace,
+          id: workflow_id,
+          name: execution_options.name, # Workflow class name
+          run_id: run_id,
+          attempt: 1,
+          task_queue: 'unit-test-task-queue',
+          headers: {},
+          run_started_at: Time.now,
+          memo: {},
+        )
         context = Temporal::Testing::LocalWorkflowContext.new(
-          execution, workflow_id, run_id, workflow_class.disabled_releases, execution_options.headers
+          execution, workflow_id, run_id, workflow_class.disabled_releases, child_metadata
         )
 
         workflow_class.execute_in_context(context, input)

--- a/spec/unit/lib/temporal/testing/local_workflow_context_spec.rb
+++ b/spec/unit/lib/temporal/testing/local_workflow_context_spec.rb
@@ -4,6 +4,7 @@ require 'temporal/api/errordetails/v1/message_pb'
 
 describe Temporal::Testing::LocalWorkflowContext do
   let(:workflow_id) { 'workflow_id_1' }
+  let(:workflow_name) { 'HelloWorldWorkflow' }
   let(:run_id) { 'run_id_1' }
   let(:execution) { Temporal::Testing::WorkflowExecution.new }
   let(:task_queue) { 'my_test_queue' }
@@ -16,7 +17,7 @@ describe Temporal::Testing::LocalWorkflowContext do
       Temporal::Metadata::Workflow.new(
         namespace: 'ruby-samples',
         id: workflow_id,
-        name: 'HelloWorldWorkflow',
+        name: workflow_name,
         run_id: run_id,
         attempt: 1,
         task_queue: task_queue,
@@ -153,6 +154,7 @@ describe Temporal::Testing::LocalWorkflowContext do
       expect(result.name).to eq('MetadataCapturingActivity')
       expect(result.namespace).to eq('default-namespace')
       expect(result.workflow_id).to eq(workflow_id)
+      expect(result.workflow_name).to eq(workflow_name)
       expect(result.workflow_run_id).to eq(run_id)
     end
   end


### PR DESCRIPTION
I was working with activity metadata in unit tests, and noticed that workflow_name was always nil. This behavior doesn't match the behavior outside of tests. This PR brings to the two in line.

I also noticed that the 5th arg to `LocalWorkflowContext.new` was a `Temporal::Metadata::Workflow` [for a parent workflow](https://github.com/coinbase/temporal-ruby/blob/master/lib/temporal/testing/workflow_override.rb#L42) but a hash (the result of `execution_options.headers`) for a child workflow. Now it's a `Temporal::Metadata::Workflow` for both.