### PR TITLE
Added fix for nil search attributes when listing workflows

### DIFF
--- a/lib/temporal/workflow/execution_info.rb
+++ b/lib/temporal/workflow/execution_info.rb
@@ -17,7 +17,7 @@ module Temporal
       ]
 
       def self.generate_from(response)
-        search_attributes = self.from_payload_map(response.search_attributes.indexed_fields) if !response.search_attributes.nil?
+        search_attributes = response.search_attributes.nil? ? {} : self.from_payload_map(response.search_attributes.indexed_fields)
         new(
           workflow: response.type.name,
           workflow_id: response.execution.workflow_id,

--- a/lib/temporal/workflow/execution_info.rb
+++ b/lib/temporal/workflow/execution_info.rb
@@ -17,6 +17,7 @@ module Temporal
       ]
 
       def self.generate_from(response)
+        search_attributes = self.from_payload_map(response.search_attributes.indexed_fields) if !response.search_attributes.nil?
         new(
           workflow: response.type.name,
           workflow_id: response.execution.workflow_id,
@@ -26,7 +27,7 @@ module Temporal
           status: Temporal::Workflow::Status::API_STATUS_MAP.fetch(response.status),
           history_length: response.history_length,
           memo: self.from_payload_map(response.memo.fields),
-          search_attributes: self.from_payload_map(response.search_attributes.indexed_fields),
+          search_attributes: search_attributes,
         ).freeze
       end
 

--- a/spec/unit/lib/temporal/workflow/execution_info_spec.rb
+++ b/spec/unit/lib/temporal/workflow/execution_info_spec.rb
@@ -25,7 +25,7 @@ describe Temporal::Workflow::ExecutionInfo do
       api_info.search_attributes = nil
 
       result = described_class.generate_from(api_info)
-      expect(result).to be_an_instance_of(Temporal::Workflow::ExecutionInfo)
+      expect(result.search_attributes).to be_nil
     end
   end
 

--- a/spec/unit/lib/temporal/workflow/execution_info_spec.rb
+++ b/spec/unit/lib/temporal/workflow/execution_info_spec.rb
@@ -25,7 +25,7 @@ describe Temporal::Workflow::ExecutionInfo do
       api_info.search_attributes = nil
 
       result = described_class.generate_from(api_info)
-      expect(result.search_attributes).to be_nil
+      expect(result.search_attributes).to eq({})
     end
   end
 

--- a/spec/unit/lib/temporal/workflow/execution_info_spec.rb
+++ b/spec/unit/lib/temporal/workflow/execution_info_spec.rb
@@ -21,10 +21,11 @@ describe Temporal::Workflow::ExecutionInfo do
       expect(subject).to be_frozen
     end
 
-    it 'deseralizes if search_attributes is nil' do
+    it 'deserializes if search_attributes is nil' do
       api_info.search_attributes = nil
 
-      described_class.generate_from(api_info)
+      result = described_class.generate_from(api_info)
+      expect(result).to be_an_instance_of(Temporal::Workflow::ExecutionInfo)
     end
   end
 

--- a/spec/unit/lib/temporal/workflow/execution_info_spec.rb
+++ b/spec/unit/lib/temporal/workflow/execution_info_spec.rb
@@ -20,6 +20,12 @@ describe Temporal::Workflow::ExecutionInfo do
     it 'freezes the info' do
       expect(subject).to be_frozen
     end
+
+    it 'deseralizes if search_attributes is nil' do
+      api_info.search_attributes = nil
+
+      described_class.generate_from(api_info)
+    end
   end
 
   describe 'statuses' do


### PR DESCRIPTION
list_workflow_executions is currently not working when search attributes object is nil. This PR adds the nil check for `response.search_attributes` to ensure it doesn't blow up.