### PR TITLE
Important performance and correctness fixes for wait_until

### DIFF
--- a/lib/temporal/workflow/dispatcher.rb
+++ b/lib/temporal/workflow/dispatcher.rb
@@ -1,3 +1,5 @@
+require 'temporal/errors'
+
 module Temporal
   class Workflow
     # This provides a generic event dispatcher mechanism. There are two main entry
@@ -13,18 +15,44 @@ module Temporal
     # the event_name. The order of this dispatch is not guaranteed.
     #
     class Dispatcher
+      # Raised if a duplicate ID is encountered during dispatch handling.
+      # This likely indicates a bug in temporal-ruby or that unsupported multithreaded
+      # workflow code is being used.
+      class DuplicateIDError < InternalError; end
+
+      # Tracks a registered handle so that it can be unregistered later
+      # The handlers are passed by reference here to be mutated (removed) by the
+      # unregister call below.
+      class RegistrationHandle
+        def initialize(handlers_for_target, id)
+          @handlers_for_target = handlers_for_target
+          @id = id
+        end
+
+        # Unregister the handler from the dispatcher
+        def unregister
+          handlers_for_target.delete(id)
+        end
+
+        private
+
+        attr_reader :handlers_for_target, :id
+      end
+
       WILDCARD = '*'.freeze
       TARGET_WILDCARD = '*'.freeze
 
       EventStruct = Struct.new(:event_name, :handler)
 
       def initialize
-        @handlers = Hash.new { |hash, key| hash[key] = [] }
+        @handlers = Hash.new { |hash, key| hash[key] = {} }
+        @next_id = 0
       end
 
       def register_handler(target, event_name, &handler)
-        handlers[target] << EventStruct.new(event_name, handler)
-        self
+        @next_id += 1
+        handlers[target][@next_id] = EventStruct.new(event_name, handler)
+        RegistrationHandle.new(handlers[target], @next_id)
       end
 
       def dispatch(target, event_name, args = nil)
@@ -39,9 +67,10 @@ module Temporal
 
       def handlers_for(target, event_name)
         handlers[target]
-          .concat(handlers[TARGET_WILDCARD])
-          .select { |event_struct| match?(event_struct, event_name) }
-          .map(&:handler)
+          .merge(handlers[TARGET_WILDCARD]) { raise DuplicateIDError.new('Cannot resolve duplicate dispatcher handler IDs') }
+          .select { |_, event_struct| match?(event_struct, event_name) }
+          .sort
+          .map { |_, event_struct| event_struct.handler }
       end
 
       def match?(event_struct, event_name)


### PR DESCRIPTION
This contains critical follow ups to #111.

### Deterministically order wildcard dispatch handlers

Dispatch handlers for `wait_until` are now called in a deterministic order that does not change as a workflow progresses, preventing non-determinism errors from arising where user code is indeed deterministic.

When `wait_until` is called, a dispatch handler is added that resumes the fiber once the condition has been satisfied. Because this condition could change due to any workflow progress, it must be evaluated on every dispatch. Before this change, all `wait_until` handlers were always evaluated after any targeted dispatch callbacks (such as from a specific activity or timer). This can cause non-determinism in certain corner cases. These callbacks are now always called in the same order. This is achieved by associating an autoincrementing, unique ID with each handler. When the list of handlers is merged and filtered, it is now sorted by these IDs, guaranteeing order even as the workflow progresses.

### Remove dispatch handlers once they're no longer needed

In activities with long histories, the number of dispatch handlers can get large. Particularly for workflows that call `wait_until` many times (such as in a loop), the number can get very large, and they must be invoked on _every_ dispatch. This can cause performance problems that result in workflow task timeout.

This change removes dispatch handlers once no longer needed. The unique autoincrementing ID mentioned from the above fix is used to remove handlers once they are no longer needed, dramatically improving performance for workflows with long histories. A `DispatchHandler` type is introduced to encapsulate this removal-by-id behavior.