### PR TITLE
Improvements to upsert_search_attributes

### DIFF
--- a/examples/spec/integration/upsert_search_attributes_spec.rb
+++ b/examples/spec/integration/upsert_search_attributes_spec.rb
@@ -1,7 +1,7 @@
 require 'workflows/upsert_search_attributes_workflow'
 
-describe 'Temporal::Workflow::Context.upsert_search_attributes', :integration do 
-  it 'can upsert a search attribute and then retrieve it' do 
+describe 'Temporal::Workflow::Context.upsert_search_attributes', :integration do
+  it 'can upsert a search attribute and then retrieve it' do
     workflow_id = 'upsert_search_attributes_test_wf-' + SecureRandom.uuid
 
     expected_attributes = {
@@ -9,6 +9,7 @@ describe 'Temporal::Workflow::Context.upsert_search_attributes', :integration do
       'CustomBoolField' => true,
       'CustomDoubleField' => 3.14,
       'CustomIntField' => 0,
+      'CustomDatetimeField' => Time.now.utc.strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
 
     run_id = Temporal.start_workflow(
@@ -27,8 +28,8 @@ describe 'Temporal::Workflow::Context.upsert_search_attributes', :integration do
     expect(added_attributes).to eq(expected_attributes)
 
     execution_info = Temporal.fetch_workflow_execution_info(
-      integration_spec_namespace, 
-      workflow_id, 
+      integration_spec_namespace,
+      workflow_id,
       nil
     )
     expect(execution_info.search_attributes).to eq(expected_attributes)

--- a/examples/spec/integration/upsert_search_attributes_spec.rb
+++ b/examples/spec/integration/upsert_search_attributes_spec.rb
@@ -1,4 +1,5 @@
 require 'workflows/upsert_search_attributes_workflow'
+require 'time'
 
 describe 'Temporal::Workflow::Context.upsert_search_attributes', :integration do
   it 'can upsert a search attribute and then retrieve it' do
@@ -9,7 +10,7 @@ describe 'Temporal::Workflow::Context.upsert_search_attributes', :integration do
       'CustomBoolField' => true,
       'CustomDoubleField' => 3.14,
       'CustomIntField' => 0,
-      'CustomDatetimeField' => Time.now.utc.strftime("%Y-%m-%dT%H:%M:%SZ"),
+      'CustomDatetimeField' => Time.now.utc.iso8601,
     }
 
     run_id = Temporal.start_workflow(

--- a/examples/workflows/upsert_search_attributes_workflow.rb
+++ b/examples/workflows/upsert_search_attributes_workflow.rb
@@ -1,17 +1,18 @@
 class UpsertSearchAttributesWorkflow < Temporal::Workflow
-  def execute(string_value, bool_value, float_value, int_value)
+  # time_value example: use this format: Time.now.utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+  def execute(string_value, bool_value, float_value, int_value, time_value)
     # These are included in the default temporal docker setup.
     # Run tctl admin cluster get-search-attributes to list the options and
     # See https://docs.temporal.io/docs/tctl/how-to-add-a-custom-search-attribute-to-a-cluster-using-tctl
     # for instructions on adding them.
-    attributes = { 
+    attributes = {
       'CustomStringField' => string_value,
       'CustomBoolField' => bool_value,
       'CustomDoubleField' => float_value,
       'CustomIntField' => int_value,
+      'CustomDatetimeField' => time_value,
     }
     workflow.upsert_search_attributes(attributes)
-
     attributes
   end
 end

--- a/lib/temporal/testing/local_workflow_context.rb
+++ b/lib/temporal/testing/local_workflow_context.rb
@@ -196,9 +196,7 @@ module Temporal
 
       def upsert_search_attributes(search_attributes)
         Temporal::Workflow::Context::Validators.validate_search_attributes(search_attributes)
-
-        # We no-op in local testing mode since there is no search functionality.  We don't fail because we 
-        # don't want to block workflows testing other aspects.
+        execution.upsert_search_attributes(search_attributes)
       end
 
       private

--- a/lib/temporal/testing/local_workflow_context.rb
+++ b/lib/temporal/testing/local_workflow_context.rb
@@ -5,7 +5,7 @@ require 'temporal/execution_options'
 require 'temporal/metadata/activity'
 require 'temporal/workflow/future'
 require 'temporal/workflow/history/event_target'
-require 'temporal/workflow/context_validators'
+require 'temporal/workflow/context_helpers'
 
 module Temporal
   module Testing
@@ -195,7 +195,7 @@ module Temporal
       end
 
       def upsert_search_attributes(search_attributes)
-        Temporal::Workflow::Context::Validators.validate_search_attributes(search_attributes)
+        search_attributes = Temporal::Workflow::Context::Helpers.process_search_attributes(search_attributes)
         execution.upsert_search_attributes(search_attributes)
       end
 

--- a/lib/temporal/testing/temporal_override.rb
+++ b/lib/temporal/testing/temporal_override.rb
@@ -31,7 +31,6 @@ module Temporal
 
       def fetch_workflow_execution_info(_namespace, workflow_id, run_id)
         return super if Temporal::Testing.disabled?
-
         execution = executions[[workflow_id, run_id]]
 
         Workflow::ExecutionInfo.new(
@@ -42,6 +41,7 @@ module Temporal
           close_time: nil,
           status: execution.status,
           history_length: nil,
+          search_attributes: execution.search_attributes,
         ).freeze
       end
 

--- a/lib/temporal/testing/workflow_execution.rb
+++ b/lib/temporal/testing/workflow_execution.rb
@@ -3,11 +3,12 @@ require 'temporal/testing/future_registry'
 module Temporal
   module Testing
     class WorkflowExecution
-      attr_reader :status
+      attr_reader :status, :search_attributes
 
       def initialize
         @status = Workflow::ExecutionInfo::RUNNING_STATUS
         @futures = FutureRegistry.new
+        @search_attributes = {}
       end
 
       def run(&block)
@@ -34,6 +35,10 @@ module Temporal
       def fail_activity(token, exception)
         futures.fail(token, exception)
         resume
+      end
+
+      def upsert_search_attributes(search_attributes)
+        @search_attributes.merge!(search_attributes)
       end
 
       private

--- a/lib/temporal/workflow/context.rb
+++ b/lib/temporal/workflow/context.rb
@@ -352,9 +352,14 @@ module Temporal
       end
 
       # @param search_attributes [Hash]
-      # replaces or adds the values of your custom search attributes specified during a workflow's execution.
+      #   If an attribute is registered as a Datetime, you must pass it in this format, for example if you're getting
+      #   the current time:
+      #     workflow.now.utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+      #
+      # Replaces or adds the values of your custom search attributes specified during a workflow's execution.
       # To use this your server must support ElasticSearch, and the attributes must be pre-configured
       # See https://docs.temporal.io/docs/concepts/what-is-a-search-attribute/
+
       def upsert_search_attributes(search_attributes)
         Validators.validate_search_attributes(search_attributes)
         command = Command::UpsertSearchAttributes.new(

--- a/lib/temporal/workflow/context.rb
+++ b/lib/temporal/workflow/context.rb
@@ -5,7 +5,7 @@ require 'temporal/errors'
 require 'temporal/thread_local_context'
 require 'temporal/workflow/history/event_target'
 require 'temporal/workflow/command'
-require 'temporal/workflow/context_validators'
+require 'temporal/workflow/context_helpers'
 require 'temporal/workflow/future'
 require 'temporal/workflow/replay_aware_logger'
 require 'temporal/workflow/state_manager'
@@ -351,21 +351,25 @@ module Temporal
         future
       end
 
-      # @param search_attributes [Hash]
-      #   If an attribute is registered as a Datetime, you must pass it in this format, for example if you're getting
-      #   the current time:
-      #     workflow.now.utc.strftime("%Y-%m-%dT%H:%M:%SZ")
-      #
       # Replaces or adds the values of your custom search attributes specified during a workflow's execution.
-      # To use this your server must support ElasticSearch, and the attributes must be pre-configured
+      # To use this your server must support Elasticsearch, and the attributes must be pre-configured
       # See https://docs.temporal.io/docs/concepts/what-is-a-search-attribute/
-
+      #
+      # @param search_attributes [Hash]
+      #   If an attribute is registered as a Datetime, you can pass in a Time: e.g.
+      #     workflow.now
+      #   or as a string in UTC ISO-8601 format:
+      #     workflow.now.utc.iso8601
+      #   It would look like: "2022-03-01T17:39:06Z"
+      # @return [Hash] the search attributes after any preprocessing.
+      #
       def upsert_search_attributes(search_attributes)
-        Validators.validate_search_attributes(search_attributes)
+        search_attributes = Helpers.process_search_attributes(search_attributes)
         command = Command::UpsertSearchAttributes.new(
           search_attributes: search_attributes
         )
         schedule_command(command)
+        search_attributes
       end
 
       private

--- a/lib/temporal/workflow/context_helpers.rb
+++ b/lib/temporal/workflow/context_helpers.rb
@@ -1,11 +1,11 @@
-
+require 'time'
 module Temporal
   class Workflow
     class Context
       # Shared between Context and LocalWorkflowContext so we can do the same validations in test and production.
-      module Validators
+      module Helpers
 
-        def self.validate_search_attributes(search_attributes)
+        def self.process_search_attributes(search_attributes)
           if search_attributes.nil?
             raise ArgumentError, 'search_attributes cannot be nil'
           end
@@ -14,6 +14,14 @@ module Temporal
           end
           if search_attributes.empty?
             raise ArgumentError, "Cannot upsert an empty hash for search_attributes, as this would do nothing."
+          end
+          search_attributes.transform_values do |attribute|
+            if attribute.is_a?(Time)
+              # The server expects UTC times in the standard format.
+              attribute.utc.iso8601
+            else
+              attribute
+            end
           end
         end
       end

--- a/spec/unit/lib/temporal/testing/local_workflow_context_spec.rb
+++ b/spec/unit/lib/temporal/testing/local_workflow_context_spec.rb
@@ -1,6 +1,7 @@
 require 'temporal/testing'
 require 'temporal/workflow'
 require 'temporal/api/errordetails/v1/message_pb'
+require 'time'
 
 describe Temporal::Testing::LocalWorkflowContext do
   let(:workflow_id) { 'workflow_id_1' }
@@ -206,7 +207,7 @@ describe Temporal::Testing::LocalWorkflowContext do
           workflow_context.upsert_search_attributes(nil)
         end.to raise_error(ArgumentError, 'search_attributes cannot be nil')
       end
-  
+
       it 'requires a hash' do
         expect do
           workflow_context.upsert_search_attributes(['array_not_supported'])
@@ -217,6 +218,13 @@ describe Temporal::Testing::LocalWorkflowContext do
         expect do
           workflow_context.upsert_search_attributes({})
         end.to raise_error(ArgumentError, 'Cannot upsert an empty hash for search_attributes, as this would do nothing.')
+      end
+
+      it 'converts a Time to the ISO8601 UTC format expected by the Temporal server' do
+        time = Time.now
+        expect(
+          workflow_context.upsert_search_attributes({'CustomDatetimeField' => time})
+        ).to eq({ 'CustomDatetimeField' => time.utc.iso8601 })
       end
     end
   end

--- a/spec/unit/lib/temporal/testing/temporal_override_spec.rb
+++ b/spec/unit/lib/temporal/testing/temporal_override_spec.rb
@@ -13,6 +13,15 @@ describe Temporal::Testing::TemporalOverride do
     def execute; end
   end
 
+  class UpsertSearchAttributesWorkflow < Temporal::Workflow
+    namespace 'default-namespace'
+    task_queue 'default-task-queue'
+
+    def execute
+      workflow.upsert_search_attributes('CustomIntField' => 5)
+    end
+  end
+
   context 'when testing mode is disabled' do
     describe 'Temporal.start_workflow' do
       let(:connection) { instance_double('Temporal::Connection::GRPC') }
@@ -139,7 +148,7 @@ describe Temporal::Testing::TemporalOverride do
       it 'explicitly does not support staring a workflow with a signal' do
         expect {
           client.start_workflow(TestTemporalOverrideWorkflow, options: { signal_name: 'breakme' })
-        }.to raise_error(NotImplementedError) do |e| 
+        }.to raise_error(NotImplementedError) do |e|
           expect(e.message).to eql("Signals are not available when Temporal::Testing.local! is on")
         end
       end
@@ -259,6 +268,23 @@ describe Temporal::Testing::TemporalOverride do
             end
           end
         end
+      end
+
+      describe 'Temporal.fetch_workflow_execution_info' do
+        it 'retrieves search attributes' do
+          workflow_id = 'upsert_search_attributes_test_wf-' + SecureRandom.uuid
+
+          run_id = client.start_workflow(
+            UpsertSearchAttributesWorkflow,
+            options: {
+              workflow_id: workflow_id,
+            },
+          )
+
+          info = client.fetch_workflow_execution_info('default-namespace', workflow_id, run_id)
+          expect(info.search_attributes).to eq({'CustomIntField' => 5})
+        end
+
       end
     end
   end

--- a/spec/unit/lib/temporal/workflow/context_spec.rb
+++ b/spec/unit/lib/temporal/workflow/context_spec.rb
@@ -1,5 +1,6 @@
 require 'temporal/workflow'
 require 'temporal/workflow/context'
+require 'time'
 
 class MyTestWorkflow < Temporal::Workflow; end
 
@@ -33,8 +34,17 @@ describe Temporal::Workflow::Context do
     it 'creates a command to execute the request' do
       expect(state_manager).to receive(:schedule)
         .with an_instance_of(Temporal::Workflow::Command::UpsertSearchAttributes)
-      workflow_context.upsert_search_attributes({'CustomIntField' => 5})
+      workflow_context.upsert_search_attributes({ 'CustomIntField' => 5 })
     end
 
+    it 'converts a Time to the ISO8601 UTC format expected by the Temporal server' do
+      time = Time.now
+      allow(state_manager).to receive(:schedule)
+        .with an_instance_of(Temporal::Workflow::Command::UpsertSearchAttributes)
+
+      expect(
+        workflow_context.upsert_search_attributes({'CustomDatetimeField' => time})
+      ).to eq({ 'CustomDatetimeField' => time.utc.iso8601 })
+    end
   end
 end


### PR DESCRIPTION
1) Make it work in local test mode by caching the attributes on `WorkflowExecution`
2) Figured out how to pass a Datetime into temporal and updated the test and docs accordingly
3) Allow people to pass a `Time` in which gets converted under the hood to the appropriate format.

# Test Plan

Local testing: `rspec ./spec/unit/lib/temporal/testing/temporal_override_spec.rb`
Integration with datetime: 
```
# Terminal 1
cd examples
./bin/worker
# Terminal 2
rspec ./spec/integration/upsert_search_attributes_spec.rb`
```

