### PR TITLE
Populate namespace field to all workflow/activity task RPCs

### DIFF
--- a/lib/temporal/activity/task_processor.rb
+++ b/lib/temporal/activity/task_processor.rb
@@ -54,7 +54,7 @@ module Temporal
 
       attr_reader :task, :namespace, :task_token, :activity_name, :activity_class,
       :middleware_chain, :metadata, :config
-      
+
       def connection
         @connection ||= Temporal::Connection.generate(config.for_connection)
       end
@@ -71,7 +71,7 @@ module Temporal
           Temporal.logger.debug("Failed to report activity task completion, retrying", metadata.to_h)
         end
         Temporal::Connection::Retryer.with_retries(on_retry: log_retry) do
-          connection.respond_activity_task_completed(task_token: task_token, result: result)
+          connection.respond_activity_task_completed(namespace: namespace, task_token: task_token, result: result)
         end
       rescue StandardError => error
         Temporal.logger.error("Unable to complete Activity", metadata.to_h.merge(error: error.inspect))
@@ -85,7 +85,7 @@ module Temporal
           Temporal.logger.debug("Failed to report activity task failure, retrying", metadata.to_h)
         end
         Temporal::Connection::Retryer.with_retries(on_retry: log_retry) do
-          connection.respond_activity_task_failed(task_token: task_token, exception: error)
+          connection.respond_activity_task_failed(namespace: namespace, task_token: task_token, exception: error)
         end
       rescue StandardError => error
         Temporal.logger.error("Unable to fail Activity task", metadata.to_h.merge(error: error.inspect))

--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -174,8 +174,9 @@ module Temporal
         poll_request.execute
       end
 
-      def respond_workflow_task_completed(task_token:, commands:)
+      def respond_workflow_task_completed(namespace:, task_token:, commands:)
         request = Temporal::Api::WorkflowService::V1::RespondWorkflowTaskCompletedRequest.new(
+          namespace: namespace,
           identity: identity,
           task_token: task_token,
           commands: Array(commands).map { |(_, command)| Serializer.serialize(command) }
@@ -183,8 +184,9 @@ module Temporal
         client.respond_workflow_task_completed(request)
       end
 
-      def respond_workflow_task_failed(task_token:, cause:, exception: nil)
+      def respond_workflow_task_failed(namespace:, task_token:, cause:, exception: nil)
         request = Temporal::Api::WorkflowService::V1::RespondWorkflowTaskFailedRequest.new(
+          namespace: namespace,
           identity: identity,
           task_token: task_token,
           cause: cause,
@@ -210,8 +212,9 @@ module Temporal
         poll_request.execute
       end
 
-      def record_activity_task_heartbeat(task_token:, details: nil)
+      def record_activity_task_heartbeat(namespace:, task_token:, details: nil)
         request = Temporal::Api::WorkflowService::V1::RecordActivityTaskHeartbeatRequest.new(
+          namespace: namespace,
           task_token: task_token,
           details: to_details_payloads(details),
           identity: identity
@@ -223,8 +226,9 @@ module Temporal
         raise NotImplementedError
       end
 
-      def respond_activity_task_completed(task_token:, result:)
+      def respond_activity_task_completed(namespace:, task_token:, result:)
         request = Temporal::Api::WorkflowService::V1::RespondActivityTaskCompletedRequest.new(
+          namespace: namespace,
           identity: identity,
           task_token: task_token,
           result: to_result_payloads(result),
@@ -244,8 +248,9 @@ module Temporal
         client.respond_activity_task_completed_by_id(request)
       end
 
-      def respond_activity_task_failed(task_token:, exception:)
+      def respond_activity_task_failed(namespace:, task_token:, exception:)
         request = Temporal::Api::WorkflowService::V1::RespondActivityTaskFailedRequest.new(
+          namespace: namespace,
           identity: identity,
           task_token: task_token,
           failure: Serializer::Failure.new(exception).to_proto
@@ -265,8 +270,9 @@ module Temporal
         client.respond_activity_task_failed_by_id(request)
       end
 
-      def respond_activity_task_canceled(task_token:, details: nil)
+      def respond_activity_task_canceled(namespace:, task_token:, details: nil)
         request = Temporal::Api::WorkflowService::V1::RespondActivityTaskCanceledRequest.new(
+          namespace: namespace,
           task_token: task_token,
           details: to_details_payloads(details),
           identity: identity

--- a/lib/temporal/workflow/task_processor.rb
+++ b/lib/temporal/workflow/task_processor.rb
@@ -90,7 +90,7 @@ module Temporal
       def complete_task(commands)
         Temporal.logger.info("Workflow task completed", metadata.to_h)
 
-        connection.respond_workflow_task_completed(task_token: task_token, commands: commands)
+        connection.respond_workflow_task_completed(namespace: namespace, task_token: task_token, commands: commands)
       end
 
       def fail_task(error)
@@ -103,6 +103,7 @@ module Temporal
         return if task.attempt > MAX_FAILED_ATTEMPTS
 
         connection.respond_workflow_task_failed(
+          namespace: namespace,
           task_token: task_token,
           cause: Temporal::Api::Enums::V1::WorkflowTaskFailedCause::WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED_FAILURE,
           exception: error

--- a/spec/unit/lib/temporal/activity/task_processor_spec.rb
+++ b/spec/unit/lib/temporal/activity/task_processor_spec.rb
@@ -54,6 +54,7 @@ describe Temporal::Activity::TaskProcessor do
         expect(connection)
           .to have_received(:respond_activity_task_failed)
           .with(
+            namespace: namespace,
             task_token: task.task_token,
             exception: an_instance_of(Temporal::ActivityNotRegistered)
           )
@@ -110,7 +111,7 @@ describe Temporal::Activity::TaskProcessor do
 
           expect(connection)
             .to have_received(:respond_activity_task_completed)
-            .with(task_token: task.task_token, result: 'result')
+            .with(namespace: namespace, task_token: task.task_token, result: 'result')
         end
 
         it 'ignores connection exception' do
@@ -171,6 +172,7 @@ describe Temporal::Activity::TaskProcessor do
           expect(connection)
             .to have_received(:respond_activity_task_failed)
             .with(
+              namespace: namespace,
               task_token: task.task_token,
               exception: exception
             )
@@ -224,6 +226,7 @@ describe Temporal::Activity::TaskProcessor do
             expect(connection)
               .to have_received(:respond_activity_task_failed)
               .with(
+                namespace: namespace,
                 task_token: task.task_token,
                 exception: exception
               )
@@ -248,7 +251,11 @@ describe Temporal::Activity::TaskProcessor do
 
             expect(connection)
               .to have_received(:respond_activity_task_failed)
-              .with(task_token: task.task_token, exception: exception)
+              .with(
+                namespace: namespace,
+                task_token: task.task_token,
+                exception: exception
+              )
           end
         end
       end

--- a/spec/unit/lib/temporal/workflow/task_processor_spec.rb
+++ b/spec/unit/lib/temporal/workflow/task_processor_spec.rb
@@ -89,7 +89,7 @@ describe Temporal::Workflow::TaskProcessor do
 
           expect(connection)
             .to have_received(:respond_workflow_task_completed)
-            .with(task_token: task.task_token, commands: commands)
+            .with(namespace: namespace, task_token: task.task_token, commands: commands)
         end
 
         it 'ignores connection exception' do
@@ -128,6 +128,7 @@ describe Temporal::Workflow::TaskProcessor do
           expect(connection)
             .to have_received(:respond_workflow_task_failed)
             .with(
+              namespace: namespace,
               task_token: task.task_token,
               cause: Temporal::Api::Enums::V1::WorkflowTaskFailedCause::WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED_FAILURE,
               exception: exception
@@ -216,6 +217,7 @@ describe Temporal::Workflow::TaskProcessor do
             expect(connection)
               .to have_received(:respond_workflow_task_failed)
               .with(
+                namespace: namespace,
                 task_token: task.task_token,
                 cause: Temporal::Api::Enums::V1::WorkflowTaskFailedCause::WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED_FAILURE,
                 exception: an_instance_of(Temporal::UnexpectedResponse)


### PR DESCRIPTION
The somewhat recently added `namespace` field on workflow & activity task RPCs is critical for any use of an [Authorizer](https://docs.temporal.io/docs/server/security/#authorizer-plugin-interface).

Without this change, the flow is:
1.  Workflow tasks poll successful
2. [locally] Workflow task started
3. [locally] Workflow task finished
4. Workflow task completed -- `#<GRPC::PermissionDenied: 7:Request unauthorized.>`
5. Workflow task failed (failure is also not being reported to the server)

Related auth code:
https://github.com/temporalio/temporal/blob/3c427e6a2d5e7bcdda5868f379a26f6eb578871f/common/authorization/interceptor.go#L126-L137 
