### PR TITLE
[wip] expose memo for child workflow execution

### DIFF
--- a/lib/temporal/workflow/context.rb
+++ b/lib/temporal/workflow/context.rb
@@ -112,7 +112,8 @@ module Temporal
           task_queue: execution_options.task_queue,
           retry_policy: execution_options.retry_policy,
           timeouts: execution_options.timeouts,
-          headers: execution_options.headers
+          headers: execution_options.headers,
+          memo: execution_options.memo,
         )
 
         target, cancelation_id = schedule_command(command)


### PR DESCRIPTION
PR #121 exposed Memos across the codebase. Though memo was added to `StartChildWorkflow` [here](https://github.com/coinbase/temporal-ruby/blob/master/lib/temporal/connection/serializer/start_child_workflow.rb#L26), it is not actually getting passed from the options in `execute_workflow`. 

This PR just corrects that omission.