### PR TITLE
Add parent_run_id, parent_id to workflow metadata

### DIFF
--- a/examples/spec/integration/parent_close_workflow_spec.rb
+++ b/examples/spec/integration/parent_close_workflow_spec.rb
@@ -50,6 +50,6 @@ describe ParentCloseWorkflow, :integration do
       workflow_id: child_workflow_id,
     )
 
-    expect(result).to eq('slow child ran')
+    expect(result).to eq({ parent_workflow_id: workflow_id })
   end
 end

--- a/examples/workflows/slow_child_workflow.rb
+++ b/examples/workflows/slow_child_workflow.rb
@@ -4,6 +4,6 @@ class SlowChildWorkflow < Temporal::Workflow
       workflow.sleep(delay)
     end
 
-    return 'slow child ran'
+    return { parent_workflow_id: workflow.metadata.parent_id }
   end
 end

--- a/lib/temporal/metadata.rb
+++ b/lib/temporal/metadata.rb
@@ -47,6 +47,8 @@ module Temporal
           name: event.attributes.workflow_type.name,
           id: task_metadata.workflow_id,
           run_id: event.attributes.original_execution_run_id,
+          parent_id: event.attributes.parent_workflow_execution&.workflow_id,
+          parent_run_id: event.attributes.parent_workflow_execution&.run_id,
           attempt: event.attributes.attempt,
           namespace: task_metadata.namespace,
           task_queue: event.attributes.task_queue.name,

--- a/lib/temporal/metadata/workflow.rb
+++ b/lib/temporal/metadata/workflow.rb
@@ -3,13 +3,15 @@ require 'temporal/metadata/base'
 module Temporal
   module Metadata
     class Workflow < Base
-      attr_reader :namespace, :id, :name, :run_id, :attempt, :task_queue, :headers, :run_started_at, :memo
+      attr_reader :namespace, :id, :name, :run_id, :parent_id, :parent_run_id, :attempt, :task_queue, :headers, :run_started_at, :memo
 
-      def initialize(namespace:, id:, name:, run_id:, attempt:, task_queue:, headers:, run_started_at:, memo:)
+      def initialize(namespace:, id:, name:, run_id:, parent_id:, parent_run_id:, attempt:, task_queue:, headers:, run_started_at:, memo:)
         @namespace = namespace
         @id = id
         @name = name
         @run_id = run_id
+        @parent_id = parent_id
+        @parent_run_id = parent_run_id
         @attempt = attempt
         @task_queue = task_queue
         @headers = headers
@@ -29,6 +31,8 @@ module Temporal
           'workflow_id' => id,
           'workflow_name' => name,
           'workflow_run_id' => run_id,
+          'parent_workflow_id' => parent_id,
+          'parent_workflow_run_id' => parent_run_id,
           'attempt' => attempt,
           'task_queue' => task_queue,
           'run_started_at' => run_started_at.to_f,

--- a/lib/temporal/testing/temporal_override.rb
+++ b/lib/temporal/testing/temporal_override.rb
@@ -100,6 +100,8 @@ module Temporal
           id: workflow_id,
           name: execution_options.name,
           run_id: run_id,
+          parent_id: nil,
+          parent_run_id: nil,
           attempt: 1,
           task_queue: execution_options.task_queue,
           run_started_at: Time.now,

--- a/lib/temporal/testing/workflow_override.rb
+++ b/lib/temporal/testing/workflow_override.rb
@@ -32,6 +32,8 @@ module Temporal
           id: workflow_id,
           name: name, # Workflow class name
           run_id: run_id,
+          parent_id: nil,
+          parent_run_id: nil,
           attempt: 1,
           task_queue: 'unit-test-task-queue',
           headers: {},

--- a/spec/fabricators/workflow_metadata_fabricator.rb
+++ b/spec/fabricators/workflow_metadata_fabricator.rb
@@ -5,6 +5,8 @@ Fabricator(:workflow_metadata, from: :open_struct) do
   id { SecureRandom.uuid }
   name 'TestWorkflow'
   run_id { SecureRandom.uuid }
+  parent_id { nil }
+  parent_run_id { nil }
   attempt 1
   task_queue { Fabricate(:api_task_queue) }
   run_started_at { Time.now }

--- a/spec/unit/lib/temporal/metadata/workflow_spec.rb
+++ b/spec/unit/lib/temporal/metadata/workflow_spec.rb
@@ -32,6 +32,8 @@ describe Temporal::Metadata::Workflow do
         'attempt' => subject.attempt,
         'workflow_name' => subject.name,
         'workflow_run_id' => subject.run_id,
+        'parent_workflow_id' => nil,
+        'parent_workflow_run_id' => nil,
         'task_queue' => subject.task_queue,
         'run_started_at' => subject.run_started_at.to_f,
         'memo' => subject.memo,

--- a/spec/unit/lib/temporal/testing/local_workflow_context_spec.rb
+++ b/spec/unit/lib/temporal/testing/local_workflow_context_spec.rb
@@ -19,6 +19,8 @@ describe Temporal::Testing::LocalWorkflowContext do
         id: workflow_id,
         name: 'HelloWorldWorkflow',
         run_id: run_id,
+        parent_id: nil,
+        parent_run_id: nil,
         attempt: 1,
         task_queue: task_queue,
         headers: {},

--- a/spec/unit/lib/temporal/workflow/executor_spec.rb
+++ b/spec/unit/lib/temporal/workflow/executor_spec.rb
@@ -70,6 +70,8 @@ describe Temporal::Workflow::Executor do
                 id: workflow_metadata.workflow_id,
                 name: event_attributes.workflow_type.name,
                 run_id: event_attributes.original_execution_run_id,
+                parent_id: nil,
+                parent_run_id: nil,
                 attempt: event_attributes.attempt,
                 task_queue: event_attributes.task_queue.name,
                 run_started_at: workflow_started_event.event_time.to_time,


### PR DESCRIPTION
# Motivation
Exposing parent_workflow_id and parent_run_id in workflow executions will help with programming child workflows, and improve logging (since workflow metadata is appended to logs). This is mostly just plumbing from temporal's workflow started response.

# Testing
I modified parent_workflow_spec to return the new metadata field from a child, and asserted that it was correct.
```
bundle exec rspec spec/
cd examples
./bin/worker
USE_ENCRYPTION=1 ./bin/worker
bundle exec rspec spec/integration
```