### PR TITLE
Expose wait_for_start for child workflow execution

### DIFF
--- a/examples/workflows/parent_close_workflow.rb
+++ b/examples/workflows/parent_close_workflow.rb
@@ -5,7 +5,6 @@ class ParentCloseWorkflow < Temporal::Workflow
     options = {
       workflow_id: child_workflow_id,
       parent_close_policy: parent_close_policy,
-      wait_for_start: true
     }
     SlowChildWorkflow.execute(1, options: options)
     return

--- a/examples/workflows/parent_close_workflow.rb
+++ b/examples/workflows/parent_close_workflow.rb
@@ -2,11 +2,12 @@ require 'workflows/slow_child_workflow'
 
 class ParentCloseWorkflow < Temporal::Workflow
   def execute(child_workflow_id, parent_close_policy)
-    options = { workflow_id: child_workflow_id, parent_close_policy: parent_close_policy }
-
+    options = {
+      workflow_id: child_workflow_id,
+      parent_close_policy: parent_close_policy,
+      wait_for_start: true
+    }
     SlowChildWorkflow.execute(1, options: options)
-    workflow.sleep(0.1) # Make sure the child workflow is scheduled before we exit.
-
     return
   end
 end

--- a/lib/temporal/workflow/context.rb
+++ b/lib/temporal/workflow/context.rb
@@ -103,6 +103,7 @@ module Temporal
         input << args unless args.empty?
 
         parent_close_policy = options.delete(:parent_close_policy)
+        wait_for_start = options.delete(:wait_for_start)
         execution_options = ExecutionOptions.new(workflow_class, options, config.default_execution_options)
 
         command = Command::StartChildWorkflow.new(
@@ -129,6 +130,14 @@ module Temporal
         dispatcher.register_handler(target, 'failed') do |exception|
           future.fail(exception)
           future.failure_callbacks.each { |callback| call_in_fiber(callback, exception) }
+        end
+
+        if wait_for_start
+          child_workflow_started = false
+          dispatcher.register_handler(target, 'started') do
+            child_workflow_started = true
+          end
+          wait_for { child_workflow_started }
         end
 
         future

--- a/lib/temporal/workflow/context.rb
+++ b/lib/temporal/workflow/context.rb
@@ -103,7 +103,6 @@ module Temporal
         input << args unless args.empty?
 
         parent_close_policy = options.delete(:parent_close_policy)
-        wait_for_start = options.delete(:wait_for_start)
         execution_options = ExecutionOptions.new(workflow_class, options, config.default_execution_options)
 
         command = Command::StartChildWorkflow.new(
@@ -132,13 +131,12 @@ module Temporal
           future.failure_callbacks.each { |callback| call_in_fiber(callback, exception) }
         end
 
-        if wait_for_start
-          child_workflow_started = false
-          dispatcher.register_handler(target, 'started') do
-            child_workflow_started = true
-          end
-          wait_for { child_workflow_started }
+        # Temporal docs say that we *must* wait for the child to get spawned:
+        child_workflow_started = false
+        dispatcher.register_handler(target, 'started') do
+          child_workflow_started = true
         end
+        wait_for { child_workflow_started }
 
         future
       end

--- a/lib/temporal/workflow/state_manager.rb
+++ b/lib/temporal/workflow/state_manager.rb
@@ -241,7 +241,7 @@ module Temporal
           dispatch(target, 'failed', 'StandardError', from_payloads(event.attributes.cause))
 
         when 'CHILD_WORKFLOW_EXECUTION_STARTED'
-          dispatch(target, 'started', event.attributes.workflow_execution)
+          dispatch(target, 'started')
           state_machine.start
 
         when 'CHILD_WORKFLOW_EXECUTION_COMPLETED'

--- a/lib/temporal/workflow/state_manager.rb
+++ b/lib/temporal/workflow/state_manager.rb
@@ -241,6 +241,7 @@ module Temporal
           dispatch(target, 'failed', 'StandardError', from_payloads(event.attributes.cause))
 
         when 'CHILD_WORKFLOW_EXECUTION_STARTED'
+          dispatch(target, 'started', event.attributes.workflow_execution)
           state_machine.start
 
         when 'CHILD_WORKFLOW_EXECUTION_COMPLETED'


### PR DESCRIPTION
# Summary
Currently, in order to ensure child workflows behave as expected, we have to wait for temporal to send a ChildExecutionStarted history event. Since we can't do that, we've been sleeping. This PR adds a wait_for_start to child workflow execution so that we can reliably wait for Child workflows, as [indicated in Temporal's docs](https://docs.temporal.io/docs/concepts/what-is-a-child-workflow-execution)

# Testing
I ran:
```
bundle exec rspec spec/
cd examples
./bin/worker
USE_ENCRYPTION=1 ./bin/worker
bundle exec rspec spec/integration
```

I modified parent_close_workflow_spec to use this flag instead of sleep. If you disable `wait_for_start`, the test will fail nondeterministically.