### PR TITLE
Binary checksum

### DIFF
--- a/examples/bin/worker
+++ b/examples/bin/worker
@@ -17,7 +17,7 @@ if !ENV['USE_ENCRYPTION'].nil?
   end
 end
 
-worker = Temporal::Worker.new
+worker = Temporal::Worker.new(binary_checksum: `git show HEAD -s --format=%H`.strip)
 
 worker.register_workflow(AsyncActivityWorkflow)
 worker.register_workflow(AsyncHelloWorldWorkflow)

--- a/examples/spec/integration/upsert_search_attributes_spec.rb
+++ b/examples/spec/integration/upsert_search_attributes_spec.rb
@@ -4,8 +4,9 @@ require 'time'
 describe 'Temporal::Workflow::Context.upsert_search_attributes', :integration do
   it 'can upsert a search attribute and then retrieve it' do
     workflow_id = 'upsert_search_attributes_test_wf-' + SecureRandom.uuid
+    expected_binary_checksum = `git show HEAD -s --format=%H`.strip
 
-    expected_attributes = {
+    expected_added_attributes = {
       'CustomStringField' => 'moo',
       'CustomBoolField' => true,
       'CustomDoubleField' => 3.14,
@@ -15,7 +16,7 @@ describe 'Temporal::Workflow::Context.upsert_search_attributes', :integration do
 
     run_id = Temporal.start_workflow(
       UpsertSearchAttributesWorkflow,
-      *expected_attributes.values,
+      *expected_added_attributes.values,
       options: {
         workflow_id: workflow_id,
       },
@@ -26,7 +27,13 @@ describe 'Temporal::Workflow::Context.upsert_search_attributes', :integration do
       workflow_id: workflow_id,
       run_id: run_id,
     )
-    expect(added_attributes).to eq(expected_attributes)
+    expect(added_attributes).to eq(expected_added_attributes)
+
+    # These attributes are set for the worker in bin/worker
+    expected_attributes = {
+      # Contains a list of all binary checksums seen for this workflow execution
+      'BinaryChecksums' => [expected_binary_checksum]
+    }.merge(expected_added_attributes)
 
     execution_info = Temporal.fetch_workflow_execution_info(
       integration_spec_namespace,

--- a/lib/temporal/worker.rb
+++ b/lib/temporal/worker.rb
@@ -8,10 +8,23 @@ module Temporal
   class Worker
     # activity_thread_pool_size: number of threads that the poller can use to run activities.
     #   can be set to 1 if you want no paralellism in your activities, at the cost of throughput.
+
+    # binary_checksum: The binary checksum identifies the version of workflow worker code. It is set on each completed or failed workflow
+    #   task. It is present in API responses that return workflow execution info, and is shown in temporal-web and tctl.
+    #   It is traditionally a checksum of the application binary. However, Temporal server treats this as an opaque
+    #   identifier and it does not have to be a "checksum". Typical values for a Ruby application might include the hash
+    #   of the latest git commit or a semantic version number.
+    #
+    #   It can be used to reset workflow history to before a "bad binary" was deployed. Bad checksum values can also
+    #   be marked at the namespace level. This will cause Temporal server to reject any polling for workflow tasks
+    #   from workers with these bad versions.
+    #
+    #   See https://docs.temporal.io/docs/tctl/how-to-use-tctl/#recovery-from-bad-deployment----auto-reset-workflow
     def initialize(
       config = Temporal.configuration,
       activity_thread_pool_size: Temporal::Activity::Poller::DEFAULT_OPTIONS[:thread_pool_size],
-      workflow_thread_pool_size: Temporal::Workflow::Poller::DEFAULT_OPTIONS[:thread_pool_size]
+      workflow_thread_pool_size: Temporal::Workflow::Poller::DEFAULT_OPTIONS[:thread_pool_size],
+      binary_checksum: Temporal::Workflow::Poller::DEFAULT_OPTIONS[:binary_checksum]
     )
       @config = config
       @workflows = Hash.new { |hash, key| hash[key] = ExecutableLookup.new }
@@ -25,6 +38,7 @@ module Temporal
       }
       @workflow_poller_options = {
         thread_pool_size: workflow_thread_pool_size,
+        binary_checksum: binary_checksum
       }
     end
 

--- a/spec/fabricators/grpc/history_event_fabricator.rb
+++ b/spec/fabricators/grpc/history_event_fabricator.rb
@@ -73,7 +73,8 @@ Fabricator(:api_workflow_task_completed_event, from: :api_history_event) do
     Temporal::Api::History::V1::WorkflowTaskCompletedEventAttributes.new(
       scheduled_event_id: attrs[:event_id] - 2,
       started_event_id: attrs[:event_id] - 1,
-      identity: 'test-worker@test-host'
+      identity: 'test-worker@test-host',
+      binary_checksum: 'v1.0.0',
     )
   end
 end

--- a/spec/unit/lib/temporal/workflow/poller_spec.rb
+++ b/spec/unit/lib/temporal/workflow/poller_spec.rb
@@ -10,8 +10,20 @@ describe Temporal::Workflow::Poller do
   let(:config) { Temporal::Configuration.new }
   let(:middleware_chain) { instance_double(Temporal::Middleware::Chain) }
   let(:middleware) { [] }
+  let(:binary_checksum) { 'v1.0.0' }
 
-  subject { described_class.new(namespace, task_queue, lookup, config, middleware) }
+  subject do
+    described_class.new(
+      namespace,
+      task_queue,
+      lookup,
+      config,
+      middleware,
+      {
+        binary_checksum: binary_checksum
+      }
+    )
+  end
 
   before do
     allow(Temporal::Connection).to receive(:generate).and_return(connection)
@@ -31,7 +43,7 @@ describe Temporal::Workflow::Poller do
 
       expect(connection)
         .to have_received(:poll_workflow_task_queue)
-        .with(namespace: namespace, task_queue: task_queue)
+        .with(namespace: namespace, task_queue: task_queue, binary_checksum: binary_checksum)
         .twice
     end
 
@@ -75,7 +87,7 @@ describe Temporal::Workflow::Poller do
 
         expect(Temporal::Workflow::TaskProcessor)
           .to have_received(:new)
-          .with(task, namespace, lookup, middleware_chain, config)
+          .with(task, namespace, lookup, middleware_chain, config, binary_checksum)
         expect(task_processor).to have_received(:process)
       end
 
@@ -98,7 +110,7 @@ describe Temporal::Workflow::Poller do
           expect(Temporal::Middleware::Chain).to have_received(:new).with(middleware)
           expect(Temporal::Workflow::TaskProcessor)
             .to have_received(:new)
-            .with(task, namespace, lookup, middleware_chain, config)
+            .with(task, namespace, lookup, middleware_chain, config, binary_checksum)
         end
       end
     end

--- a/spec/unit/lib/temporal/workflow/task_processor_spec.rb
+++ b/spec/unit/lib/temporal/workflow/task_processor_spec.rb
@@ -3,7 +3,7 @@ require 'temporal/middleware/chain'
 require 'temporal/configuration'
 
 describe Temporal::Workflow::TaskProcessor do
-  subject { described_class.new(task, namespace, lookup, middleware_chain, config) }
+  subject { described_class.new(task, namespace, lookup, middleware_chain, config, binary_checksum) }
 
   let(:namespace) { 'test-namespace' }
   let(:lookup) { instance_double('Temporal::ExecutableLookup', find: nil) }
@@ -16,6 +16,7 @@ describe Temporal::Workflow::TaskProcessor do
   let(:middleware_chain) { Temporal::Middleware::Chain.new }
   let(:input) { ['arg1', 'arg2'] }
   let(:config) { Temporal::Configuration.new }
+  let(:binary_checksum) { 'v1.0.0' }
 
   describe '#process' do
     let(:context) { instance_double('Temporal::Workflow::Context') }
@@ -113,6 +114,7 @@ describe Temporal::Workflow::TaskProcessor do
                 namespace: namespace,
                 task_token: task.task_token,
                 commands: commands,
+                binary_checksum: binary_checksum,
                 query_results: { query_id => query_result }
               )
           end
@@ -150,7 +152,7 @@ describe Temporal::Workflow::TaskProcessor do
             expect(connection).to_not have_received(:respond_query_task_completed)
             expect(connection)
               .to have_received(:respond_workflow_task_completed)
-              .with(namespace: namespace, task_token: task.task_token, commands: commands, query_results: nil)
+              .with(namespace: namespace, task_token: task.task_token, commands: commands, query_results: nil, binary_checksum: binary_checksum)
           end
 
           it 'ignores connection exception' do
@@ -196,7 +198,8 @@ describe Temporal::Workflow::TaskProcessor do
                 namespace: namespace,
                 task_token: task.task_token,
                 cause: Temporal::Api::Enums::V1::WorkflowTaskFailedCause::WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED_FAILURE,
-                exception: exception
+                exception: exception,
+                binary_checksum: binary_checksum
               )
           end
         end
@@ -211,7 +214,8 @@ describe Temporal::Workflow::TaskProcessor do
                 namespace: namespace,
                 task_token: task.task_token,
                 cause: Temporal::Api::Enums::V1::WorkflowTaskFailedCause::WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED_FAILURE,
-                exception: exception
+                exception: exception,
+                binary_checksum: binary_checksum
               )
           end
 
@@ -325,7 +329,8 @@ describe Temporal::Workflow::TaskProcessor do
                 namespace: namespace,
                 task_token: task.task_token,
                 cause: Temporal::Api::Enums::V1::WorkflowTaskFailedCause::WORKFLOW_TASK_FAILED_CAUSE_WORKFLOW_WORKER_UNHANDLED_FAILURE,
-                exception: an_instance_of(Temporal::UnexpectedResponse)
+                exception: an_instance_of(Temporal::UnexpectedResponse),
+                binary_checksum: binary_checksum
               )
           end
         end


### PR DESCRIPTION
### Summary

Adds binary checksums for propagating information about the binary running workflow tasks into Temporal

This makes it possible to see the version of the worker code that executed a workflow task in temporal-web and tctl. The value is also indexed into elastic search, where it becomes possible to query for all workflows that executed on a certain worker version. Workflow histories can be reset to the last entry before a "bad" version was deployed. Checksums can also be marked as "bad" on a per namespace basis, resulting in Temporal server rejecting polling requests from workers running a "bad" version.

### Testing

Modified existing specs where binary checksum is propagated down:
```
rspec spec/unit/lib/temporal/grpc_spec.rb
rspec spec/unit/lib/temporal/worker_spec.rb
rspec spec/unit/lib/temporal/workflow/poller_spec.rb
rspec spec/unit/lib/temporal/workflow/task_processor_spec.rb
```

The integration worker binary sets this to the latest git commit hash that is then checked in a modified integration test for upserting search attributes:
```
cd examples
bin/worker # in another terminal
USE_ENCRYPTION=1 bin/worker # in another terminal
rspec spec/integration/upsert_search_attributes_spec.rb
```