### PR TITLE
Allow opting out of child workflow futures

### DIFF
--- a/lib/temporal/workflow/child_workflow_future.rb
+++ b/lib/temporal/workflow/child_workflow_future.rb
@@ -1,0 +1,29 @@
+require 'fiber'
+require 'temporal/workflow/future'
+
+module Temporal
+  class Workflow
+    # A future that represents a child workflow execution, that additionally tracks whether a 
+    # child workflow execution has started.
+    class ChildWorkflowFuture < Future
+      def initialize(target, context, cancelation_id: nil)
+        @started = false
+        super
+      end
+
+      def started?
+        @started
+      end
+
+      def start
+        raise 'cannot start a fulfilled future' if finished?
+
+        @started = true
+      end
+
+      private
+
+      attr_reader :started
+    end
+  end
+end


### PR DESCRIPTION
# Summary

Create a new `ChildWorkflowFuture < Future` that can track whether or not it has been started. Add `should_wait_for_start` to child workflow execution (defaults to true), so that one can disable waiting for a child workflow execution to start.

# Motivation

Currently, in [this PR](https://github.com/coinbase/temporal-ruby/pull/167), we chose to have child workflow futures always start before returning, since Temporal requires that child workflow executions begin before a parent workflow execution terminates [(docs)](https://docs.temporal.io/docs/concepts/what-is-a-child-workflow-execution).

However, there are some cases where this is undesired– in the case where one wants to spawn many child workflows, you probably want to batch this wait until the end, rather than serially wait for each child workflow to begin, before scheduling the next.

For this reason, we want the ability to allow the user to opt out of this auto-start, and wait for this future to happen at a time of their choosing.

# Tests:
Ran the following:
```
bundle exec rspec spec/
cd examples
(terminal 1) ./bin/worker
(terminal 2) USE_ENCRYPTION=1 ./bin/worker
(terminal 3) bundle exec rspec spec/integration
```