### PR TITLE
Query functionality for temporal-web: stack trace and registered queries

### DIFF
--- a/examples/spec/integration/query_workflow_spec.rb
+++ b/examples/spec/integration/query_workflow_spec.rb
@@ -24,6 +24,11 @@ describe QueryWorkflow, :integration do
     expect { Temporal.query_workflow(described_class, 'unknown_query', workflow_id, run_id) }
       .to raise_error(Temporal::QueryFailed, 'Workflow did not register a handler for unknown_query')
 
+    # Query built-in stack trace handler, looking for a couple of key parts of the contents
+    stack_trace = Temporal.query_workflow(described_class, '__stack_trace', workflow_id, run_id)
+    expect(stack_trace).to start_with "Fiber count: 1\n\n"
+    expect(stack_trace).to include "/examples/workflows/query_workflow.rb:"
+
     Temporal.signal_workflow(described_class, 'make_progress', workflow_id, run_id)
 
     # Query for updated signal_count with an unsatisfied reject condition

--- a/examples/spec/integration/query_workflow_spec.rb
+++ b/examples/spec/integration/query_workflow_spec.rb
@@ -22,7 +22,7 @@ describe QueryWorkflow, :integration do
 
     # Query with unregistered handler
     expect { Temporal.query_workflow(described_class, 'unknown_query', workflow_id, run_id) }
-      .to raise_error(Temporal::QueryFailed, 'Workflow did not register a handler for unknown_query')
+      .to raise_error(Temporal::QueryFailed, "Workflow did not register a handler for 'unknown_query'. KnownQueryTypes=[__stack_trace, state, signal_count]")
 
     # Query built-in stack trace handler, looking for a couple of key parts of the contents
     stack_trace = Temporal.query_workflow(described_class, '__stack_trace', workflow_id, run_id)
@@ -50,7 +50,7 @@ describe QueryWorkflow, :integration do
       .to eq 2
 
     expect { Temporal.query_workflow(described_class, 'unknown_query', workflow_id, run_id) }
-      .to raise_error(Temporal::QueryFailed, 'Workflow did not register a handler for unknown_query')
+      .to raise_error(Temporal::QueryFailed, "Workflow did not register a handler for 'unknown_query'. KnownQueryTypes=[__stack_trace, state, signal_count]")
 
     # Now that the workflow is completed, test a query with a reject condition satisfied
     expect { Temporal.query_workflow(described_class, 'state', workflow_id, run_id, query_reject_condition: :not_open) }

--- a/lib/temporal/workflow/executor.rb
+++ b/lib/temporal/workflow/executor.rb
@@ -1,9 +1,10 @@
 require 'fiber'
 
+require 'temporal/workflow/context'
 require 'temporal/workflow/dispatcher'
 require 'temporal/workflow/query_registry'
+require 'temporal/workflow/stack_trace_tracker'
 require 'temporal/workflow/state_manager'
-require 'temporal/workflow/context'
 require 'temporal/workflow/history/event_target'
 require 'temporal/metadata'
 
@@ -14,7 +15,8 @@ module Temporal
       # @param history [Workflow::History]
       # @param task_metadata [Metadata::WorkflowTask]
       # @param config [Configuration]
-      def initialize(workflow_class, history, task_metadata, config)
+      # @param track_stack_trace [Boolean]
+      def initialize(workflow_class, history, task_metadata, config, track_stack_trace)
         @workflow_class = workflow_class
         @dispatcher = Dispatcher.new
         @query_registry = QueryRegistry.new
@@ -22,6 +24,7 @@ module Temporal
         @history = history
         @task_metadata = task_metadata
         @config = config
+        @track_stack_trace = track_stack_trace
       end
 
       def run
@@ -46,13 +49,13 @@ module Temporal
       # @param queries [Hash<String, Temporal::Workflow::TaskProcessor::Query>]
       #
       # @return [Hash<String, Temporal::Workflow::QueryResult>]
-      def process_queries(queries = {})
+      def process_queries(queries)
         queries.transform_values(&method(:process_query))
       end
 
       private
 
-      attr_reader :workflow_class, :dispatcher, :query_registry, :state_manager, :task_metadata, :history, :config
+      attr_reader :workflow_class, :dispatcher, :query_registry, :state_manager, :task_metadata, :history, :config, :track_stack_trace
 
       def process_query(query)
         result = query_registry.handle(query.query_type, query.query_args)
@@ -64,7 +67,7 @@ module Temporal
 
       def execute_workflow(input, workflow_started_event)
         metadata = Metadata.generate_workflow_metadata(workflow_started_event, task_metadata)
-        context = Workflow::Context.new(state_manager, dispatcher, workflow_class, metadata, config, query_registry)
+        context = Workflow::Context.new(state_manager, dispatcher, workflow_class, metadata, config, query_registry, track_stack_trace)
 
         Fiber.new do
           workflow_class.execute_in_context(context, input)

--- a/lib/temporal/workflow/query_registry.rb
+++ b/lib/temporal/workflow/query_registry.rb
@@ -19,7 +19,10 @@ module Temporal
         handler = handlers[type]
 
         unless handler
-          raise Temporal::QueryFailed, "Workflow did not register a handler for #{type}"
+          # The end of the formatted error message (e.g., "KnownQueryTypes=[query-1, query-2, query-3]")
+          # is used by temporal-web to show a list of queries that can be run on the 'Query' tab of a
+          # workflow. If that part of the error message is changed, that functionality will break.
+          raise Temporal::QueryFailed, "Workflow did not register a handler for '#{type}'. KnownQueryTypes=[#{handlers.keys.join(", ")}]"
         end
 
         handler.call(*args)

--- a/lib/temporal/workflow/stack_trace_tracker.rb
+++ b/lib/temporal/workflow/stack_trace_tracker.rb
@@ -1,0 +1,39 @@
+require 'fiber'
+
+module Temporal
+  class Workflow
+    # Temporal-web issues a query that returns the stack trace for all workflow fibers
+    # that are currently scheduled. This is helpful for understanding what exactly a
+    # workflow is waiting on.
+    class StackTraceTracker
+      STACK_TRACE_QUERY_NAME = '__stack_trace'
+
+      def initialize
+        @stack_traces = {}
+      end
+
+      # Record the stack trace for the current fiber
+      def record
+        stack_traces[Fiber.current] = Kernel.caller
+      end
+
+      # Clear the stack traces for the current fiber
+      def clear
+        stack_traces.delete(Fiber.current)
+      end
+
+      # Format all recorded backtraces in a human readable format
+      def to_s
+        formatted_stack_traces = ["Fiber count: #{stack_traces.count}"] + stack_traces.map do |_, stack_trace|
+          stack_trace.join("\n")
+        end
+
+        formatted_stack_traces.join("\n\n") + "\n"
+      end
+
+      private
+
+      attr_reader :stack_traces
+    end
+  end
+end

--- a/spec/unit/lib/temporal/workflow/executor_spec.rb
+++ b/spec/unit/lib/temporal/workflow/executor_spec.rb
@@ -111,7 +111,7 @@ describe Temporal::Workflow::Executor do
       expect(results['2'].error).to eq(query_2_error)
       expect(results['3']).to be_a(Temporal::Workflow::QueryResult::Failure)
       expect(results['3'].error).to be_a(Temporal::QueryFailed)
-      expect(results['3'].error.message).to eq('Workflow did not register a handler for unknown')
+      expect(results['3'].error.message).to eq("Workflow did not register a handler for 'unknown'. KnownQueryTypes=[success, failure]")
     end
   end
 end

--- a/spec/unit/lib/temporal/workflow/executor_spec.rb
+++ b/spec/unit/lib/temporal/workflow/executor_spec.rb
@@ -5,7 +5,7 @@ require 'temporal/workflow/task_processor'
 require 'temporal/workflow/query_registry'
 
 describe Temporal::Workflow::Executor do
-  subject { described_class.new(workflow, history, workflow_metadata, config) }
+  subject { described_class.new(workflow, history, workflow_metadata, config, false) }
 
   let(:workflow_started_event) { Fabricate(:api_workflow_execution_started_event, event_id: 1) }
   let(:history) do

--- a/spec/unit/lib/temporal/workflow/query_registry_spec.rb
+++ b/spec/unit/lib/temporal/workflow/query_registry_spec.rb
@@ -60,7 +60,7 @@ describe Temporal::Workflow::QueryRegistry do
       it 'raises' do
         expect do
           subject.handle('test-query')
-        end.to raise_error(Temporal::QueryFailed, 'Workflow did not register a handler for test-query')
+        end.to raise_error(Temporal::QueryFailed, "Workflow did not register a handler for 'test-query'. KnownQueryTypes=[]")
       end
     end
   end

--- a/spec/unit/lib/temporal/workflow/stack_trace_tracker_spec.rb
+++ b/spec/unit/lib/temporal/workflow/stack_trace_tracker_spec.rb
@@ -1,0 +1,56 @@
+require 'temporal/workflow/stack_trace_tracker'
+
+describe Temporal::Workflow::StackTraceTracker do
+  subject { described_class.new }
+  describe '#to_s' do
+    def record_function
+      subject.record
+    end
+
+    def record_and_clear_function
+      subject.record
+      subject.clear
+    end
+
+    def record_two_function
+      subject.record
+
+      Fiber.new do
+        subject.record
+      end.resume
+    end
+
+    it 'starts empty' do
+      expect(subject.to_s).to eq("Fiber count: 0\n")
+    end
+
+    it 'one fiber' do
+      record_function
+      stack_trace = subject.to_s
+      expect(stack_trace).to start_with("Fiber count: 1\n\n")
+
+      first_stack_line = stack_trace.split("\n")[2]
+      expect(first_stack_line).to include("record_function")
+    end
+
+    it 'one fiber cleared' do
+      record_and_clear_function
+      stack_trace = subject.to_s
+      expect(stack_trace).to start_with("Fiber count: 0\n")
+    end
+
+    it 'two fibers' do
+      record_two_function
+      output = subject.to_s
+      expect(output).to start_with("Fiber count: 2\n\n")
+
+      stack_traces = output.split("\n\n")
+
+      first_stack = stack_traces[1]
+      expect(first_stack).to include("record_two_function")
+
+      second_stack = stack_traces[2]
+      expect(second_stack).to include("block in record_two_function")
+    end
+  end
+end


### PR DESCRIPTION
### Summary

- Adds a built-in `__stack_trace` query for all workflows that returns the stack trace of all suspended fibers for a workflow
- The error message returned when an unknown query is received now matches that of the Go SDK ([source](https://github.com/temporalio/sdk-go/blob/cee305f568f4b7cba5ec1c597d206bd0114289d7/internal/internal_workflow.go#L550))
   - Temporal-web intentionally makes an unknown query `__cadence_web_list`, then parses its error message to extract a list of all registered queries.
   - Matching the error message has the effect of enableing a UI in temporal-web for executing queries on the 'Query' tab of a workflow.

### Screenshot

If there are multiple fibers suspended, it displays more than one stack trace. Here, we see a workflow that is sleeping in an activity's done callback, while waiting for an activity to synchronously complete.

<img width="637" alt="image" src="https://user-images.githubusercontent.com/15093535/172080616-ea039b1f-f6eb-4ebe-87ab-a46f71e37058.png">

### Testing

There are several new or modified specs:
```
# Modified spec with some additional tests for the stack trace query end-to-end behavior
bundle exec rspec spec/unit/lib/temporal/workflow/context_spec.rb

# Minorly modified to propagate tracking bit
bundle exec rspec spec/unit/lib/temporal/workflow/executor_spec.rb

# New unit tests for new StackTraceTracker class
bundle exec rspec spec/unit/lib/temporal/workflow/stack_trace_tracker_spec.rb

# Modified existing example test for queries to perform both of these built-in queries and check their outputs
cd examples
bundle rspec examples/spec/integration/query_workflow_spec.rb
```