### PR TITLE
Added list workflows API and Pagination Support

### DIFF
--- a/lib/temporal.rb
+++ b/lib/temporal.rb
@@ -28,7 +28,8 @@ module Temporal
                  :complete_activity,
                  :fail_activity,
                  :list_open_workflow_executions,
-                 :list_closed_workflow_executions
+                 :list_closed_workflow_executions,
+                 :query_workflow_executions
 
   class << self
     def configure(&block)

--- a/lib/temporal/client.rb
+++ b/lib/temporal/client.rb
@@ -399,8 +399,8 @@ module Temporal
       Temporal::Workflow::Executions.new(connection: connection, status: :closed, request_options: { namespace: namespace, from: from, to: to, next_page_token: next_page_token, max_page_size: max_page_size}.merge(filter))
     end
 
-    def list_workflow_executions(namespace, query, next_page_token: nil, max_page_size: nil)
-      Temporal::Workflow::Executions.new(connection: connection, status: :closed, request_options: { namespace: namespace, query: query, next_page_token: next_page_token, max_page_size: max_page_size }.merge(filter))
+    def query_workflow_executions(namespace, query, next_page_token: nil, max_page_size: nil)
+      Temporal::Workflow::Executions.new(connection: connection, status: :all, request_options: { namespace: namespace, query: query, next_page_token: next_page_token, max_page_size: max_page_size }.merge(filter))
     end
 
     class ResultConverter

--- a/lib/temporal/client.rb
+++ b/lib/temporal/client.rb
@@ -5,6 +5,7 @@ require 'temporal/activity/async_token'
 require 'temporal/workflow'
 require 'temporal/workflow/history'
 require 'temporal/workflow/execution_info'
+require 'temporal/workflow/executions'
 require 'temporal/workflow/status'
 require 'temporal/reset_strategy'
 
@@ -386,16 +387,20 @@ module Temporal
       Workflow::History.new(history_response.history.events)
     end
 
-    def list_open_workflow_executions(namespace, from, to = Time.now, filter: {})
+    def list_open_workflow_executions(namespace, from, to = Time.now, filter: {}, next_page_token: nil, max_page_size: nil)
       validate_filter(filter, :workflow, :workflow_id)
 
-      fetch_executions(:open, { namespace: namespace, from: from, to: to }.merge(filter))
+      Temporal::Workflow::Executions.new(connection: connection, status: :open, request_options: { namespace: namespace, from: from, to: to, next_page_token: next_page_token, max_page_size: max_page_size}.merge(filter))
     end
 
-    def list_closed_workflow_executions(namespace, from, to = Time.now, filter: {})
+    def list_closed_workflow_executions(namespace, from, to = Time.now, filter: {}, next_page_token: nil, max_page_size: nil)
       validate_filter(filter, :status, :workflow, :workflow_id)
 
-      fetch_executions(:closed, { namespace: namespace, from: from, to: to }.merge(filter))
+      Temporal::Workflow::Executions.new(connection: connection, status: :closed, request_options: { namespace: namespace, from: from, to: to, next_page_token: next_page_token, max_page_size: max_page_size}.merge(filter))
+    end
+
+    def list_workflow_executions(namespace, query, next_page_token: nil, max_page_size: nil)
+      Temporal::Workflow::Executions.new(connection: connection, status: :closed, request_options: { namespace: namespace, query: query, next_page_token: next_page_token, max_page_size: max_page_size }.merge(filter))
     end
 
     class ResultConverter
@@ -449,32 +454,5 @@ module Temporal
       raise ArgumentError, 'Only one filter is allowed' if filter.size > 1
     end
 
-    def fetch_executions(status, request_options)
-      api_method =
-        if status == :open
-          :list_open_workflow_executions
-        else
-          :list_closed_workflow_executions
-        end
-
-      executions = []
-      next_page_token = nil
-
-      loop do
-        response = connection.public_send(
-          api_method,
-          **request_options.merge(next_page_token: next_page_token)
-        )
-
-        executions += Array(response.executions)
-        next_page_token = response.next_page_token
-
-        break if next_page_token.to_s.empty?
-      end
-
-      executions.map do |raw_execution|
-        Temporal::Workflow::ExecutionInfo.generate_from(raw_execution)
-      end
-    end
   end
 end

--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -411,10 +411,10 @@ module Temporal
         client.terminate_workflow_execution(request)
       end
 
-      def list_open_workflow_executions(namespace:, from:, to:, next_page_token: nil, workflow_id: nil, workflow: nil)
+      def list_open_workflow_executions(namespace:, from:, to:, next_page_token: nil, workflow_id: nil, workflow: nil, max_page_size: nil)
         request = Temporal::Api::WorkflowService::V1::ListOpenWorkflowExecutionsRequest.new(
           namespace: namespace,
-          maximum_page_size: options[:max_page_size],
+          maximum_page_size: max_page_size.nil? ? options[:max_page_size] : max_page_size,
           next_page_token: next_page_token,
           start_time_filter: serialize_time_filter(from, to),
           execution_filter: serialize_execution_filter(workflow_id),
@@ -423,10 +423,10 @@ module Temporal
         client.list_open_workflow_executions(request)
       end
 
-      def list_closed_workflow_executions(namespace:, from:, to:, next_page_token: nil, workflow_id: nil, workflow: nil, status: nil)
+      def list_closed_workflow_executions(namespace:, from:, to:, next_page_token: nil, workflow_id: nil, workflow: nil, status: nil, max_page_size: nil)
         request = Temporal::Api::WorkflowService::V1::ListClosedWorkflowExecutionsRequest.new(
           namespace: namespace,
-          maximum_page_size: options[:max_page_size],
+          maximum_page_size: max_page_size.nil? ? options[:max_page_size] : max_page_size,
           next_page_token: next_page_token,
           start_time_filter: serialize_time_filter(from, to),
           execution_filter: serialize_execution_filter(workflow_id),
@@ -436,8 +436,14 @@ module Temporal
         client.list_closed_workflow_executions(request)
       end
 
-      def list_workflow_executions
-        raise NotImplementedError
+      def list_workflow_executions(namespace:, query:, next_page_token: nil, max_page_size: nil)
+        request = Temporal::Api::WorkflowService::V1::ListWorkflowExecutionsRequest.new(
+          namespace: namespace,
+          page_size: max_page_size.nil? ? options[:max_page_size] : max_page_size,
+          next_page_token: next_page_token,
+          query: query
+        )
+        client.list_workflow_executions(request)
       end
 
       def list_archived_workflow_executions

--- a/lib/temporal/workflow/executions.rb
+++ b/lib/temporal/workflow/executions.rb
@@ -1,0 +1,67 @@
+require 'temporal/concerns/payloads'
+require 'temporal/workflow/status'
+
+module Temporal
+  class Workflow
+    class Executions
+      include Enumerable
+  
+      DEFAULT_REQUEST_OPTIONS = {
+        next_page_token: nil
+      }.freeze
+
+      def initialize(connection:, status:, request_options:)
+        @connection = connection
+        @status = status
+        @request_options = DEFAULT_REQUEST_OPTIONS.merge(request_options)
+      end
+      
+      def next_page_token
+        @request_options[:next_page_token]
+      end
+
+      def next_page
+        self.class.new(connection: @connection, status: @status, request_options: @request_options.merge(next_page_token: next_page_token))
+      end
+
+      def each(&blk)
+        api_method =
+          if @status == :open
+            :list_open_workflow_executions
+          elsif @status == :closed
+            :list_closed_workflow_executions
+          else
+            :list_workflow_executions
+          end
+        
+        executions = []
+        
+        loop do
+          response = @connection.public_send(
+            api_method,
+            **@request_options.merge(next_page_token: @request_options[:next_page_token])
+          )
+
+          paginated_executions = response.executions.map do |raw_execution|
+            execution = Temporal::Workflow::ExecutionInfo.generate_from(raw_execution) 
+            if block_given?
+              yield execution
+            end
+
+            execution
+          end
+
+          @request_options[:next_page_token] = response.next_page_token
+
+          return unless @request_options[:max_page_size].nil? # return after the first loop if set pagination size
+
+          executions += paginated_executions
+
+          break if @request_options[:next_page_token].to_s.empty?
+        end
+
+        executions
+      end
+    end
+  end
+end

--- a/lib/temporal/workflow/executions.rb
+++ b/lib/temporal/workflow/executions.rb
@@ -30,7 +30,7 @@ module Temporal
           elsif @status == :closed
             :list_closed_workflow_executions
           else
-            :query_workflow_executions
+            :list_workflow_executions
           end
         
         executions = []

--- a/lib/temporal/workflow/executions.rb
+++ b/lib/temporal/workflow/executions.rb
@@ -1,5 +1,4 @@
-require 'temporal/concerns/payloads'
-require 'temporal/workflow/status'
+require 'temporal/workflow/execution_info'
 
 module Temporal
   class Workflow
@@ -24,14 +23,14 @@ module Temporal
         self.class.new(connection: @connection, status: @status, request_options: @request_options.merge(next_page_token: next_page_token))
       end
 
-      def each(&blk)
+      def each()
         api_method =
           if @status == :open
             :list_open_workflow_executions
           elsif @status == :closed
             :list_closed_workflow_executions
           else
-            :list_workflow_executions
+            :query_workflow_executions
           end
         
         executions = []
@@ -53,7 +52,7 @@ module Temporal
 
           @request_options[:next_page_token] = response.next_page_token
 
-          return unless @request_options[:max_page_size].nil? # return after the first loop if set pagination size
+          return paginated_executions unless @request_options[:max_page_size].nil? # return after the first loop if set pagination size
 
           executions += paginated_executions
 

--- a/lib/temporal/workflow/executions.rb
+++ b/lib/temporal/workflow/executions.rb
@@ -23,7 +23,7 @@ module Temporal
         self.class.new(connection: @connection, status: @status, request_options: @request_options.merge(next_page_token: next_page_token))
       end
 
-      def each()
+      def each
         api_method =
           if @status == :open
             :list_open_workflow_executions

--- a/spec/unit/lib/temporal/client_spec.rb
+++ b/spec/unit/lib/temporal/client_spec.rb
@@ -931,7 +931,7 @@ describe Temporal::Client do
 
       it 'raises ArgumentError' do
         expect do
-          subject.list_open_workflow_executions(namespace, from, filter: filter).each
+          subject.list_open_workflow_executions(namespace, from, filter: filter).to_a
         end.to raise_error(ArgumentError, 'Allowed filters are: [:workflow, :workflow_id]')
       end
     end
@@ -948,7 +948,7 @@ describe Temporal::Client do
 
     context 'when called without filters' do
       it 'makes a request' do
-        subject.list_open_workflow_executions(namespace, from).each
+        subject.list_open_workflow_executions(namespace, from).to_a
 
         expect(connection)
           .to have_received(:list_open_workflow_executions)
@@ -958,7 +958,7 @@ describe Temporal::Client do
 
     context 'when called with :to' do
       it 'makes a request' do
-        subject.list_open_workflow_executions(namespace, from, now - 10).each
+        subject.list_open_workflow_executions(namespace, from, now - 10).to_a
 
         expect(connection)
           .to have_received(:list_open_workflow_executions)
@@ -968,7 +968,7 @@ describe Temporal::Client do
 
     context 'when called with a :workflow filter' do
       it 'makes a request' do
-        subject.list_open_workflow_executions(namespace, from, filter: { workflow: 'TestWorkflow' }).each
+        subject.list_open_workflow_executions(namespace, from, filter: { workflow: 'TestWorkflow' }).to_a
 
         expect(connection)
           .to have_received(:list_open_workflow_executions)
@@ -978,7 +978,7 @@ describe Temporal::Client do
 
     context 'when called with a :workflow_id filter' do
       it 'makes a request' do
-        subject.list_open_workflow_executions(namespace, from, filter: { workflow_id: 'xxx' }).each
+        subject.list_open_workflow_executions(namespace, from, filter: { workflow_id: 'xxx' }).to_a
 
         expect(connection)
           .to have_received(:list_open_workflow_executions)

--- a/spec/unit/lib/temporal/client_spec.rb
+++ b/spec/unit/lib/temporal/client_spec.rb
@@ -800,8 +800,7 @@ describe Temporal::Client do
 
     it 'returns a list of executions' do
       executions = subject.list_open_workflow_executions(namespace, from)
-
-      expect(executions.length).to eq(1)
+      expect(executions.count).to eq(1)
       expect(executions.first).to be_an_instance_of(Temporal::Workflow::ExecutionInfo)
     end
 
@@ -832,33 +831,98 @@ describe Temporal::Client do
       end
 
       it 'calls the API 3 times' do
-        subject.list_open_workflow_executions(namespace, from)
+        subject.list_open_workflow_executions(namespace, from).count
 
         expect(connection).to have_received(:list_open_workflow_executions).exactly(3).times
 
         expect(connection)
           .to have_received(:list_open_workflow_executions)
-          .with(namespace: namespace, from: from, to: now, next_page_token: nil)
+          .with(namespace: namespace, from: from, to: now, next_page_token: nil, max_page_size: nil)
           .once
 
         expect(connection)
           .to have_received(:list_open_workflow_executions)
-          .with(namespace: namespace, from: from, to: now, next_page_token: 'a')
+          .with(namespace: namespace, from: from, to: now, next_page_token: 'a', max_page_size: nil)
           .once
 
         expect(connection)
           .to have_received(:list_open_workflow_executions)
-          .with(namespace: namespace, from: from, to: now, next_page_token: 'b')
+          .with(namespace: namespace, from: from, to: now, next_page_token: 'b', max_page_size: nil)
           .once
       end
 
       it 'returns a list of executions' do
         executions = subject.list_open_workflow_executions(namespace, from)
 
-        expect(executions.length).to eq(3)
+        expect(executions.count).to eq(3)
         executions.each do |execution|
           expect(execution).to be_an_instance_of(Temporal::Workflow::ExecutionInfo)
         end
+      end
+
+      it 'returns the next page token and paginates correctly' do        
+        executions1 = subject.list_open_workflow_executions(namespace, from, max_page_size: 10)
+        executions1.map do |execution|
+          expect(execution).to be_an_instance_of(Temporal::Workflow::ExecutionInfo)
+        end
+        expect(executions1.next_page_token).to eq('a')
+        expect(connection)
+          .to have_received(:list_open_workflow_executions)
+          .with(namespace: namespace, from: from, to: now, next_page_token: nil, max_page_size: 10)
+          .once
+
+        executions2 = subject.list_open_workflow_executions(namespace, from, next_page_token: executions1.next_page_token, max_page_size: 10)
+        executions2.map do |execution|
+          expect(execution).to be_an_instance_of(Temporal::Workflow::ExecutionInfo)
+        end
+        expect(executions2.next_page_token).to eq('b')
+        expect(connection)
+          .to have_received(:list_open_workflow_executions)
+          .with(namespace: namespace, from: from, to: now, next_page_token: 'a', max_page_size: 10)
+          .once
+
+        executions3 = subject.list_open_workflow_executions(namespace, from, next_page_token: executions2.next_page_token, max_page_size: 10)
+        executions3.map do |execution|
+          expect(execution).to be_an_instance_of(Temporal::Workflow::ExecutionInfo)
+        end
+        expect(executions3.next_page_token).to eq('')
+        expect(connection)
+          .to have_received(:list_open_workflow_executions)
+          .with(namespace: namespace, from: from, to: now, next_page_token: 'a', max_page_size: 10)
+          .once
+      end
+
+      it 'returns the next page and paginates correctly' do        
+        executions1 = subject.list_open_workflow_executions(namespace, from, max_page_size: 10)
+        executions1.map do |execution|
+          expect(execution).to be_an_instance_of(Temporal::Workflow::ExecutionInfo)
+        end
+        expect(executions1.next_page_token).to eq('a')
+        expect(connection)
+          .to have_received(:list_open_workflow_executions)
+          .with(namespace: namespace, from: from, to: now, next_page_token: nil, max_page_size: 10)
+          .once
+
+        executions2 = executions1.next_page
+        executions2.map do |execution|
+          expect(execution).to be_an_instance_of(Temporal::Workflow::ExecutionInfo)
+        end
+        expect(executions2.next_page_token).to eq('b')
+        expect(connection)
+          .to have_received(:list_open_workflow_executions)
+          .with(namespace: namespace, from: from, to: now, next_page_token: 'a', max_page_size: 10)
+          .once
+
+        executions3 = executions2.next_page
+        executions3.map do |execution|
+          expect(execution).to be_an_instance_of(Temporal::Workflow::ExecutionInfo)
+        end
+        expect(executions3.next_page_token).to eq('')
+        expect(connection)
+          .to have_received(:list_open_workflow_executions)
+          .with(namespace: namespace, from: from, to: now, next_page_token: 'a', max_page_size: 10)
+          .once
+
       end
     end
 
@@ -867,7 +931,7 @@ describe Temporal::Client do
 
       it 'raises ArgumentError' do
         expect do
-          subject.list_open_workflow_executions(namespace, from, filter: filter)
+          subject.list_open_workflow_executions(namespace, from, filter: filter).each
         end.to raise_error(ArgumentError, 'Allowed filters are: [:workflow, :workflow_id]')
       end
     end
@@ -877,48 +941,48 @@ describe Temporal::Client do
 
       it 'raises ArgumentError' do
         expect do
-          subject.list_open_workflow_executions(namespace, from, filter: filter)
+          subject.list_open_workflow_executions(namespace, from, filter: filter).count
         end.to raise_error(ArgumentError, 'Only one filter is allowed')
       end
     end
 
     context 'when called without filters' do
       it 'makes a request' do
-        subject.list_open_workflow_executions(namespace, from)
+        subject.list_open_workflow_executions(namespace, from).each
 
         expect(connection)
           .to have_received(:list_open_workflow_executions)
-          .with(namespace: namespace, from: from, to: now, next_page_token: nil)
+          .with(namespace: namespace, from: from, to: now, next_page_token: nil, max_page_size: nil)
       end
     end
 
     context 'when called with :to' do
       it 'makes a request' do
-        subject.list_open_workflow_executions(namespace, from, now - 10)
+        subject.list_open_workflow_executions(namespace, from, now - 10).each
 
         expect(connection)
           .to have_received(:list_open_workflow_executions)
-          .with(namespace: namespace, from: from, to: now - 10, next_page_token: nil)
+          .with(namespace: namespace, from: from, to: now - 10, next_page_token: nil, max_page_size: nil)
       end
     end
 
     context 'when called with a :workflow filter' do
       it 'makes a request' do
-        subject.list_open_workflow_executions(namespace, from, filter: { workflow: 'TestWorkflow' })
+        subject.list_open_workflow_executions(namespace, from, filter: { workflow: 'TestWorkflow' }).each
 
         expect(connection)
           .to have_received(:list_open_workflow_executions)
-          .with(namespace: namespace, from: from, to: now, next_page_token: nil, workflow: 'TestWorkflow')
+          .with(namespace: namespace, from: from, to: now, next_page_token: nil, workflow: 'TestWorkflow', max_page_size: nil)
       end
     end
 
     context 'when called with a :workflow_id filter' do
       it 'makes a request' do
-        subject.list_open_workflow_executions(namespace, from, filter: { workflow_id: 'xxx' })
+        subject.list_open_workflow_executions(namespace, from, filter: { workflow_id: 'xxx' }).each
 
         expect(connection)
           .to have_received(:list_open_workflow_executions)
-          .with(namespace: namespace, from: from, to: now, next_page_token: nil, workflow_id: 'xxx')
+          .with(namespace: namespace, from: from, to: now, next_page_token: nil, workflow_id: 'xxx', max_page_size: nil)
       end
     end
   end


### PR DESCRIPTION
# Summary
Adds the `list_workflow_executions` API to the client (which support searching by the query string [List Filters API](https://docs.temporal.io/docs/temporal-explained/visibility/#list-filters)) and exposes the pagination for `list_open_workflow_executions` and `list_closed_workflow_exceptions`.

```ruby
# fully backwards compatible (executions is a custom class, but has Enumerable interface, so fully compatible with the current version)
executions = client.list_workflow_executions(namespace, query)
executions.each { |execution| ... } # iterates through all executions on all pages, loaded lazily

# limiting results per page
executions = client.list_workflow_executions(namespace, query, max_page_size: 100)
executions.each { |execution| ... } # iterates through a single page only
token = executions.next_page_token # gives you access to the token

# with per page limit and a next page token
executions = client.list_workflow_executions(namespace, query, max_page_size: 100, next_page_token: token)
executions.each { |execution| ... } # iterates through a single page only
executions.next_page_token # gives you access to the next token

# even supports next page iterator
executions = executions.next_page # gives you a next page iterator
```

# Test Plan
```
# unit test
bundle exec rspec spec/

# integration test
cd examples
(terminal 1) ./bin/worker
(terminal 2) USE_ENCRYPTION=1 ./bin/worker
(terminal 3) bundle exec rspec spec/integration
```