### PR TITLE
Remove error logspew when workers shutdown

### DIFF
--- a/lib/temporal/activity/poller.rb
+++ b/lib/temporal/activity/poller.rb
@@ -75,6 +75,9 @@ module Temporal
 
       def poll_for_task
         connection.poll_activity_task_queue(namespace: namespace, task_queue: task_queue)
+      rescue ::GRPC::Cancelled
+        # We're shutting down and we've already reported that in the logs
+        nil
       rescue StandardError => error
         Temporal.logger.error("Unable to poll activity task queue", { namespace: namespace, task_queue: task_queue, error: error.inspect })
 

--- a/lib/temporal/workflow/poller.rb
+++ b/lib/temporal/workflow/poller.rb
@@ -29,7 +29,7 @@ module Temporal
 
       def stop_polling
         @shutting_down = true
-        Temporal.logger.info('Shutting down a workflow poller')
+        Temporal.logger.info('Shutting down a workflow poller', { namespace: namespace, task_queue: task_queue })
       end
 
       def cancel_pending_requests

--- a/lib/temporal/workflow/poller.rb
+++ b/lib/temporal/workflow/poller.rb
@@ -1,3 +1,4 @@
+require 'grpc/errors'
 require 'temporal/connection'
 require 'temporal/thread_pool'
 require 'temporal/middleware/chain'
@@ -75,6 +76,9 @@ module Temporal
 
       def poll_for_task
         connection.poll_workflow_task_queue(namespace: namespace, task_queue: task_queue)
+      rescue ::GRPC::Cancelled
+        # We're shutting down and we've already reported that in the logs
+        nil
       rescue StandardError => error
         Temporal.logger.error("Unable to poll Workflow task queue", { namespace: namespace, task_queue: task_queue, error: error.inspect })
         Temporal::ErrorHandler.handle(error, config)


### PR DESCRIPTION
# Description
Upon worker shutdown, we see

```
^CI, [2022-03-01T10:23:31.365933 #37552]  INFO -- temporal_client: Shutting down a workflow poller {}
I, [2022-03-01T10:23:31.366013 #37552]  INFO -- temporal_client: Shutting down a workflow poller {}
I, [2022-03-01T10:23:31.366046 #37552]  INFO -- temporal_client: Shutting down activity poller {"namespace":"ruby-samples","task_queue":"general"}
I, [2022-03-01T10:23:31.366069 #37552]  INFO -- temporal_client: Shutting down activity poller {"namespace":"ruby-samples","task_queue":"file-processing"}
E, [2022-03-01T10:23:32.371431 #37552] ERROR -- temporal_client: Unable to poll Workflow task queue {"namespace":"ruby-samples","task_queue":"general","error":"#<GRPC::Cancelled: 1:Cancelled. debug_error_string:{\"created\":\"@1646159012.369890000\",\"description\":\"Error received from peer ipv6:[::1]:7233\",\"file\":\"src/core/lib/surface/call.cc\",\"file_line\":1070,\"grpc_message\":\"Cancelled\",\"grpc_status\":1}>"}
E, [2022-03-01T10:23:32.371874 #37552] ERROR -- temporal_client: Unable to poll Workflow task queue {"namespace":"ruby-samples","task_queue":"file-processing","error":"#<GRPC::Cancelled: 1:Cancelled. debug_error_string:{\"created\":\"@1646159012.370120000\",\"description\":\"Error received from peer ipv6:[::1]:7233\",\"file\":\"src/core/lib/surface/call.cc\",\"file_line\":1070,\"grpc_message\":\"Cancelled\",\"grpc_status\":1}>"}
E, [2022-03-01T10:23:32.372262 #37552] ERROR -- temporal_client: Unable to poll activity task queue {"namespace":"ruby-samples","task_queue":"general","error":"#<GRPC::Cancelled: 1:Cancelled. debug_error_string:{\"created\":\"@1646159012.370372000\",\"description\":\"Error received from peer ipv6:[::1]:7233\",\"file\":\"src/core/lib/surface/call.cc\",\"file_line\":1070,\"grpc_message\":\"Cancelled\",\"grpc_status\":1}>"}
E, [2022-03-01T10:23:32.372556 #37552] ERROR -- temporal_client: Unable to poll activity task queue {"namespace":"ruby-samples","task_queue":"file-processing","error":"#<GRPC::Cancelled: 1:Cancelled. debug_error_string:{\"created\":\"@1646159012.370682000\",\"description\":\"Error received from peer ipv6:[::1]:7233\",\"file\":\"src/core/lib/surface/call.cc\",\"file_line\":1070,\"grpc_message\":\"Cancelled\",\"grpc_status\":1}>"}
```

At least 5 engineers have been confused by these errors on different occasions, thinking that they indicate a problem.  So I've removed them.  The shutdown now removes the errors

# Test Plan
Ctrl+C the worker:

```
coinbase/temporal-ruby/examples $ ./bin/worker 
D, [2022-03-01T10:42:32.442291 #42299] DEBUG -- metrics: workflow_poller.time_since_last_poll | timing | 0 | namespace:ruby-samples,task_queue:general
D, [2022-03-01T10:42:32.444093 #42299] DEBUG -- temporal_client: Polling workflow task queue {"namespace":"ruby-samples","task_queue":"general"}
D, [2022-03-01T10:42:32.442841 #42299] DEBUG -- metrics: activity_poller.time_since_last_poll | timing | 0 | namespace:ruby-samples,task_queue:general
D, [2022-03-01T10:42:32.450068 #42299] DEBUG -- temporal_client: Polling activity task queue {"namespace":"ruby-samples","task_queue":"general"}
D, [2022-03-01T10:42:32.443123 #42299] DEBUG -- metrics: workflow_poller.time_since_last_poll | timing | 0 | namespace:ruby-samples,task_queue:file-processing
D, [2022-03-01T10:42:32.454926 #42299] DEBUG -- temporal_client: Polling workflow task queue {"namespace":"ruby-samples","task_queue":"file-processing"}
D, [2022-03-01T10:42:32.443612 #42299] DEBUG -- metrics: activity_poller.time_since_last_poll | timing | 2 | namespace:ruby-samples,task_queue:file-processing
D, [2022-03-01T10:42:32.460494 #42299] DEBUG -- temporal_client: Polling activity task queue {"namespace":"ruby-samples","task_queue":"file-processing"}
^CI, [2022-03-01T10:42:33.811122 #42299]  INFO -- temporal_client: Shutting down a workflow poller {"namespace":"ruby-samples","task_queue":"general"}
I, [2022-03-01T10:42:33.811224 #42299]  INFO -- temporal_client: Shutting down a workflow poller {"namespace":"ruby-samples","task_queue":"file-processing"}
I, [2022-03-01T10:42:33.811266 #42299]  INFO -- temporal_client: Shutting down activity poller {"namespace":"ruby-samples","task_queue":"general"}
I, [2022-03-01T10:42:33.811293 #42299]  INFO -- temporal_client: Shutting down activity poller {"namespace":"ruby-samples","task_queue":"file-processing"}
```
