### PR TITLE
Updating register namespace

### DIFF
--- a/examples/spec/integration/register_namespace_spec.rb
+++ b/examples/spec/integration/register_namespace_spec.rb
@@ -24,7 +24,6 @@ describe 'Temporal.register_namespace' do
       break if result.next_page_token == ''
 
       next_page_token = result.next_page_token
-      end
     end
 
     expect(found_namespace).to_not eq(nil)

--- a/examples/spec/integration/register_namespace_spec.rb
+++ b/examples/spec/integration/register_namespace_spec.rb
@@ -16,7 +16,7 @@ describe 'Temporal.register_namespace' do
     next_page_token = ''
 
     while found_namespace.nil?
-      result = Temporal.list_namespaces(page_size: 5, next_page_token: next_page_token)
+      result = Temporal.list_namespaces(page_size: 100, next_page_token: next_page_token)
       result.namespaces.each do |namespace|
         if namespace.namespace_info.name == name
           found_namespace = namespace
@@ -37,10 +37,10 @@ describe 'Temporal.register_namespace' do
     expect(found_namespace.config.workflow_execution_retention_ttl.seconds).to eq(retention_period * 24 * 60 * 60)
   end
 
-#   it 'errors if attempting to register a namespace with the same name' do
-#     name = "test_namespace_#{SecureRandom.uuid}"
-#     Temporal.register_namespace(name)
+  it 'errors if attempting to register a namespace with the same name' do
+    name = "test_namespace_#{SecureRandom.uuid}"
+    Temporal.register_namespace(name)
     
-#     expect {Temporal.register_namespace(name)}.to raise_error(Temporal::NamespaceAlreadyExistsFailure, 'Namespace already exists.')
-#   end
+    expect {Temporal.register_namespace(name)}.to raise_error(Temporal::NamespaceAlreadyExistsFailure, 'Namespace already exists.')
+  end
 end

--- a/examples/spec/integration/register_namespace_spec.rb
+++ b/examples/spec/integration/register_namespace_spec.rb
@@ -1,0 +1,46 @@
+require 'workflows/timeout_workflow'
+
+describe 'Temporal.register_namespace' do
+  it 'can register a new namespace' do
+    # have to generate a new namespace on each run because currently can't delete namespaces
+    name = "test_namespace_#{SecureRandom.uuid}"
+    description = 'this is the description'
+    retention_period = 30
+    namespace_data = { test: 'value' }
+
+    result = Temporal.register_namespace(name, description, retention_period: retention_period, namespace_data: namespace_data)
+    expect(result).to be_an_instance_of(Temporal::Api::WorkflowService::V1::RegisterNamespaceResponse)
+
+    # fetch the namespace from Temporal and check it exists and has the correct settings
+    found_namespace = nil
+    next_page_token = ''
+
+    while found_namespace.nil?
+      result = Temporal.list_namespaces(page_size: 5, next_page_token: next_page_token)
+      result.namespaces.each do |namespace|
+        if namespace.namespace_info.name == name
+          found_namespace = namespace
+          break
+        end
+      end
+
+      if result.next_page_token == ''
+        break
+      else
+        next_page_token = result.next_page_token
+      end
+    end
+
+    expect(found_namespace).to_not eq(nil)
+    expect(found_namespace.namespace_info.name).to eq(name)
+    expect(found_namespace.namespace_info.data).to eq(namespace_data)
+    expect(found_namespace.config.workflow_execution_retention_ttl.seconds).to eq(retention_period * 24 * 60 * 60)
+  end
+
+#   it 'errors if attempting to register a namespace with the same name' do
+#     name = "test_namespace_#{SecureRandom.uuid}"
+#     Temporal.register_namespace(name)
+    
+#     expect {Temporal.register_namespace(name)}.to raise_error(Temporal::NamespaceAlreadyExistsFailure, 'Namespace already exists.')
+#   end
+end

--- a/examples/spec/integration/register_namespace_spec.rb
+++ b/examples/spec/integration/register_namespace_spec.rb
@@ -1,14 +1,12 @@
-require 'workflows/timeout_workflow'
-
 describe 'Temporal.register_namespace' do
   it 'can register a new namespace' do
     # have to generate a new namespace on each run because currently can't delete namespaces
     name = "test_namespace_#{SecureRandom.uuid}"
     description = 'this is the description'
-    retention_period_days = 30
+    retention_period = 30
     data = { test: 'value' }
 
-    Temporal.register_namespace(name, description, retention_period_days: retention_period_days, data: data)
+    Temporal.register_namespace(name, description, retention_period: retention_period, data: data)
 
     # fetch the namespace from Temporal and check it exists and has the correct settings 
     # (need to wait a few seconds for temporal to catch up so try a few times)
@@ -21,7 +19,7 @@ describe 'Temporal.register_namespace' do
          
         expect(result.namespace_info.name).to eq(name)
         expect(result.namespace_info.data).to eq(data)
-        expect(result.config.workflow_execution_retention_ttl.seconds).to eq(retention_period_days * 24 * 60 * 60)
+        expect(result.config.workflow_execution_retention_ttl.seconds).to eq(retention_period * 24 * 60 * 60)
         break
       rescue GRPC::NotFound
         sleep 0.5

--- a/examples/spec/integration/register_namespace_spec.rb
+++ b/examples/spec/integration/register_namespace_spec.rb
@@ -13,7 +13,7 @@ describe 'Temporal.register_namespace' do
     # fetch the namespace from Temporal and check it exists and has the correct settings 
     # (need to wait a few seconds for temporal to catch up so try a few times)
     attempts = 0
-    while attempts < 25 do
+    while attempts < 30 do
       attempts += 1
       
       begin
@@ -24,7 +24,7 @@ describe 'Temporal.register_namespace' do
         expect(result.config.workflow_execution_retention_ttl.seconds).to eq(retention_period * 24 * 60 * 60)
         break
       rescue GRPC::NotFound
-        sleep 2
+        sleep 0.5
       end
     end
   end

--- a/examples/spec/integration/register_namespace_spec.rb
+++ b/examples/spec/integration/register_namespace_spec.rb
@@ -17,17 +17,13 @@ describe 'Temporal.register_namespace' do
 
     while found_namespace.nil?
       result = Temporal.list_namespaces(page_size: 100, next_page_token: next_page_token)
-      result.namespaces.each do |namespace|
-        if namespace.namespace_info.name == name
-          found_namespace = namespace
-          break
-        end
+      found_namespace = result.namespaces.find do |namespace|
+        namespace.namespace_info.name == name
       end
 
-      if result.next_page_token == ''
-        break
-      else
-        next_page_token = result.next_page_token
+      break if result.next_page_token == ''
+
+      next_page_token = result.next_page_token
       end
     end
 

--- a/examples/spec/integration/register_namespace_spec.rb
+++ b/examples/spec/integration/register_namespace_spec.rb
@@ -5,10 +5,10 @@ describe 'Temporal.register_namespace' do
     # have to generate a new namespace on each run because currently can't delete namespaces
     name = "test_namespace_#{SecureRandom.uuid}"
     description = 'this is the description'
-    retention_period = 30
+    retention_period_days = 30
     data = { test: 'value' }
 
-    Temporal.register_namespace(name, description, retention_period: retention_period, data: data)
+    Temporal.register_namespace(name, description, retention_period_days: retention_period_days, data: data)
 
     # fetch the namespace from Temporal and check it exists and has the correct settings 
     # (need to wait a few seconds for temporal to catch up so try a few times)
@@ -21,7 +21,7 @@ describe 'Temporal.register_namespace' do
          
         expect(result.namespace_info.name).to eq(name)
         expect(result.namespace_info.data).to eq(data)
-        expect(result.config.workflow_execution_retention_ttl.seconds).to eq(retention_period * 24 * 60 * 60)
+        expect(result.config.workflow_execution_retention_ttl.seconds).to eq(retention_period_days * 24 * 60 * 60)
         break
       rescue GRPC::NotFound
         sleep 0.5

--- a/lib/temporal/client.rb
+++ b/lib/temporal/client.rb
@@ -132,13 +132,12 @@ module Temporal
     #
     # @param name [String] name of the new namespace
     # @param description [String] optional namespace description
-    # @param global [Boolean] flag to set if the namespace is a global namespace or not
-    # @param retention_period [Int] optional retention period in days
-    # @param namespace_data [Hash] A key-value map for any customized purpose that can be retreived with describe_namespace
-    def register_namespace(name, description = nil, global: false, retention_period:  10, data: nil)
-      connection.register_namespace(name: name, description: description, global: global, retention_period: retention_period, data: data)
+    # @param is_global [Boolean] used to distinguish local namespaces from global namespaces
+    # @param retention_period_days [Int] optional  value which specifies how long Temporal will keep workflows after completing
+    # @param namespace_data [Hash] optional key-value map for any customized purpose that can be retreived with describe_namespace
+    def register_namespace(name, description = nil, is_global: false, retention_period_days:  10, data: nil)
+      connection.register_namespace(name: name, description: description, is_global: is_global, retention_period_days: retention_period_days, data: data)
     end
-
 
     # Fetches metadata for a namespace.
     # @param name [String] name of the namespace

--- a/lib/temporal/client.rb
+++ b/lib/temporal/client.rb
@@ -132,9 +132,13 @@ module Temporal
     #
     # @param name [String] name of the new namespace
     # @param description [String] optional namespace description
-    def register_namespace(name, description = nil)
-      connection.register_namespace(name: name, description: description)
+    # @param global [Boolean] flag to set if the namespace is a global namespace or not
+    # @param retention_period [Int] optional retention period in days
+    # @param namespace_data [Hash] A key-value map for any customized purpose
+    def register_namespace(name, description = nil, global: false, retention_period:  10, namespace_data: nil)
+      connection.register_namespace(name: name, description: description, global: global, retention_period: retention_period, namespace_data: namespace_data)
     end
+
 
     # Fetches metadata for a namespace.
     # @param name [String] name of the namespace

--- a/lib/temporal/client.rb
+++ b/lib/temporal/client.rb
@@ -132,7 +132,7 @@ module Temporal
     #
     # @param name [String] name of the new namespace
     # @param description [String] optional namespace description
-    # @param is_global [Boolean] used to distinguish local namespaces from global namespaces
+    # @param is_global [Boolean] used to distinguish local namespaces from global namespaces (https://docs.temporal.io/docs/server/namespaces/#global-namespaces)
     # @param retention_period_days [Int] optional  value which specifies how long Temporal will keep workflows after completing
     # @param namespace_data [Hash] optional key-value map for any customized purpose that can be retreived with describe_namespace
     def register_namespace(name, description = nil, is_global: false, retention_period_days:  10, data: nil)

--- a/lib/temporal/client.rb
+++ b/lib/temporal/client.rb
@@ -133,10 +133,10 @@ module Temporal
     # @param name [String] name of the new namespace
     # @param description [String] optional namespace description
     # @param is_global [Boolean] used to distinguish local namespaces from global namespaces (https://docs.temporal.io/docs/server/namespaces/#global-namespaces)
-    # @param retention_period_days [Int] optional  value which specifies how long Temporal will keep workflows after completing
-    # @param namespace_data [Hash] optional key-value map for any customized purpose that can be retreived with describe_namespace
-    def register_namespace(name, description = nil, is_global: false, retention_period_days:  10, data: nil)
-      connection.register_namespace(name: name, description: description, is_global: is_global, retention_period_days: retention_period_days, data: data)
+    # @param retention_period [Int] optional value which specifies how long Temporal will keep workflows after completing
+    # @param data [Hash] optional key-value map for any customized purpose that can be retreived with describe_namespace
+    def register_namespace(name, description = nil, is_global: false, retention_period: 10, data: nil)
+      connection.register_namespace(name: name, description: description, is_global: is_global, retention_period: retention_period, data: data)
     end
 
     # Fetches metadata for a namespace.

--- a/lib/temporal/client.rb
+++ b/lib/temporal/client.rb
@@ -134,9 +134,9 @@ module Temporal
     # @param description [String] optional namespace description
     # @param global [Boolean] flag to set if the namespace is a global namespace or not
     # @param retention_period [Int] optional retention period in days
-    # @param namespace_data [Hash] A key-value map for any customized purpose
-    def register_namespace(name, description = nil, global: false, retention_period:  10, namespace_data: nil)
-      connection.register_namespace(name: name, description: description, global: global, retention_period: retention_period, namespace_data: namespace_data)
+    # @param namespace_data [Hash] A key-value map for any customized purpose that can be retreived with describe_namespace
+    def register_namespace(name, description = nil, global: false, retention_period:  10, data: nil)
+      connection.register_namespace(name: name, description: description, global: global, retention_period: retention_period, data: data)
     end
 
 

--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -31,13 +31,13 @@ module Temporal
         @poll_request = nil
       end
 
-      def register_namespace(name:, description: nil, is_global: false, retention_period_days: 10, data: nil)
+      def register_namespace(name:, description: nil, is_global: false, retention_period: 10, data: nil)
         request = Temporal::Api::WorkflowService::V1::RegisterNamespaceRequest.new(
           namespace: name,
           description: description,
           is_global_namespace: is_global,
           workflow_execution_retention_period: Google::Protobuf::Duration.new(
-            seconds: (retention_period_days * 24 * 60 * 60).to_i
+            seconds: (retention_period * 24 * 60 * 60).to_i
           ),
           data: data,
         )

--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -37,7 +37,7 @@ module Temporal
           description: description,
           is_global_namespace: global,
           workflow_execution_retention_period: Google::Protobuf::Duration.new(
-            seconds: retention_period * 24 * 60 * 60
+            seconds: (retention_period * 24 * 60 * 60).to_i
           ),
           data: namespace_data,
         )

--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -31,13 +31,13 @@ module Temporal
         @poll_request = nil
       end
 
-      def register_namespace(name:, description: nil, global: false, retention_period: 10, data: nil)
+      def register_namespace(name:, description: nil, is_global: false, retention_period_days: 10, data: nil)
         request = Temporal::Api::WorkflowService::V1::RegisterNamespaceRequest.new(
           namespace: name,
           description: description,
-          is_global_namespace: global,
+          is_global_namespace: is_global,
           workflow_execution_retention_period: Google::Protobuf::Duration.new(
-            seconds: (retention_period * 24 * 60 * 60).to_i
+            seconds: (retention_period_days * 24 * 60 * 60).to_i
           ),
           data: data,
         )

--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -31,14 +31,15 @@ module Temporal
         @poll_request = nil
       end
 
-      def register_namespace(name:, description: nil, global: false, retention_period: 10)
+      def register_namespace(name:, description: nil, global: false, retention_period: 10, namespace_data: nil)
         request = Temporal::Api::WorkflowService::V1::RegisterNamespaceRequest.new(
           namespace: name,
           description: description,
           is_global_namespace: global,
           workflow_execution_retention_period: Google::Protobuf::Duration.new(
             seconds: retention_period * 24 * 60 * 60
-          )
+          ),
+          data: namespace_data,
         )
         client.register_namespace(request)
       rescue ::GRPC::AlreadyExists => e

--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -31,7 +31,7 @@ module Temporal
         @poll_request = nil
       end
 
-      def register_namespace(name:, description: nil, global: false, retention_period: 10, namespace_data: nil)
+      def register_namespace(name:, description: nil, global: false, retention_period: 10, data: nil)
         request = Temporal::Api::WorkflowService::V1::RegisterNamespaceRequest.new(
           namespace: name,
           description: description,
@@ -39,7 +39,7 @@ module Temporal
           workflow_execution_retention_period: Google::Protobuf::Duration.new(
             seconds: (retention_period * 24 * 60 * 60).to_i
           ),
-          data: namespace_data,
+          data: data,
         )
         client.register_namespace(request)
       rescue ::GRPC::AlreadyExists => e

--- a/spec/unit/lib/temporal/client_spec.rb
+++ b/spec/unit/lib/temporal/client_spec.rb
@@ -307,7 +307,7 @@ describe Temporal::Client do
 
       expect(connection)
         .to have_received(:register_namespace)
-        .with(name: 'new-namespace', description: nil, global: false, data: nil, retention_period: 10)
+        .with(name: 'new-namespace', description: nil, is_global: false, data: nil, retention_period_days: 10)
     end
 
     it 'registers namespace with the specified name and description' do
@@ -315,7 +315,7 @@ describe Temporal::Client do
 
       expect(connection)
         .to have_received(:register_namespace)
-        .with(name: 'new-namespace', description: 'namespace description', global: false, data: nil, retention_period: 10)
+        .with(name: 'new-namespace', description: 'namespace description', is_global: false, data: nil, retention_period_days: 10)
     end
   end
 

--- a/spec/unit/lib/temporal/client_spec.rb
+++ b/spec/unit/lib/temporal/client_spec.rb
@@ -307,7 +307,7 @@ describe Temporal::Client do
 
       expect(connection)
         .to have_received(:register_namespace)
-        .with(name: 'new-namespace', description: nil)
+        .with(name: 'new-namespace', description: nil, global: false, namespace_data: nil, retention_period: 10)
     end
 
     it 'registers namespace with the specified name and description' do
@@ -315,7 +315,7 @@ describe Temporal::Client do
 
       expect(connection)
         .to have_received(:register_namespace)
-        .with(name: 'new-namespace', description: 'namespace description')
+        .with(name: 'new-namespace', description: 'namespace description', global: false, namespace_data: nil, retention_period: 10)
     end
   end
 

--- a/spec/unit/lib/temporal/client_spec.rb
+++ b/spec/unit/lib/temporal/client_spec.rb
@@ -307,7 +307,7 @@ describe Temporal::Client do
 
       expect(connection)
         .to have_received(:register_namespace)
-        .with(name: 'new-namespace', description: nil, global: false, namespace_data: nil, retention_period: 10)
+        .with(name: 'new-namespace', description: nil, global: false, data: nil, retention_period: 10)
     end
 
     it 'registers namespace with the specified name and description' do
@@ -315,7 +315,7 @@ describe Temporal::Client do
 
       expect(connection)
         .to have_received(:register_namespace)
-        .with(name: 'new-namespace', description: 'namespace description', global: false, namespace_data: nil, retention_period: 10)
+        .with(name: 'new-namespace', description: 'namespace description', global: false, data: nil, retention_period: 10)
     end
   end
 

--- a/spec/unit/lib/temporal/client_spec.rb
+++ b/spec/unit/lib/temporal/client_spec.rb
@@ -307,7 +307,7 @@ describe Temporal::Client do
 
       expect(connection)
         .to have_received(:register_namespace)
-        .with(name: 'new-namespace', description: nil, is_global: false, data: nil, retention_period_days: 10)
+        .with(name: 'new-namespace', description: nil, is_global: false, data: nil, retention_period: 10)
     end
 
     it 'registers namespace with the specified name and description' do
@@ -315,7 +315,7 @@ describe Temporal::Client do
 
       expect(connection)
         .to have_received(:register_namespace)
-        .with(name: 'new-namespace', description: 'namespace description', is_global: false, data: nil, retention_period_days: 10)
+        .with(name: 'new-namespace', description: 'namespace description', is_global: false, data: nil, retention_period: 10)
     end
   end
 


### PR DESCRIPTION
Currently we can't specify many settings / configs that the register_namespace API provides. This PR adds the ability to set the retention period and the namespace data when registering a namespace with Temporal. 

Also this introduces an integration test (which might be controversial) which registers namespaces and tests the errors. This does create a new namespace which can't be deleted but seems like the only way to integration test this function.