### PR TITLE
Add gRPC credentials

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,6 @@ jobs:
           - POSTGRES_USER=postgres
           - POSTGRES_PWD=temporal
           - POSTGRES_SEEDS=postgres
-          - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml
 
     environment:
       - TEMPORAL_HOST=temporal

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ docker-compose up
 ### SSL
 
 In many production deployments you will end up connecting to your Temporal Services via SSL. In this
-case you must read the public cert of the CA that issued your Temporal server's SSL cert and create
+case you must read the public certificate of the CA that issued your Temporal server's SSL certificate and create
 an instance of [gRPC Channel Credentials](https://grpc.io/docs/guides/auth/#with-server-authentication-ssltls-1).
 
 Configure your Temporal connection:

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Temporal.configure do |config|
   config.port = 7233
   config.namespace = 'ruby-samples'
   config.task_queue = 'hello-world'
+  config.credentials = :this_channel_is_insecure
 end
 
 begin
@@ -112,6 +113,57 @@ Run:
 curl -O https://raw.githubusercontent.com/temporalio/docker-compose/main/docker-compose.yml
 
 docker-compose up
+```
+
+## Using Credentials
+
+### SSL
+
+In many production deployments you will end up connecting to your Temporal Services via SSL. In this
+case you must read the public cert of the CA that issued your Temporal server's SSL cert and create
+an instance of [gRPC Channel Credentials](https://grpc.io/docs/guides/auth/#with-server-authentication-ssltls-1).
+
+Configure your Temporal connection:
+
+```ruby
+Temporal.configure do |config|
+    config.host = 'localhost'
+    config.port = 7233
+    config.namespace = 'ruby-samples'
+    config.task_queue = 'hello-world'
+    config.credentials = GRPC::Core::ChannelCredentials.new(root_cert, client_key, client_chain)
+end
+```
+
+### OAuth2 Token
+
+Use gRPC Call Credentials to add OAuth2 token to gRPC calls:
+
+```ruby
+Temporal.configure do |config|
+    config.host = 'localhost'
+    config.port = 7233
+    config.namespace = 'ruby-samples'
+    config.task_queue = 'hello-world'
+    config.credentials = GRPC::Core::CallCredentials.new(updater_proc)
+end
+```
+`updater_proc` should be a method that returns `proc`. See an example of `updater_proc` in [googleauth](https://www.rubydoc.info/gems/googleauth/0.1.0/Signet/OAuth2/Client) library.
+
+### Combining Credentials
+
+To configure both SSL and OAuth2 token cedentials use `compose` method:
+
+```ruby
+Temporal.configure do |config|
+    config.host = 'localhost'
+    config.port = 7233
+    config.namespace = 'ruby-samples'
+    config.task_queue = 'hello-world'
+    config.credentials = GRPC::Core::ChannelCredentials.new(root_cert, client_key, client_chain).compose(
+        GRPC::Core::CallCredentials.new(token.updater_proc)
+    )
+end
 ```
 
 ## Workflows

--- a/lib/temporal/configuration.rb
+++ b/lib/temporal/configuration.rb
@@ -7,12 +7,12 @@ require 'temporal/connection/converter/composite'
 
 module Temporal
   class Configuration
-    Connection = Struct.new(:type, :host, :port, keyword_init: true)
+    Connection = Struct.new(:type, :host, :port, :credentials, keyword_init: true)
     Execution = Struct.new(:namespace, :task_queue, :timeouts, :headers, keyword_init: true)
 
     attr_reader :timeouts, :error_handlers
     attr_writer :converter
-    attr_accessor :connection_type, :host, :port, :logger, :metrics_adapter, :namespace, :task_queue, :headers
+    attr_accessor :connection_type, :host, :port, :credentials, :logger, :metrics_adapter, :namespace, :task_queue, :headers
 
     # See https://docs.temporal.io/blog/activity-timeouts/ for general docs.
     # We want an infinite execution timeout for cron schedules and other perpetual workflows.
@@ -53,6 +53,7 @@ module Temporal
       @headers = DEFAULT_HEADERS
       @converter = DEFAULT_CONVERTER
       @error_handlers = []
+      @credentials = :this_channel_is_insecure
     end
 
     def on_error(&block)
@@ -79,7 +80,8 @@ module Temporal
       Connection.new(
         type: connection_type,
         host: host,
-        port: port
+        port: port,
+        credentials: credentials
       ).freeze
     end
 

--- a/lib/temporal/connection.rb
+++ b/lib/temporal/connection.rb
@@ -10,12 +10,13 @@ module Temporal
       connection_class = CLIENT_TYPES_MAP[configuration.type]
       host = configuration.host
       port = configuration.port
+      credentials = configuration.credentials
 
       hostname = `hostname`
       thread_id = Thread.current.object_id
       identity = "#{thread_id}@#{hostname}"
 
-      connection_class.new(host, port, identity)
+      connection_class.new(host, port, identity, credentials)
     end
   end
 end

--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -31,9 +31,10 @@ module Temporal
         max_page_size: 100
       }.freeze
 
-      def initialize(host, port, identity, options = {})
+      def initialize(host, port, identity, credentials, options = {})
         @url = "#{host}:#{port}"
         @identity = identity
+        @credentials = credentials
         @poll = true
         @poll_mutex = Mutex.new
         @poll_request = nil
@@ -536,12 +537,12 @@ module Temporal
 
       private
 
-      attr_reader :url, :identity, :options, :poll_mutex, :poll_request
+      attr_reader :url, :identity, :credentials, :options, :poll_mutex, :poll_request
 
       def client
         @client ||= Temporal::Api::WorkflowService::V1::WorkflowService::Stub.new(
           url,
-          :this_channel_is_insecure,
+          credentials,
           timeout: 60
         )
       end

--- a/spec/unit/lib/temporal/connection_spec.rb
+++ b/spec/unit/lib/temporal/connection_spec.rb
@@ -1,0 +1,58 @@
+describe Temporal::Connection do
+  subject { described_class.generate(config.for_connection) }
+
+  let(:connection_type) { :grpc }
+  let(:credentials) { nil }
+  let(:config) do
+    config = Temporal::Configuration.new
+    config.connection_type = connection_type
+    config.credentials = credentials if credentials
+    config
+  end
+
+  context 'insecure' do
+    let(:credentials) { :this_channel_is_insecure }
+
+    it 'generates a grpc connection' do
+      expect(subject).to be_kind_of(Temporal::Connection::GRPC)
+      expect(subject.send(:identity)).not_to be_nil
+      expect(subject.send(:credentials)).to eq(:this_channel_is_insecure)
+    end
+  end
+
+  context 'ssl' do
+    let(:credentials) { GRPC::Core::ChannelCredentials.new }
+
+    it 'generates a grpc connection' do
+      expect(subject).to be_kind_of(Temporal::Connection::GRPC)
+      expect(subject.send(:identity)).not_to be_nil
+      expect(subject.send(:credentials)).to be_kind_of(GRPC::Core::ChannelCredentials)
+    end
+  end
+
+  context 'oauth2' do
+    let(:credentials) { GRPC::Core::CallCredentials.new(proc { { authorization: 'token' } }) }
+
+    it 'generates a grpc connection' do
+      expect(subject).to be_kind_of(Temporal::Connection::GRPC)
+      expect(subject.send(:identity)).not_to be_nil
+      expect(subject.send(:credentials)).to be_kind_of(GRPC::Core::CallCredentials)
+    end
+  end
+
+  context 'ssl + oauth2' do
+    let(:credentials) do
+      GRPC::Core::ChannelCredentials.new.compose(
+        GRPC::Core::CallCredentials.new(
+          proc { { authorization: 'token' } }
+        )
+      )
+    end
+
+    it 'generates a grpc connection' do
+      expect(subject).to be_kind_of(Temporal::Connection::GRPC)
+      expect(subject.send(:identity)).not_to be_nil
+      expect(subject.send(:credentials)).to be_kind_of(GRPC::Core::ChannelCredentials)
+    end
+  end
+end

--- a/spec/unit/lib/temporal/grpc_spec.rb
+++ b/spec/unit/lib/temporal/grpc_spec.rb
@@ -10,7 +10,7 @@ describe Temporal::Connection::GRPC do
   let(:run_id) { SecureRandom.uuid }
   let(:now) { Time.now}
 
-  subject { Temporal::Connection::GRPC.new(nil, nil, identity) }
+  subject { Temporal::Connection::GRPC.new(nil, nil, identity, :this_channel_is_insecure) }
 
   class TestDeserializer
     extend Temporal::Concerns::Payloads


### PR DESCRIPTION
Closes https://github.com/coinbase/temporal-ruby/issues/70

Third attempt at adding SSL support. Previous attempts died: https://github.com/coinbase/temporal-ruby/pull/73 and https://github.com/coinbase/temporal-ruby/pull/140

Bonus: allows adding OAuth2 tokens using same gRPC credentials.