### PR TITLE
Expose scheduled_time and current_attempt_scheduled_time on activity metadata

### DIFF
--- a/lib/temporal/metadata.rb
+++ b/lib/temporal/metadata.rb
@@ -22,9 +22,8 @@ module Temporal
           workflow_name: task.workflow_type.name,
           headers: from_payload_map(task.header&.fields || {}),
           heartbeat_details: from_details_payloads(task.heartbeat_details),
-          # temporal doesn't render sub-second times, so we ignore the nanos field
           scheduled_at: task.scheduled_time.to_time,
-          current_attempt_scheduled_at: task.current_attempt_scheduled_time
+          current_attempt_scheduled_at: task.current_attempt_scheduled_time.to_time
         )
       end
 

--- a/lib/temporal/metadata.rb
+++ b/lib/temporal/metadata.rb
@@ -21,7 +21,10 @@ module Temporal
           workflow_id: task.workflow_execution.workflow_id,
           workflow_name: task.workflow_type.name,
           headers: from_payload_map(task.header&.fields || {}),
-          heartbeat_details: from_details_payloads(task.heartbeat_details)
+          heartbeat_details: from_details_payloads(task.heartbeat_details),
+          # temporal doesn't render sub-second times, so we ignore the nanos field
+          scheduled_time: task.scheduled_time.seconds,
+          current_attempt_scheduled_time: task.current_attempt_scheduled_time.seconds
         )
       end
 

--- a/lib/temporal/metadata.rb
+++ b/lib/temporal/metadata.rb
@@ -23,8 +23,8 @@ module Temporal
           headers: from_payload_map(task.header&.fields || {}),
           heartbeat_details: from_details_payloads(task.heartbeat_details),
           # temporal doesn't render sub-second times, so we ignore the nanos field
-          scheduled_time: task.scheduled_time.seconds,
-          current_attempt_scheduled_time: task.current_attempt_scheduled_time.seconds
+          scheduled_at: task.scheduled_time.to_time,
+          current_attempt_scheduled_at: task.current_attempt_scheduled_time
         )
       end
 

--- a/lib/temporal/metadata/activity.rb
+++ b/lib/temporal/metadata/activity.rb
@@ -3,9 +3,9 @@ require 'temporal/metadata/base'
 module Temporal
   module Metadata
     class Activity < Base
-      attr_reader :namespace, :id, :name, :task_token, :attempt, :workflow_run_id, :workflow_id, :workflow_name, :headers, :heartbeat_details
+      attr_reader :namespace, :id, :name, :task_token, :attempt, :workflow_run_id, :workflow_id, :workflow_name, :headers, :heartbeat_details, :scheduled_time, :current_attempt_scheduled_time
 
-      def initialize(namespace:, id:, name:, task_token:, attempt:, workflow_run_id:, workflow_id:, workflow_name:, headers: {}, heartbeat_details:)
+      def initialize(namespace:, id:, name:, task_token:, attempt:, workflow_run_id:, workflow_id:, workflow_name:, headers: {}, heartbeat_details:, scheduled_time:, current_attempt_scheduled_time:)
         @namespace = namespace
         @id = id
         @name = name
@@ -16,6 +16,8 @@ module Temporal
         @workflow_name = workflow_name
         @headers = headers
         @heartbeat_details = heartbeat_details
+        @scheduled_time = scheduled_time
+        @current_attempt_scheduled_time = current_attempt_scheduled_time
 
         freeze
       end
@@ -32,7 +34,9 @@ module Temporal
           'workflow_run_id' => workflow_run_id,
           'activity_id' => id,
           'activity_name' => name,
-          'attempt' => attempt
+          'attempt' => attempt,
+          'scheduled_time' => scheduled_time,
+          'current_attempt_scheduled_time' => current_attempt_scheduled_time,
         }
       end
     end

--- a/lib/temporal/metadata/activity.rb
+++ b/lib/temporal/metadata/activity.rb
@@ -3,9 +3,9 @@ require 'temporal/metadata/base'
 module Temporal
   module Metadata
     class Activity < Base
-      attr_reader :namespace, :id, :name, :task_token, :attempt, :workflow_run_id, :workflow_id, :workflow_name, :headers, :heartbeat_details, :scheduled_time, :current_attempt_scheduled_time
+      attr_reader :namespace, :id, :name, :task_token, :attempt, :workflow_run_id, :workflow_id, :workflow_name, :headers, :heartbeat_details, :scheduled_at, :current_attempt_scheduled_at
 
-      def initialize(namespace:, id:, name:, task_token:, attempt:, workflow_run_id:, workflow_id:, workflow_name:, headers: {}, heartbeat_details:, scheduled_time:, current_attempt_scheduled_time:)
+      def initialize(namespace:, id:, name:, task_token:, attempt:, workflow_run_id:, workflow_id:, workflow_name:, headers: {}, heartbeat_details:, scheduled_at:, current_attempt_scheduled_at:)
         @namespace = namespace
         @id = id
         @name = name
@@ -16,8 +16,8 @@ module Temporal
         @workflow_name = workflow_name
         @headers = headers
         @heartbeat_details = heartbeat_details
-        @scheduled_time = scheduled_time
-        @current_attempt_scheduled_time = current_attempt_scheduled_time
+        @scheduled_at = scheduled_at
+        @current_attempt_scheduled_at = current_attempt_scheduled_at
 
         freeze
       end
@@ -35,8 +35,8 @@ module Temporal
           'activity_id' => id,
           'activity_name' => name,
           'attempt' => attempt,
-          'scheduled_time' => scheduled_time,
-          'current_attempt_scheduled_time' => current_attempt_scheduled_time,
+          'scheduled_at' => scheduled_at.to_s,
+          'current_attempt_scheduled_at' => current_attempt_scheduled_at.to_s,
         }
       end
     end

--- a/lib/temporal/testing/local_workflow_context.rb
+++ b/lib/temporal/testing/local_workflow_context.rb
@@ -60,7 +60,9 @@ module Temporal
           workflow_id: workflow_id,
           workflow_name: nil, # not yet used, but will be in the future
           headers: execution_options.headers,
-          heartbeat_details: nil
+          heartbeat_details: nil,
+          scheduled_time: Time.now.to_i,
+          current_attempt_scheduled_time: Time.now.to_i,
         )
         context = LocalActivityContext.new(metadata)
 
@@ -108,7 +110,9 @@ module Temporal
           workflow_id: workflow_id,
           workflow_name: nil, # not yet used, but will be in the future
           headers: execution_options.headers,
-          heartbeat_details: nil
+          heartbeat_details: nil,
+          scheduled_time: Time.now.to_i,
+          current_attempt_scheduled_time: Time.now.to_i,
         )
         context = LocalActivityContext.new(metadata)
 

--- a/lib/temporal/testing/local_workflow_context.rb
+++ b/lib/temporal/testing/local_workflow_context.rb
@@ -61,8 +61,8 @@ module Temporal
           workflow_name: nil, # not yet used, but will be in the future
           headers: execution_options.headers,
           heartbeat_details: nil,
-          scheduled_time: Time.now.to_i,
-          current_attempt_scheduled_time: Time.now.to_i,
+          scheduled_at: Time.now,
+          current_attempt_scheduled_at: Time.now,
         )
         context = LocalActivityContext.new(metadata)
 
@@ -111,8 +111,8 @@ module Temporal
           workflow_name: nil, # not yet used, but will be in the future
           headers: execution_options.headers,
           heartbeat_details: nil,
-          scheduled_time: Time.now.to_i,
-          current_attempt_scheduled_time: Time.now.to_i,
+          scheduled_at: Time.now,
+          current_attempt_scheduled_at: Time.now,
         )
         context = LocalActivityContext.new(metadata)
 

--- a/spec/fabricators/activity_metadata_fabricator.rb
+++ b/spec/fabricators/activity_metadata_fabricator.rb
@@ -11,6 +11,6 @@ Fabricator(:activity_metadata, from: :open_struct) do
   workflow_name 'TestWorkflow'
   headers { {} }
   heartbeat_details nil
-  scheduled_time 0
-  current_attempt_scheduled_time 0
+  scheduled_at { Time.now }
+  current_attempt_scheduled_at { Time.now }
 end

--- a/spec/fabricators/activity_metadata_fabricator.rb
+++ b/spec/fabricators/activity_metadata_fabricator.rb
@@ -11,4 +11,6 @@ Fabricator(:activity_metadata, from: :open_struct) do
   workflow_name 'TestWorkflow'
   headers { {} }
   heartbeat_details nil
+  scheduled_time 0
+  current_attempt_scheduled_time 0
 end

--- a/spec/fabricators/grpc/activity_task_fabricator.rb
+++ b/spec/fabricators/grpc/activity_task_fabricator.rb
@@ -11,6 +11,8 @@ Fabricator(:api_activity_task, from: Temporal::Api::WorkflowService::V1::PollAct
   workflow_execution { Fabricate(:api_workflow_execution) }
   current_attempt_scheduled_time { Google::Protobuf::Timestamp.new.tap { |t| t.from_time(Time.now) } }
   started_time { Google::Protobuf::Timestamp.new.tap { |t| t.from_time(Time.now) } }
+  scheduled_time { Google::Protobuf::Timestamp.new.tap { |t| t.from_time(Time.now) } }
+  current_attempt_scheduled_time { Google::Protobuf::Timestamp.new.tap { |t| t.from_time(Time.now) } }  
   header do |attrs|
     fields = (attrs[:headers] || {}).each_with_object({}) do |(field, value), h|
       h[field] = Temporal.configuration.converter.to_payload(value)

--- a/spec/fabricators/grpc/activity_task_fabricator.rb
+++ b/spec/fabricators/grpc/activity_task_fabricator.rb
@@ -12,7 +12,7 @@ Fabricator(:api_activity_task, from: Temporal::Api::WorkflowService::V1::PollAct
   current_attempt_scheduled_time { Google::Protobuf::Timestamp.new.tap { |t| t.from_time(Time.now) } }
   started_time { Google::Protobuf::Timestamp.new.tap { |t| t.from_time(Time.now) } }
   scheduled_time { Google::Protobuf::Timestamp.new.tap { |t| t.from_time(Time.now) } }
-  current_attempt_scheduled_time { Google::Protobuf::Timestamp.new.tap { |t| t.from_time(Time.now) } }  
+  current_attempt_scheduled_time { Google::Protobuf::Timestamp.new.tap { |t| t.from_time(Time.now) } }
   header do |attrs|
     fields = (attrs[:headers] || {}).each_with_object({}) do |(field, value), h|
       h[field] = Temporal.configuration.converter.to_payload(value)

--- a/spec/unit/lib/temporal/metadata/activity_spec.rb
+++ b/spec/unit/lib/temporal/metadata/activity_spec.rb
@@ -16,8 +16,8 @@ describe Temporal::Metadata::Activity do
       expect(subject.workflow_name).to eq(args.workflow_name)
       expect(subject.headers).to eq(args.headers)
       expect(subject.heartbeat_details).to eq(args.heartbeat_details)
-      expect(subject.scheduled_time).to eq(args.scheduled_time)
-      expect(subject.current_attempt_scheduled_time).to eq(args.current_attempt_scheduled_time)      
+      expect(subject.scheduled_at).to eq(args.scheduled_at)
+      expect(subject.current_attempt_scheduled_at).to eq(args.current_attempt_scheduled_at)
     end
 
     it { is_expected.to be_frozen }
@@ -39,8 +39,8 @@ describe Temporal::Metadata::Activity do
         'workflow_id' => subject.workflow_id,
         'workflow_name' => subject.workflow_name,
         'workflow_run_id' => subject.workflow_run_id,
-        'scheduled_time' => subject.scheduled_time,
-        'current_attempt_scheduled_time' => subject.current_attempt_scheduled_time,
+        'scheduled_at' => subject.scheduled_at.to_s,
+        'current_attempt_scheduled_at' => subject.current_attempt_scheduled_at.to_s,
       })
     end
   end

--- a/spec/unit/lib/temporal/metadata/activity_spec.rb
+++ b/spec/unit/lib/temporal/metadata/activity_spec.rb
@@ -16,6 +16,8 @@ describe Temporal::Metadata::Activity do
       expect(subject.workflow_name).to eq(args.workflow_name)
       expect(subject.headers).to eq(args.headers)
       expect(subject.heartbeat_details).to eq(args.heartbeat_details)
+      expect(subject.scheduled_time).to eq(args.scheduled_time)
+      expect(subject.current_attempt_scheduled_time).to eq(args.current_attempt_scheduled_time)      
     end
 
     it { is_expected.to be_frozen }
@@ -36,7 +38,9 @@ describe Temporal::Metadata::Activity do
         'namespace' => subject.namespace,
         'workflow_id' => subject.workflow_id,
         'workflow_name' => subject.workflow_name,
-        'workflow_run_id' => subject.workflow_run_id
+        'workflow_run_id' => subject.workflow_run_id,
+        'scheduled_time' => subject.scheduled_time,
+        'current_attempt_scheduled_time' => subject.current_attempt_scheduled_time,
       })
     end
   end


### PR DESCRIPTION
## Summary
This adds two scheduling-related fields to the activity metadata. These are present in the temporal java SDK.

## Testing
```
bundle exec rspec spec/unit/

cd examples
./bin/worker &
USE_ENCRYPTION=1 ./bin/worker &
bundle exec rspec spec/integration
```