### PR TITLE
Named signal handlers

### DIFF
--- a/examples/bin/worker
+++ b/examples/bin/worker
@@ -49,6 +49,7 @@ worker.register_workflow(TripBookingWorkflow)
 worker.register_workflow(UpsertSearchAttributesWorkflow)
 worker.register_workflow(WaitForWorkflow)
 worker.register_workflow(WaitForExternalSignalWorkflow)
+worker.register_workflow(WaitForNamedSignalWorkflow)
 
 worker.register_activity(AsyncActivity)
 worker.register_activity(EchoActivity)

--- a/examples/spec/integration/named_signal_handler_spec.rb
+++ b/examples/spec/integration/named_signal_handler_spec.rb
@@ -23,6 +23,19 @@ describe WaitForNamedSignalWorkflow, :integration do
 
         expect(result[:received]).to include({signal_name => [arg1, arg2]})
         expect(result[:counts]).to include({signal_name => 1})
+        expect(result).to eq(
+          {
+            received: {
+              signal_name => [arg1, arg2],
+              'catch-all' => [arg1, arg2]
+            },
+            counts: {
+              signal_name => 1,
+              'catch-all' => 1
+            }
+          }
+        )
+
       end
 
       it 'receives the signal in its catch-all signal handler' do

--- a/examples/spec/integration/named_signal_handler_spec.rb
+++ b/examples/spec/integration/named_signal_handler_spec.rb
@@ -1,0 +1,78 @@
+require 'workflows/wait_for_named_signal_workflow'
+
+describe WaitForNamedSignalWorkflow, :integration do
+  let(:receiver_workflow_id) { SecureRandom.uuid }
+
+  context 'when the signal is named' do
+    let(:arg1) { "arg1" }
+    let(:arg2) { 7890.1234 }
+
+    context 'and the workflow has a named signal handler matching the signal name' do
+      let(:signal_name) { "NamedSignal" }
+
+      it 'receives the signal in its named handler' do
+        _, run_id = run_workflow(WaitForNamedSignalWorkflow, signal_name, options: { workflow_id: receiver_workflow_id})
+
+        Temporal.signal_workflow(WaitForNamedSignalWorkflow, signal_name, receiver_workflow_id, run_id, [arg1, arg2])
+
+        result = Temporal.await_workflow_result(
+          WaitForNamedSignalWorkflow,
+          workflow_id: receiver_workflow_id,
+          run_id: run_id,
+        )
+
+        expect(result).to eq(
+          {
+            received: {
+              signal_name => [arg1, arg2]
+            },
+            counts: {
+              signal_name => 1
+            }
+          }
+        )
+      end
+
+      it 'does NOT receive the signal in its catch-all signal handler' do
+        _, run_id = run_workflow(WaitForNamedSignalWorkflow, signal_name, options: { workflow_id: receiver_workflow_id})
+
+        Temporal.signal_workflow(WaitForNamedSignalWorkflow, signal_name, receiver_workflow_id, run_id, [arg1, arg2])
+
+        result = Temporal.await_workflow_result(
+          WaitForNamedSignalWorkflow,
+          workflow_id: receiver_workflow_id,
+          run_id: run_id,
+        )
+
+        expect(result[:received].keys).to eq([signal_name])
+      end
+    end
+
+    context 'and the workflow does NOT have a named signal handler matching the signal name' do
+      let(:signal_name) { 'doesNOTmatchAsignalHandler' }
+
+      it 'receives the signal in its catch-all signal handler' do
+        _, run_id = run_workflow(WaitForNamedSignalWorkflow, signal_name, options: { workflow_id: receiver_workflow_id})
+
+        Temporal.signal_workflow(WaitForNamedSignalWorkflow, signal_name, receiver_workflow_id, run_id, [arg1, arg2])
+
+        result = Temporal.await_workflow_result(
+          WaitForNamedSignalWorkflow,
+          workflow_id: receiver_workflow_id,
+          run_id: run_id,
+        )
+
+        expect(result).to eq(
+          {
+            received: {
+              'catch-all' => [arg1, arg2]
+            },
+            counts: {
+              'catch-all' => 1
+            }
+          }
+        )
+      end
+    end
+  end
+end

--- a/examples/spec/integration/named_signal_handler_spec.rb
+++ b/examples/spec/integration/named_signal_handler_spec.rb
@@ -21,19 +21,11 @@ describe WaitForNamedSignalWorkflow, :integration do
           run_id: run_id,
         )
 
-        expect(result).to eq(
-          {
-            received: {
-              signal_name => [arg1, arg2]
-            },
-            counts: {
-              signal_name => 1
-            }
-          }
-        )
+        expect(result[:received]).to include({signal_name => [arg1, arg2]})
+        expect(result[:counts]).to include({signal_name => 1})
       end
 
-      it 'does NOT receive the signal in its catch-all signal handler' do
+      it 'receives the signal in its catch-all signal handler' do
         _, run_id = run_workflow(WaitForNamedSignalWorkflow, signal_name, options: { workflow_id: receiver_workflow_id})
 
         Temporal.signal_workflow(WaitForNamedSignalWorkflow, signal_name, receiver_workflow_id, run_id, [arg1, arg2])
@@ -44,7 +36,8 @@ describe WaitForNamedSignalWorkflow, :integration do
           run_id: run_id,
         )
 
-        expect(result[:received].keys).to eq([signal_name])
+        expect(result[:received]).to include({"catch-all" => [arg1, arg2]})
+        expect(result[:counts]).to include({"catch-all" => 1})
       end
     end
 

--- a/examples/workflows/wait_for_named_signal_workflow.rb
+++ b/examples/workflows/wait_for_named_signal_workflow.rb
@@ -1,0 +1,27 @@
+# Can receive signals to its named signal handler. If a signal doesn't match the
+# named handler's signature, then it matches the catch-all signal handler
+#
+class WaitForNamedSignalWorkflow < Temporal::Workflow
+  def execute(expected_signal)
+    signals_received = {}
+    signal_counts = Hash.new { |h,k| h[k] = 0 }
+
+    # catch-all handler
+    workflow.on_signal do |signal, input|
+      workflow.logger.info("Received signal name #{signal}, with input #{input.inspect}")
+      signals_received['catch-all'] = input
+      signal_counts['catch-all'] += 1
+    end
+
+    workflow.on_signal('NamedSignal') do |input|
+      workflow.logger.info("Received signal name NamedSignal, with input #{input.inspect}")
+      signals_received['NamedSignal'] = input
+      signal_counts['NamedSignal'] += 1
+    end
+
+    timeout_timer = workflow.start_timer(1)
+    workflow.wait_for(timeout_timer)
+
+    { received: signals_received, counts: signal_counts }
+  end
+end

--- a/examples/workflows/wait_for_named_signal_workflow.rb
+++ b/examples/workflows/wait_for_named_signal_workflow.rb
@@ -8,13 +8,13 @@ class WaitForNamedSignalWorkflow < Temporal::Workflow
 
     # catch-all handler
     workflow.on_signal do |signal, input|
-      workflow.logger.info("Received signal name #{signal}, with input #{input.inspect}")
+      workflow.logger.info("Received signal name as #{signal}, with input #{input.inspect}")
       signals_received['catch-all'] = input
       signal_counts['catch-all'] += 1
     end
 
     workflow.on_signal('NamedSignal') do |input|
-      workflow.logger.info("Received signal name NamedSignal, with input #{input.inspect}")
+      workflow.logger.info("Received signal name -NamedSignal-, with input #{input.inspect}")
       signals_received['NamedSignal'] = input
       signal_counts['NamedSignal'] += 1
     end

--- a/lib/temporal/workflow/context.rb
+++ b/lib/temporal/workflow/context.rb
@@ -280,11 +280,23 @@ module Temporal
         state_manager.local_time
       end
 
-      def on_signal(&block)
+      # Define a signal handler to receive signals onto the workflow. When
+      # +name+ is defined, this creates a named signal handler which will be
+      # invoked whenever a signal named +name+ is received. A handler without
+      # a set name (defaults to nil) will be the default handler and will receive
+      # all signals that do not match a named signal handler.
+      #
+      # @param name [String, Symbol, nil] an optional signal name; converted to a String
+      def on_signal(handler_name=nil, &block)
         target = History::EventTarget.workflow
 
-        dispatcher.register_handler(target, 'signaled') do |signal, input|
-          call_in_fiber(block, signal, input)
+        dispatcher.register_handler(target, 'signaled', handler_name: handler_name) do |signal, input|
+          if handler_name
+            # do not pass signal name when triggering a named handler
+            call_in_fiber(block, input)
+          else
+            call_in_fiber(block, signal, input)
+          end
         end
       end
 

--- a/lib/temporal/workflow/context.rb
+++ b/lib/temporal/workflow/context.rb
@@ -297,7 +297,7 @@ module Temporal
             call_in_fiber(block, input)
           end
         else
-          dispatcher.register_handler(target, Dispatcher::WILDCARD) do |signal, input|
+          dispatcher.register_handler(Dispatcher::TARGET_WILDCARD, 'signaled') do |signal, input|
             call_in_fiber(block, signal, input)
           end
         end

--- a/lib/temporal/workflow/context.rb
+++ b/lib/temporal/workflow/context.rb
@@ -9,6 +9,7 @@ require 'temporal/workflow/context_helpers'
 require 'temporal/workflow/future'
 require 'temporal/workflow/replay_aware_logger'
 require 'temporal/workflow/state_manager'
+require 'temporal/workflow/signal'
 
 # This context class is available in the workflow implementation
 # and provides context and methods for interacting with Temporal
@@ -288,11 +289,9 @@ module Temporal
       #
       # @param signal_name [String, Symbol, nil] an optional signal name; converted to a String
       def on_signal(signal_name=nil, &block)
-        target = History::EventTarget.workflow
-
         if signal_name
-          event_name = "signaled:#{signal_name}"
-          dispatcher.register_handler(target, event_name) do |_, input|
+          target = Signal.new(signal_name)
+          dispatcher.register_handler(target, 'signaled') do |_, input|
             # do not pass signal name when triggering a named handler
             call_in_fiber(block, input)
           end

--- a/lib/temporal/workflow/context.rb
+++ b/lib/temporal/workflow/context.rb
@@ -286,15 +286,18 @@ module Temporal
       # a set name (defaults to nil) will be the default handler and will receive
       # all signals that do not match a named signal handler.
       #
-      # @param name [String, Symbol, nil] an optional signal name; converted to a String
-      def on_signal(handler_name=nil, &block)
+      # @param signal_name [String, Symbol, nil] an optional signal name; converted to a String
+      def on_signal(signal_name=nil, &block)
         target = History::EventTarget.workflow
 
-        dispatcher.register_handler(target, 'signaled', handler_name: handler_name) do |signal, input|
-          if handler_name
+        if signal_name
+          event_name = "signaled:#{signal_name}"
+          dispatcher.register_handler(target, event_name) do |_, input|
             # do not pass signal name when triggering a named handler
             call_in_fiber(block, input)
-          else
+          end
+        else
+          dispatcher.register_handler(target, Dispatcher::WILDCARD) do |signal, input|
             call_in_fiber(block, signal, input)
           end
         end

--- a/lib/temporal/workflow/dispatcher.rb
+++ b/lib/temporal/workflow/dispatcher.rb
@@ -57,8 +57,13 @@ module Temporal
       end
 
       def find_named_handler(target, event_name, handler_name)
+        # to succeed then +handler_name+ must be non-nil
         handlers[target]
-          .find { |event_struct| event_struct.event_name == event_name && event_struct.handler_name == handler_name }
+          .find do |event_struct|
+          handler_name &&
+            event_struct.event_name == event_name &&
+            event_struct.handler_name == handler_name
+        end
       end
     end
   end

--- a/lib/temporal/workflow/dispatcher.rb
+++ b/lib/temporal/workflow/dispatcher.rb
@@ -4,8 +4,8 @@ module Temporal
     # points to this class, #register_handler and #dispatch.
     #
     # A handler may be associated with a specific event name so when that event occurs
-    # elsewhere in the system we may dispatch the event and execute the handler. By default
-    # we *always* execute the handler associated with the event_name.
+    # elsewhere in the system we may dispatch the event and execute the handler.
+    # We *always* execute the handler associated with the event_name.
     #
     # Optionally, we may register a named handler that is triggered when an event _and
     # an optional handler_name key_ are provided. In this situation, we dispatch to both
@@ -17,14 +17,13 @@ module Temporal
       TARGET_WILDCARD = '*'.freeze
 
       EventStruct = Struct.new(:event_name, :handler)
-      DuplicateNamedHandlerRegistrationError = Class.new(StandardError)
 
       def initialize
         @handlers = Hash.new { |hash, key| hash[key] = [] }
       end
 
       def register_handler(target, event_name, handler_name: nil, &handler)
-        handlers[target] << EventStruct.new(combine(event_name, handler_name), handler)
+        handlers[target] << EventStruct.new(sanitize_handler_name(event_name, handler_name), handler)
         self
       end
 
@@ -39,7 +38,7 @@ module Temporal
       attr_reader :handlers
 
       def handlers_for(target, event_name, handler_name)
-        named_handler = combine(event_name, handler_name)
+        named_handler = sanitize_handler_name(event_name, handler_name)
 
         handlers[target]
           .concat(handlers[TARGET_WILDCARD])
@@ -53,7 +52,7 @@ module Temporal
           event_struct.event_name == WILDCARD
       end
 
-      def combine(event_name, handler_name)
+      def sanitize_handler_name(event_name, handler_name)
         return event_name unless handler_name
         "#{event_name}:#{handler_name}"
       end

--- a/lib/temporal/workflow/signal.rb
+++ b/lib/temporal/workflow/signal.rb
@@ -1,0 +1,5 @@
+module Temporal
+  class Workflow
+    Signal = Struct.new(:signal_name)
+  end
+end

--- a/lib/temporal/workflow/state_manager.rb
+++ b/lib/temporal/workflow/state_manager.rb
@@ -224,7 +224,8 @@ module Temporal
           handle_marker(event.id, event.attributes.marker_name, from_details_payloads(event.attributes.details['data']))
 
         when 'WORKFLOW_EXECUTION_SIGNALED'
-          dispatch(target, 'signaled', event.attributes.signal_name, from_signal_payloads(event.attributes.input), handler_name: event.attributes.signal_name)
+          event_name = "signaled:#{event.attributes.signal_name}"
+          dispatch(target, event_name, event.attributes.signal_name, from_signal_payloads(event.attributes.input))
 
         when 'WORKFLOW_EXECUTION_TERMINATED'
           # todo
@@ -317,8 +318,8 @@ module Temporal
         History::EventTarget.new(command_id, target_type)
       end
 
-      def dispatch(target, name, *attributes, handler_name: nil)
-        dispatcher.dispatch(target, name, attributes, handler_name: handler_name)
+      def dispatch(target, name, *attributes)
+        dispatcher.dispatch(target, name, attributes)
       end
 
       def discard_command(target)

--- a/lib/temporal/workflow/state_manager.rb
+++ b/lib/temporal/workflow/state_manager.rb
@@ -224,7 +224,7 @@ module Temporal
           handle_marker(event.id, event.attributes.marker_name, from_details_payloads(event.attributes.details['data']))
 
         when 'WORKFLOW_EXECUTION_SIGNALED'
-          dispatch(target, 'signaled', event.attributes.signal_name, from_signal_payloads(event.attributes.input))
+          dispatch(target, 'signaled', event.attributes.signal_name, from_signal_payloads(event.attributes.input), handler_name: event.attributes.signal_name)
 
         when 'WORKFLOW_EXECUTION_TERMINATED'
           # todo
@@ -317,8 +317,8 @@ module Temporal
         History::EventTarget.new(command_id, target_type)
       end
 
-      def dispatch(target, name, *attributes)
-        dispatcher.dispatch(target, name, attributes)
+      def dispatch(target, name, *attributes, handler_name: nil)
+        dispatcher.dispatch(target, name, attributes, handler_name: handler_name)
       end
 
       def discard_command(target)

--- a/lib/temporal/workflow/state_manager.rb
+++ b/lib/temporal/workflow/state_manager.rb
@@ -5,6 +5,7 @@ require 'temporal/workflow/command_state_machine'
 require 'temporal/workflow/history/event_target'
 require 'temporal/concerns/payloads'
 require 'temporal/workflow/errors'
+require 'temporal/workflow/signal'
 
 module Temporal
   class Workflow
@@ -224,10 +225,9 @@ module Temporal
           handle_marker(event.id, event.attributes.marker_name, from_details_payloads(event.attributes.details['data']))
 
         when 'WORKFLOW_EXECUTION_SIGNALED'
-          base_event_name = 'signaled'
-          event_name = "#{base_event_name}:#{event.attributes.signal_name}"
-          dispatch(target, base_event_name, event.attributes.signal_name, from_signal_payloads(event.attributes.input))
-          dispatch(target, event_name, event.attributes.signal_name, from_signal_payloads(event.attributes.input))
+          # relies on Signal#== for matching in Dispatcher
+          signal_target = Signal.new(event.attributes.signal_name)
+          dispatch(signal_target, 'signaled', event.attributes.signal_name, from_signal_payloads(event.attributes.input))
 
         when 'WORKFLOW_EXECUTION_TERMINATED'
           # todo

--- a/lib/temporal/workflow/state_manager.rb
+++ b/lib/temporal/workflow/state_manager.rb
@@ -224,7 +224,9 @@ module Temporal
           handle_marker(event.id, event.attributes.marker_name, from_details_payloads(event.attributes.details['data']))
 
         when 'WORKFLOW_EXECUTION_SIGNALED'
-          event_name = "signaled:#{event.attributes.signal_name}"
+          base_event_name = 'signaled'
+          event_name = "#{base_event_name}:#{event.attributes.signal_name}"
+          dispatch(target, base_event_name, event.attributes.signal_name, from_signal_payloads(event.attributes.input))
           dispatch(target, event_name, event.attributes.signal_name, from_signal_payloads(event.attributes.input))
 
         when 'WORKFLOW_EXECUTION_TERMINATED'

--- a/spec/unit/lib/temporal/workflow/dispatcher_spec.rb
+++ b/spec/unit/lib/temporal/workflow/dispatcher_spec.rb
@@ -6,12 +6,74 @@ describe Temporal::Workflow::Dispatcher do
   let(:other_target) { Temporal::Workflow::History::EventTarget.new(2, Temporal::Workflow::History::EventTarget::TIMER_TYPE) }
 
   describe '#register_handler' do
-    it 'stores a given handler against the target' do
-      block = -> { 'handler body' }
+    let(:block) { -> { 'handler body' } }
+    let(:event_name) { 'signaled' }
+    let(:dispatcher) { subject.register_handler(target, event_name, handler_name: handler_name, &block) }
+    let(:handlers) { dispatcher.send(:handlers) }
 
-      subject.register_handler(target, 'signaled', &block)
+    context 'with default handler_name' do
+      let(:handler_name) { nil }
 
-      expect(subject.send(:handlers)).to include(target => [['signaled', block]])
+      it 'stores the target' do
+        expect(handlers.key?(target)).to be true
+      end
+
+      it 'stores the target and handler once' do
+        expect(handlers[target]).to be_kind_of(Array)
+        expect(handlers[target].count).to eq 1
+      end
+
+      it 'associates the event name with the target' do
+        event = handlers[target].first
+        expect(event.event_name).to eq(event_name)
+      end
+
+      it 'associates the handler with the target' do
+        event = handlers[target].first
+        expect(event.handler).to eq(block)
+      end
+
+      it 'defaults to nil for handler_name' do
+        event = handlers[target].first
+        expect(event.handler_name).to be nil
+      end
+    end
+
+    context 'with a specific handler_name' do
+      let(:handler_name) { 'specific name' }
+
+      it 'stores the target' do
+        expect(handlers.key?(target)).to be true
+      end
+
+      it 'stores the target and handler once' do
+        expect(handlers[target]).to be_kind_of(Array)
+        expect(handlers[target].count).to eq 1
+      end
+
+      it 'associates the event name with the target' do
+        event = handlers[target].first
+        expect(event.event_name).to eq(event_name)
+      end
+
+      it 'associates the handler with the target' do
+        event = handlers[target].first
+        expect(event.handler).to eq(block)
+      end
+
+      it 'associates the handler name with the target' do
+        event = handlers[target].first
+        expect(event.handler_name).to eq(handler_name)
+      end
+
+      it 'raises an ArgumentError when named handler is registered twice' do
+        subject.register_handler(target, event_name, handler_name: handler_name, &block)
+
+        # second call!
+        expect do
+          subject.register_handler(target, event_name, handler_name: handler_name, &block)
+        end.to raise_error(described_class::DuplicateNamedHandlerRegistrationError, "Duplicate registration for handler_name #{handler_name}")
+      end
     end
   end
 
@@ -87,6 +149,27 @@ describe Temporal::Workflow::Dispatcher do
 
       it 'TARGET_WILDCARD can be compared to an EventTarget object' do
         expect(target.eql?(described_class::TARGET_WILDCARD)).to be(false)
+      end
+    end
+
+    context 'with a named handler' do
+      let(:handler_7) { -> { 'seventh block' } }
+      let(:handler_name) { 'specific name' }
+      before do
+        allow(handler_7).to receive(:call)
+
+        subject.register_handler(target, 'completed', handler_name: handler_name, &handler_7)
+      end
+
+      it 'calls ONLY the named handler' do
+        subject.dispatch(target, 'completed', handler_name: handler_name)
+
+        expect(handler_7).to have_received(:call)
+
+        expect(handler_1).not_to have_received(:call)
+        expect(handler_2).not_to have_received(:call)
+        expect(handler_3).not_to have_received(:call)
+        expect(handler_4).not_to have_received(:call)
       end
     end
   end

--- a/spec/unit/lib/temporal/workflow/dispatcher_spec.rb
+++ b/spec/unit/lib/temporal/workflow/dispatcher_spec.rb
@@ -8,7 +8,7 @@ describe Temporal::Workflow::Dispatcher do
   describe '#register_handler' do
     let(:block) { -> { 'handler body' } }
     let(:event_name) { 'signaled' }
-    let(:dispatcher) { subject.register_handler(target, event_name, handler_name: handler_name, &block) }
+    let(:dispatcher) { subject.register_handler(target, event_name, &block) }
     let(:handlers) { dispatcher.send(:handlers) }
 
     context 'with default handler_name' do
@@ -36,6 +36,7 @@ describe Temporal::Workflow::Dispatcher do
 
     context 'with a specific handler_name' do
       let(:handler_name) { 'specific name' }
+      let(:event_name) { "signaled:#{handler_name}" }
 
       it 'stores the target' do
         expect(handlers.key?(target)).to be true
@@ -48,8 +49,7 @@ describe Temporal::Workflow::Dispatcher do
 
       it 'associates the event name and handler name with the target' do
         event = handlers[target].first
-        name = "#{event_name}:#{handler_name}"
-        expect(event.event_name).to eq(name)
+        expect(event.event_name).to eq(event_name)
       end
 
       it 'associates the handler with the target' do
@@ -140,7 +140,7 @@ describe Temporal::Workflow::Dispatcher do
       before do
         allow(handler_7).to receive(:call)
 
-        subject.register_handler(target, 'completed', handler_name: handler_name, &handler_7)
+        subject.register_handler(target, 'completed', &handler_7)
       end
 
       it 'calls the named handler and the default' do


### PR DESCRIPTION
Support for named signal handlers, e.g. `on_signal('SOME_NAME') { }`. Always call the "catch-all" signal handler even when a named handler exists.