### PR TITLE
Make it easier to debug converter_spec failure.

### DIFF
--- a/examples/spec/integration/converter_spec.rb
+++ b/examples/spec/integration/converter_spec.rb
@@ -1,5 +1,6 @@
 require 'workflows/hello_world_workflow'
 require 'lib/cryptconverter'
+require 'grpc/errors'
 
 describe 'Converter', :integration do
   around(:each) do |example|
@@ -23,7 +24,11 @@ describe 'Converter', :integration do
   it 'can encrypt payloads' do
     workflow_id, run_id = run_workflow(HelloWorldWorkflow, 'Tom')
 
-    wait_for_workflow_completion(workflow_id, run_id)
+    begin
+      wait_for_workflow_completion(workflow_id, run_id)
+    rescue GRPC::DeadlineExceeded
+      raise "Encrypted-payload workflow didn't run.  Make sure you run USE_ENCRYPTION=1 ./bin/worker and try again."
+    end
 
     result = fetch_history(workflow_id, run_id)
 


### PR DESCRIPTION
# Description
several engineers have been confused by this test, which requires a separate `./bin/worker` to be run.
Catch the workflow timeout and give a better error.

# Test Plan
without having run `USE_ENCRYPTION=1 ./bin/worker` ...

```
coinbase/temporal-ruby/examples $ rspec spec/integration/converter_spec.rb 
F

Failures:

  1) Converter can encrypt payloads
     Failure/Error: raise "Encrypted-payload workflow didn't run.  Make sure you run USE_ENCRYPTION=1 ./bin/worker and try again."
     
     RuntimeError:
       Encrypted-payload workflow didn't run.  Make sure you run USE_ENCRYPTION=1 ./bin/worker and try again.
     # ./spec/integration/converter_spec.rb:30:in `rescue in block (2 levels) in <top (required)>'
     # ./spec/integration/converter_spec.rb:27:in `block (2 levels) in <top (required)>'
     # ./spec/integration/converter_spec.rb:16:in `block (2 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # GRPC::DeadlineExceeded:
     #   4:Deadline Exceeded. debug_error_string:{"created":"@1646379849.945682000","description":"Error received from peer ipv6:[::1]:7233","file":"src/core/lib/surface/call.cc","file_line":1070,"grpc_message":"Deadline Exceeded","grpc_status":4}
     #   /Users/drewhoskins/coinbase/temporal-ruby/lib/temporal/connection/grpc.rb:157:in `get_workflow_execution_history'

```
