### PR TITLE
[API BREAKING] wait_for follow up fixes

### DIFF
--- a/examples/workflows/wait_for_external_signal_workflow.rb
+++ b/examples/workflows/wait_for_external_signal_workflow.rb
@@ -12,7 +12,7 @@ class WaitForExternalSignalWorkflow < Temporal::Workflow
       signal_counts[signal] += 1
     end
 
-    workflow.wait_for do
+    workflow.wait_until do
       workflow.logger.info("Awaiting #{expected_signal}, signals received so far: #{signals_received}")
       signals_received.key?(expected_signal)
     end

--- a/lib/temporal/testing/local_workflow_context.rb
+++ b/lib/temporal/testing/local_workflow_context.rb
@@ -170,12 +170,22 @@ module Temporal
         return
       end
 
-      def wait_for(*futures, &unblock_condition)
-        if futures.empty? && unblock_condition.nil?
-          raise 'You must pass either a future or an unblock condition block to wait_for'
+      def wait_for_any(*futures)
+        return if futures.empty?
+
+        while futures.empty? || futures.none?(&:finished?)
+          Fiber.yield
         end
 
-        while (futures.empty? || futures.none?(&:finished?)) && (!unblock_condition || !unblock_condition.call)
+        return
+      end
+
+      def wait_until(&unblock_condition)
+        if unblock_condition.nil?
+          raise 'You must pass either an unblock condition block to wait_for'
+        end
+
+        while !unblock_condition || !unblock_condition.call
           Fiber.yield
         end
 

--- a/lib/temporal/workflow/context.rb
+++ b/lib/temporal/workflow/context.rb
@@ -136,7 +136,7 @@ module Temporal
         dispatcher.register_handler(target, 'started') do
           child_workflow_started = true
         end
-        wait_for { child_workflow_started }
+        wait_until { child_workflow_started }
 
         future
       end
@@ -228,60 +228,56 @@ module Temporal
         completed!
       end
 
+      # Block workflow progress until all futures finish
       def wait_for_all(*futures)
         futures.each(&:wait)
 
         return
       end
 
-      # Block workflow progress until any future is finished or any unblock_condition
-      # block evaluates to true.
-      def wait_for(*futures, &unblock_condition)
-        if futures.empty? && unblock_condition.nil?
-          raise 'You must pass either a future or an unblock condition block to wait_for'
-        end
+      # Block workflow progress until one of the futures completes. Passing
+      # in an empty array will immediately unblock.
+      def wait_for_any(*futures)
+        return if futures.empty? || futures.any?(&:finished?)
 
         fiber = Fiber.current
-        should_yield = false
         blocked = true
 
-        if futures.any?
-          if futures.any?(&:finished?)
-            blocked = false
-          else
-            should_yield = true
-            futures.each do |future|
-              dispatcher.register_handler(future.target, Dispatcher::WILDCARD) do
-                if blocked && future.finished?
-                  # Because this block can run for any dispatch, ensure the fiber is only
-                  # resumed one time by checking if it's already been unblocked.
-                  blocked = false
-                  fiber.resume
-                end
-              end
+        futures.each do |future|
+          dispatcher.register_handler(future.target, Dispatcher::WILDCARD) do
+            # Because any of the futures can resume the fiber, ignore any callbacks
+            # from other futures after unblocking has occurred
+            if blocked
+              blocked = false
+              fiber.resume
             end
           end
         end
 
-        if blocked && unblock_condition
-          if unblock_condition.call
-            blocked = false
-            should_yield = false
-          else
-            should_yield = true
+        Fiber.yield
 
-            dispatcher.register_handler(Dispatcher::TARGET_WILDCARD, Dispatcher::WILDCARD) do
-              # Because this block can run for any dispatch, ensure the fiber is only
-              # resumed one time by checking if it's already been unblocked.
-              if blocked && unblock_condition.call
-                blocked = false
-                fiber.resume
-              end
-            end
+        return
+      end
+
+      # Block workflow progress until the specified block evaluates to true.
+      def wait_until(&unblock_condition)
+        raise 'You must pass a block to wait_until' if unblock_condition.nil?
+
+        return if unblock_condition.call
+
+        fiber = Fiber.current
+        blocked = true
+
+        dispatcher.register_handler(Dispatcher::TARGET_WILDCARD, Dispatcher::WILDCARD) do
+          # Because this block can run for any dispatch, ensure the fiber is only
+          # resumed one time by checking if it's already been unblocked.
+          if blocked && unblock_condition.call
+            blocked = false
+            fiber.resume
           end
         end
 
-        Fiber.yield if should_yield
+        Fiber.yield
 
         return
       end

--- a/lib/temporal/workflow/dispatcher.rb
+++ b/lib/temporal/workflow/dispatcher.rb
@@ -6,10 +6,12 @@ module Temporal
 
       def initialize
         @handlers = Hash.new { |hash, key| hash[key] = [] }
+        @next_id = 1
       end
 
       def register_handler(target, event_name, &handler)
-        handlers[target] << [event_name, handler]
+        handlers[target] << [@next_id, event_name, handler]
+        @next_id += 1
       end
 
       def dispatch(target, event_name, args = nil)
@@ -25,7 +27,8 @@ module Temporal
       def handlers_for(target, event_name)
         handlers[target]
           .concat(handlers[TARGET_WILDCARD])
-          .select { |(name, _)| name == event_name || name == WILDCARD }
+          .select { |(_, name, _)| name == event_name || name == WILDCARD }
+          .sort_by { |sequence, _, _| sequence }
           .map(&:last)
       end
     end

--- a/lib/temporal/workflow/dispatcher.rb
+++ b/lib/temporal/workflow/dispatcher.rb
@@ -6,12 +6,17 @@ module Temporal
 
       def initialize
         @handlers = Hash.new { |hash, key| hash[key] = [] }
-        @next_id = 1
+        @next_id = 0
       end
 
       def register_handler(target, event_name, &handler)
-        handlers[target] << [@next_id, event_name, handler]
         @next_id += 1
+        handlers[target] << [@next_id, event_name, handler]
+        @next_id
+      end
+
+      def remove_handler(target, id)
+        handlers[target] = handlers[target].reject { |(handler_id, _, _)| handler_id == id }
       end
 
       def dispatch(target, event_name, args = nil)

--- a/lib/temporal/workflow/future.rb
+++ b/lib/temporal/workflow/future.rb
@@ -31,7 +31,7 @@ module Temporal
 
       def wait
         return if finished?
-        context.wait_for(self)
+        context.wait_for_any(self)
       end
 
       def get

--- a/spec/unit/lib/temporal/testing/local_workflow_context_spec.rb
+++ b/spec/unit/lib/temporal/testing/local_workflow_context_spec.rb
@@ -146,7 +146,7 @@ describe Temporal::Testing::LocalWorkflowContext do
       can_continue = false
       exited = false
       fiber = Fiber.new do
-        workflow_context.wait_for do
+        workflow_context.wait_until do
           can_continue
         end
 
@@ -167,7 +167,7 @@ describe Temporal::Testing::LocalWorkflowContext do
       future = workflow_context.execute_activity(TestAsyncActivity)
 
       fiber = Fiber.new do
-        workflow_context.wait_for(future) do
+        workflow_context.wait_for_any(future) do
           false
         end
 
@@ -191,7 +191,7 @@ describe Temporal::Testing::LocalWorkflowContext do
       future.wait
 
       fiber = Fiber.new do
-        workflow_context.wait_for(future, async_future)
+        workflow_context.wait_for_any(future, async_future)
         exited = true
       end
 

--- a/spec/unit/lib/temporal/workflow/dispatcher_spec.rb
+++ b/spec/unit/lib/temporal/workflow/dispatcher_spec.rb
@@ -11,7 +11,7 @@ describe Temporal::Workflow::Dispatcher do
 
       subject.register_handler(target, 'signaled', &block)
 
-      expect(subject.send(:handlers)).to include(target => [['signaled', block]])
+      expect(subject.send(:handlers)).to include(target => [[1, 'signaled', block]])
     end
   end
 
@@ -70,10 +70,13 @@ describe Temporal::Workflow::Dispatcher do
 
     context 'with TARGET_WILDCARD target handler' do
       let(:handler_6) { -> { 'sixth block' } }
+      let(:handler_7) { -> { 'seventh block' } }
       before do
         allow(handler_6).to receive(:call)
+        allow(handler_7).to receive(:call)
 
         subject.register_handler(described_class::TARGET_WILDCARD, described_class::WILDCARD, &handler_6)
+        subject.register_handler(target, 'completed', &handler_7)
       end
 
       it 'calls the handler' do
@@ -83,6 +86,7 @@ describe Temporal::Workflow::Dispatcher do
         expect(handler_1).to have_received(:call).ordered
         expect(handler_4).to have_received(:call).ordered
         expect(handler_6).to have_received(:call).ordered
+        expect(handler_7).to have_received(:call).ordered
       end
 
       it 'TARGET_WILDCARD can be compared to an EventTarget object' do

--- a/spec/unit/lib/temporal/workflow/future_spec.rb
+++ b/spec/unit/lib/temporal/workflow/future_spec.rb
@@ -46,8 +46,8 @@ describe Temporal::Workflow::Future do
       expect(subject.get).to be exception
     end
 
-    it 'calls context.wait_for if not finished' do
-      allow(workflow_context).to receive(:wait_for).with(subject)
+    it 'calls context.wait_for_any if not finished' do
+      allow(workflow_context).to receive(:wait_for_any).with(subject)
       subject.get
     end
   end
@@ -58,8 +58,8 @@ describe Temporal::Workflow::Future do
       subject.wait
     end
 
-    it 'calls context.wait_for if not already done' do
-      allow(workflow_context).to receive(:wait_for).with(subject)
+    it 'calls context.wait_for_any if not already done' do
+      allow(workflow_context).to receive(:wait_for_any).with(subject)
       subject.wait
     end
   end


### PR DESCRIPTION
This contains several follow ups to #111 around improving correctness, performance, and API ergonomics of the use of `wait_for` with a block condition. This is equivalent to the await method in Go and Java SDKs ([Go docs](https://pkg.go.dev/go.temporal.io/sdk@v1.14.0/workflow#Await)).

**Split wait_for into dedicated methods**

The `wait_for` method on workflow context started as a way to wait on a single future to complete. It was rarely called directly because activity or timer futures have their own `.wait` methods that called through to this method. With the introduction of a conditional block to `wait_for`, this signature became much more complicated, taking both a splat of futures and a conditional block. Note this is **API breaking** because the `wait_for` method is going away. This method should rarely be called for activities and timers since futures already have an equivalent `wait` method. The use of `wait_for` with a condition block or with wait-for-any semantics will need to be rewritten using the new methods.

With this split, it is now two methods:
- `wait_for_any` which takes a splat of futures, and blocks workflow progression until at least one future is completed. This is similar to the already existing `wait_for_all`.
- `wait_until` which takes a block, and blocks until that block evaluates to true. Complex combinations of futures and workflow state can be combined into a single conditional block. For example, waiting on a timer firing or a signal being received can be done with something like,
```
signal = nil
workflow.on_signal |name, input| do
  signal = input
end

timer = workflow.start_timer(60)
workflow.wait_until { !signal.nil? || timer.finished? }
# examine state here
```

**Deterministically order wildcard dispatch handlers**

When `wait_until` is called, a dispatch function is added to resume the fiber once the condition has been satisfied. Because this condition could change due to any workflow progress, it must be evaluated on every dispatch. Before this change, these were always evaluated after any targeted dispatch callbacks (such as from a specific activity or timer). This can cause non-determinism in certain somewhat corner cases. These callbacks should always be called in the same order. This is achieved by associating an autoincrementing, unique ID with each handler. When the list of handlers is concatenated and filtered, it is now sorted by these IDs, guaranteeing order across replays.

**Remove dispatch handlers once they're no longer needed**

In activities with long histories, the number of dispatch handlers can get quite large. Particularly for workflows that call `wait_until` many times (such as in a loop), the number of these can get very large, and they must be invoked on _every_ dispatch. This can cause performance problems that result in timed out workflow tasks. The fix in this change removes these once they're no longer needed. The unique autoincrementing ID mentioned in the previous section is used to identify and remove callbacks once they are no longer needed, dramatically improving performance for workflows with long histories.