### PR TITLE
Converted WorkflowExecutionAlreadyStartedFailure handling to use RPC status

### DIFF
--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -5,6 +5,7 @@ require 'temporal/connection/errors'
 require 'temporal/connection/serializer'
 require 'temporal/connection/serializer/failure'
 require 'gen/temporal/api/workflowservice/v1/service_services_pb'
+require 'gen/temporal/api/errordetails/v1/message_pb'
 require 'temporal/concerns/payloads'
 
 module Temporal
@@ -117,9 +118,13 @@ module Temporal
 
         client.start_workflow_execution(request)
       rescue ::GRPC::AlreadyExists => e
-        # Feel like there should be cleaner way to do this...
-        run_id = e.details[/RunId: ([a-f0-9]+-[a-f0-9]+-[a-f0-9]+-[a-f0-9]+-[a-f0-9]+)/, 1]
-        raise Temporal::WorkflowExecutionAlreadyStartedFailure.new(e.details, run_id)
+        cast_error = e.to_rpc_status&.details&.map do |any_error|
+          next unless any_error.type_url == 'type.googleapis.com/temporal.api.errordetails.v1.WorkflowExecutionAlreadyStartedFailure'
+
+          any_error.unpack(Temporal::Api::ErrorDetails::V1::WorkflowExecutionAlreadyStartedFailure)
+        end&.compact&.first
+
+        raise Temporal::WorkflowExecutionAlreadyStartedFailure.new(e.details, cast_error&.run_id)
       end
 
       SERVER_MAX_GET_WORKFLOW_EXECUTION_HISTORY_POLL = 30

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@
 
 require 'temporal'
 require 'google/protobuf/well_known_types'
+require 'google/rpc/status_pb'
 require 'pry'
 
 Dir[File.expand_path('config/*.rb', __dir__)].sort.each { |f| require f }


### PR DESCRIPTION
We ran into a condition where the error message changed slightly and we were unable to extract the Run ID. This changes moves to start using the RPC error in a similar way to the [Go SDK](https://github.com/temporalio/sdk-go/blob/93e91e50709017c344a36704fd59ea51d74d26e4/internal/internal_workflow_client.go#L1054-L1061).

