### PR TITLE
Retrieve workflow cron schedule

### DIFF
--- a/examples/spec/integration/schedule_workflow_spec.rb
+++ b/examples/spec/integration/schedule_workflow_spec.rb
@@ -1,0 +1,51 @@
+require 'workflows/hello_world_workflow'
+
+describe HelloWorldWorkflow do
+  subject { described_class }
+
+  before { allow(HelloWorldActivity).to receive(:execute!).and_call_original }
+
+  it 'can retrieve the workflow schedule via run id' do
+    workflow_id = 'schedule_test_wf'
+    cron_schedule = '*/5 * * * *'
+
+    begin
+      Temporal.terminate_workflow(workflow_id)
+    rescue GRPC::NotFound => _
+      # The test workflow hasn't been scheduled before
+    end
+    
+    run_id = Temporal.schedule_workflow(HelloWorldWorkflow, cron_schedule, options: {workflow_id: workflow_id})
+
+    expect(Temporal.get_cron_schedule('ruby-samples', workflow_id, run_id: run_id)).to eq(cron_schedule)
+  end
+
+  it 'can retrieve the workflow schedule of the latest run' do
+    workflow_id = 'schedule_test_wf'
+    cron_schedule = '*/6 * * * *'
+
+    begin
+      Temporal.terminate_workflow(workflow_id)
+    rescue GRPC::NotFound => _
+      # The test workflow hasn't been scheduled before
+    end
+    
+    Temporal.schedule_workflow(HelloWorldWorkflow, cron_schedule, options: {workflow_id: workflow_id})
+
+    expect(Temporal.get_cron_schedule('ruby-samples', workflow_id)).to eq(cron_schedule)
+  end
+
+  it 'retrieves an empty schedule if no schedule' do
+    workflow_id = 'schedule_test_wf'
+
+    begin
+      Temporal.terminate_workflow(workflow_id)
+    rescue GRPC::NotFound => _
+      # The test workflow hasn't been scheduled before
+    end
+    
+    Temporal.start_workflow(HelloWorldWorkflow, options: {workflow_id: workflow_id})
+
+    expect(Temporal.get_cron_schedule('ruby-samples', workflow_id)).to eq(nil)
+  end
+end

--- a/lib/temporal.rb
+++ b/lib/temporal.rb
@@ -27,7 +27,8 @@ module Temporal
                  :complete_activity,
                  :fail_activity,
                  :list_open_workflow_executions,
-                 :list_closed_workflow_executions
+                 :list_closed_workflow_executions,
+                 :get_cron_schedule
 
   class << self
     def configure(&block)

--- a/lib/temporal/client.rb
+++ b/lib/temporal/client.rb
@@ -372,6 +372,25 @@ module Temporal
       fetch_executions(:closed, { namespace: namespace, from: from, to: to }.merge(filter))
     end
 
+    # Fetch a workflow's cron schedule
+    #
+    # @param namespace [String]
+    # @param workflow_id [String]
+    # @param run_id [String] If not specified, the most recent run will be used
+    #
+    # @return [String] the schedule in crontab format, or nil if there is no schedule
+    def get_cron_schedule(namespace, workflow_id, run_id: nil)
+      history_response = connection.get_workflow_execution_history(
+        namespace: namespace,
+        workflow_id: workflow_id,
+        run_id: run_id
+      )
+      history = Workflow::History.new(history_response.history.events)
+      cron_schedule = history.events.first.attributes.cron_schedule
+
+      cron_schedule == '' ? nil : cron_schedule
+    end
+
     class ResultConverter
       extend Concerns::Payloads
     end

--- a/spec/fabricators/workflow_started_with_cron_history_event_fabricator.rb
+++ b/spec/fabricators/workflow_started_with_cron_history_event_fabricator.rb
@@ -1,0 +1,11 @@
+Fabricator(:workflow_started_with_cron_history_event, from: Temporal::Api::History::V1::HistoryEvent) do
+  transient :cron_schedule
+
+  event_time { Google::Protobuf::Timestamp.new.tap { |t| t.from_time(Time.now) } }
+  event_type { :EVENT_TYPE_WORKFLOW_EXECUTION_STARTED }
+  workflow_execution_started_event_attributes do |attrs|
+    Temporal::Api::History::V1::WorkflowExecutionStartedEventAttributes.new(
+      cron_schedule: attrs[:cron_schedule]
+    )
+  end
+end

--- a/spec/unit/lib/temporal/client_spec.rb
+++ b/spec/unit/lib/temporal/client_spec.rb
@@ -921,4 +921,50 @@ describe Temporal::Client do
       end
     end
   end
+
+  describe '#get_cron_schedule' do
+    it 'returns its schedule' do
+      expected_schedule = '0 0 * * *'
+
+      completed_event = Fabricate(
+        :workflow_started_with_cron_history_event,
+        cron_schedule: expected_schedule
+      )
+      response = Fabricate(:workflow_execution_history, events: [completed_event])
+
+      expect(connection)
+        .to receive(:get_workflow_execution_history)
+        .with(
+          namespace: namespace,
+          workflow_id: workflow_id,
+          run_id: run_id,
+        )
+        .and_return(response)
+
+      schedule = subject.get_cron_schedule(namespace, workflow_id, run_id: run_id)
+
+      expect(schedule).to eq(expected_schedule)
+    end
+
+    it 'returns nil when there is no schedule' do
+      completed_event = Fabricate(
+        :workflow_started_with_cron_history_event,
+        cron_schedule: ''
+      )
+      response = Fabricate(:workflow_execution_history, events: [completed_event])
+
+      expect(connection)
+        .to receive(:get_workflow_execution_history)
+        .with(
+          namespace: namespace,
+          workflow_id: workflow_id,
+          run_id: run_id,
+        )
+        .and_return(response)
+
+      schedule = subject.get_cron_schedule(namespace, workflow_id, run_id: run_id)
+
+      expect(schedule).to be(nil)
+    end
+  end
 end


### PR DESCRIPTION
This implements a `get_workflow_schedule` method on the client which polls the workflow history to obtain its cron schedule from the first event. This can be used to detect if a workflow is running on a cron schedule, and if so that the schedule is correct. A set of integration tests for this method are also included.

On behalf of @evanweissburg

### Test plan
```
cd examples
bundle exec rspec spec/integration/schedule_workflow_spec.rb
bundle exec rspec spec/
cd ..
bundle exec rspec spec/unit
```