### PR TITLE
Add missing namespace arg for heartbeat, small helper refactor

### DIFF
--- a/examples/spec/helpers.rb
+++ b/examples/spec/helpers.rb
@@ -3,13 +3,10 @@ require 'securerandom'
 module Helpers
   def run_workflow(workflow, *input, **args)
     workflow_id = SecureRandom.uuid
-    run_id = Temporal.start_workflow(
-      workflow,
-      *input,
-      **args.merge(options: { workflow_id: workflow_id })
-    )
+    args[:options] = { workflow_id: workflow_id }.merge(args[:options] || {})
+    run_id = Temporal.start_workflow(workflow, *input, **args)
 
-    return workflow_id, run_id
+    [workflow_id, run_id]
   end
 
   def wait_for_workflow_completion(workflow_id, run_id)
@@ -25,7 +22,7 @@ module Helpers
   def fetch_history(workflow_id, run_id, options = {})
     connection = Temporal.send(:default_client).send(:connection)
 
-    result = connection.get_workflow_execution_history(
+    connection.get_workflow_execution_history(
       {
         namespace: Temporal.configuration.namespace,
         workflow_id: workflow_id,

--- a/examples/spec/helpers.rb
+++ b/examples/spec/helpers.rb
@@ -2,11 +2,10 @@ require 'securerandom'
 
 module Helpers
   def run_workflow(workflow, *input, **args)
-    workflow_id = SecureRandom.uuid
-    args[:options] = { workflow_id: workflow_id }.merge(args[:options] || {})
+    args[:options] = { workflow_id: SecureRandom.uuid }.merge(args[:options] || {})
     run_id = Temporal.start_workflow(workflow, *input, **args)
 
-    [workflow_id, run_id]
+    [args[:options][:workflow_id], run_id]
   end
 
   def wait_for_workflow_completion(workflow_id, run_id)

--- a/examples/spec/integration/activity_cancellation_spec.rb
+++ b/examples/spec/integration/activity_cancellation_spec.rb
@@ -1,10 +1,8 @@
 require 'workflows/long_workflow'
 
-describe 'Activity cancellation' do
-  let(:workflow_id) { SecureRandom.uuid }
-
+describe 'Activity cancellation', :integration do
   it 'cancels a running activity' do
-    run_id = Temporal.start_workflow(LongWorkflow, options: { workflow_id: workflow_id })
+    workflow_id, run_id = run_workflow(LongWorkflow)
 
     # Signal workflow after starting, allowing it to schedule the first activity
     sleep 0.5
@@ -22,8 +20,7 @@ describe 'Activity cancellation' do
 
   it 'cancels a non-started activity' do
     # Workflow is started with a signal which will cancel an activity before it has started
-    run_id = Temporal.start_workflow(LongWorkflow, options: {
-      workflow_id: workflow_id,
+    workflow_id, run_id = run_workflow(LongWorkflow, options: {
       signal_name: :CANCEL
     })
 

--- a/lib/temporal/activity/context.rb
+++ b/lib/temporal/activity/context.rb
@@ -32,7 +32,7 @@ module Temporal
 
       def heartbeat(details = nil)
         logger.debug("Activity heartbeat", metadata.to_h)
-        connection.record_activity_task_heartbeat(task_token: task_token, details: details)
+        connection.record_activity_task_heartbeat(namespace: metadata.namespace, task_token: task_token, details: details)
       end
 
       def heartbeat_details

--- a/spec/unit/lib/temporal/activity/context_spec.rb
+++ b/spec/unit/lib/temporal/activity/context_spec.rb
@@ -17,7 +17,7 @@ describe Temporal::Activity::Context do
 
       expect(client)
         .to have_received(:record_activity_task_heartbeat)
-        .with(task_token: metadata.task_token, details: nil)
+        .with(namespace: metadata.namespace, task_token: metadata.task_token, details: nil)
     end
 
     it 'records heartbeat with details' do
@@ -25,7 +25,7 @@ describe Temporal::Activity::Context do
 
       expect(client)
         .to have_received(:record_activity_task_heartbeat)
-        .with(task_token: metadata.task_token, details: { foo: :bar })
+        .with(namespace: metadata.namespace, task_token: metadata.task_token, details: { foo: :bar })
     end
   end
 


### PR DESCRIPTION
Add the missing namespace argument to the `record_activity_task_heartbeat` client method. Fixes the `activity_cancellation_spec` failure.

Also refactored the `run_workflow` helper slightly to allow override to `options[:workflow_id]` and modified the failing spec file to use the helper.