### PR TITLE
Add namespace to emitted metrics

### DIFF
--- a/lib/temporal/activity/task_processor.rb
+++ b/lib/temporal/activity/task_processor.rb
@@ -26,7 +26,7 @@ module Temporal
         start_time = Time.now
 
         Temporal.logger.debug("Processing Activity task", metadata.to_h)
-        Temporal.metrics.timing('activity_task.queue_time', queue_time_ms, activity: activity_name)
+        Temporal.metrics.timing('activity_task.queue_time', queue_time_ms, activity: activity_name, namespace: namespace)
 
         context = Activity::Context.new(connection, metadata)
 
@@ -46,7 +46,7 @@ module Temporal
         respond_failed(error)
       ensure
         time_diff_ms = ((Time.now - start_time) * 1000).round
-        Temporal.metrics.timing('activity_task.latency', time_diff_ms, activity: activity_name)
+        Temporal.metrics.timing('activity_task.latency', time_diff_ms, activity: activity_name, namespace: namespace)
         Temporal.logger.debug("Activity task processed", metadata.to_h.merge(execution_time: time_diff_ms))
       end
 

--- a/lib/temporal/workflow/task_processor.rb
+++ b/lib/temporal/workflow/task_processor.rb
@@ -24,7 +24,7 @@ module Temporal
         start_time = Time.now
 
         Temporal.logger.debug("Processing Workflow task", metadata.to_h)
-        Temporal.metrics.timing('workflow_task.queue_time', queue_time_ms, workflow: workflow_name)
+        Temporal.metrics.timing('workflow_task.queue_time', queue_time_ms, workflow: workflow_name, namespace: namespace)
 
         if !workflow_class
           raise Temporal::WorkflowNotRegistered, 'Workflow is not registered with this worker'
@@ -45,7 +45,7 @@ module Temporal
         fail_task(error)
       ensure
         time_diff_ms = ((Time.now - start_time) * 1000).round
-        Temporal.metrics.timing('workflow_task.latency', time_diff_ms, workflow: workflow_name)
+        Temporal.metrics.timing('workflow_task.latency', time_diff_ms, workflow: workflow_name, namespace: namespace)
         Temporal.logger.debug("Workflow task processed", metadata.to_h.merge(execution_time: time_diff_ms))
       end
 

--- a/spec/unit/lib/temporal/activity/task_processor_spec.rb
+++ b/spec/unit/lib/temporal/activity/task_processor_spec.rb
@@ -125,7 +125,7 @@ describe Temporal::Activity::TaskProcessor do
 
           expect(Temporal.metrics)
             .to have_received(:timing)
-            .with('activity_task.queue_time', an_instance_of(Integer), activity: activity_name)
+            .with('activity_task.queue_time', an_instance_of(Integer), activity: activity_name, namespace: namespace)
         end
 
         it 'sends latency metric' do
@@ -133,7 +133,7 @@ describe Temporal::Activity::TaskProcessor do
 
           expect(Temporal.metrics)
             .to have_received(:timing)
-            .with('activity_task.latency', an_instance_of(Integer), activity: activity_name)
+            .with('activity_task.latency', an_instance_of(Integer), activity: activity_name, namespace: namespace)
         end
 
         context 'with async activity' do
@@ -203,7 +203,7 @@ describe Temporal::Activity::TaskProcessor do
 
           expect(Temporal.metrics)
             .to have_received(:timing)
-            .with('activity_task.queue_time', an_instance_of(Integer), activity: activity_name)
+            .with('activity_task.queue_time', an_instance_of(Integer), activity: activity_name, namespace: namespace)
         end
 
         it 'sends latency metric' do
@@ -211,7 +211,7 @@ describe Temporal::Activity::TaskProcessor do
 
           expect(Temporal.metrics)
             .to have_received(:timing)
-            .with('activity_task.latency', an_instance_of(Integer), activity: activity_name)
+            .with('activity_task.latency', an_instance_of(Integer), activity: activity_name, namespace: namespace)
         end
 
         context 'with ScriptError exception' do

--- a/spec/unit/lib/temporal/workflow/task_processor_spec.rb
+++ b/spec/unit/lib/temporal/workflow/task_processor_spec.rb
@@ -105,7 +105,7 @@ describe Temporal::Workflow::TaskProcessor do
 
           expect(Temporal.metrics)
             .to have_received(:timing)
-            .with('workflow_task.queue_time', an_instance_of(Integer), workflow: workflow_name)
+            .with('workflow_task.queue_time', an_instance_of(Integer), workflow: workflow_name, namespace: namespace)
         end
 
         it 'sends latency metric' do
@@ -113,7 +113,7 @@ describe Temporal::Workflow::TaskProcessor do
 
           expect(Temporal.metrics)
             .to have_received(:timing)
-            .with('workflow_task.latency', an_instance_of(Integer), workflow: workflow_name)
+            .with('workflow_task.latency', an_instance_of(Integer), workflow: workflow_name, namespace: namespace)
         end
       end
 
@@ -170,7 +170,7 @@ describe Temporal::Workflow::TaskProcessor do
 
           expect(Temporal.metrics)
             .to have_received(:timing)
-            .with('workflow_task.queue_time', an_instance_of(Integer), workflow: workflow_name)
+            .with('workflow_task.queue_time', an_instance_of(Integer), workflow: workflow_name, namespace: namespace)
         end
 
         it 'sends latency metric' do
@@ -178,7 +178,7 @@ describe Temporal::Workflow::TaskProcessor do
 
           expect(Temporal.metrics)
             .to have_received(:timing)
-            .with('workflow_task.latency', an_instance_of(Integer), workflow: workflow_name)
+            .with('workflow_task.latency', an_instance_of(Integer), workflow: workflow_name, namespace: namespace)
         end
       end
 


### PR DESCRIPTION
This PR adds the namespace as a tag to the metrics that were missing it. The tag name was chosen to be consistent with the  other times it is used with other metrics in the library. This is helpful to be able to tell if a particular namespace is having issues. The current activity/workflow name tag doesn't have enough context.