### PR TITLE
Fix a merge error between child workflows and metadata enrichment

### DIFF
--- a/lib/temporal/testing/local_workflow_context.rb
+++ b/lib/temporal/testing/local_workflow_context.rb
@@ -137,6 +137,8 @@ module Temporal
           id: workflow_id,
           name: execution_options.name, # Workflow class name
           run_id: run_id,
+          parent_id: @workflow_id,
+          parent_run_id: @run_id,
           attempt: 1,
           task_queue: execution_options.task_queue,
           headers: execution_options.headers,


### PR DESCRIPTION
## Motivation
https://github.com/coinbase/temporal-ruby/pull/130 changed how workflow metadata was constructed in unit test land, and https://github.com/coinbase/temporal-ruby/pull/169 added two required fields on workflow metadata. 130 was written before 169, but merged after 169 (with no merge conflicts). Because 130 doesn't pass the two required fields, unit tests that try to run child workflows locally are currently broken.

## What changed?
Pass the two new required fields to `Workflow::Metadata.new` when running child workflows locally.

## Testing
```
bundle exec rspec spec/
cd examples
./bin/worker &
USE_ENCRYPTION=1 ./bin/worker &
bundle exec rspec spec/integration
```