### PR TITLE
Allow initial search attributes to be specified when starting workflows

### DIFF
--- a/examples/spec/integration/initial_search_attributes_spec.rb
+++ b/examples/spec/integration/initial_search_attributes_spec.rb
@@ -1,28 +1,32 @@
 require 'workflows/upsert_search_attributes_workflow'
 require 'time'
 
-describe 'Temporal::Workflow::Context.upsert_search_attributes', :integration do
-  it 'can upsert a search attribute and then retrieve it' do
-    workflow_id = 'upsert_search_attributes_test_wf-' + SecureRandom.uuid
+describe 'Temporal::Client.start_workflow', :integration do
+  it 'can start a workflow with initial search attributes' do
+    workflow_id = 'initial_search_attributes_test_wf-' + SecureRandom.uuid
     expected_binary_checksum = `git show HEAD -s --format=%H`.strip
 
-    expected_added_attributes = {
-      'CustomStringField' => 'moo',
-      'CustomBoolField' => true,
-      'CustomDoubleField' => 3.14,
-      'CustomIntField' => 0,
+    initial_search_attributes = {
+      'CustomBoolField' => false,
+      'CustomIntField' => -1,
       'CustomDatetimeField' => Time.now.utc.iso8601,
+      # These should get overriden when the workflow upserts them
+      'CustomStringField' => 'meow',
+      'CustomDoubleField' => 6.28,
     }
+    upserted_search_attributes = {
+      'CustomStringField' => 'moo',
+      'CustomDoubleField' => 3.14,
+    }
+    expected_custom_attributes = initial_search_attributes.merge(upserted_search_attributes)
 
     run_id = Temporal.start_workflow(
       UpsertSearchAttributesWorkflow,
-      string_value: expected_added_attributes['CustomStringField'],
-      bool_value: expected_added_attributes['CustomBoolField'],
-      float_value: expected_added_attributes['CustomDoubleField'],
-      int_value: expected_added_attributes['CustomIntField'],
-      time_value: expected_added_attributes['CustomDatetimeField'],
+      string_value: upserted_search_attributes['CustomStringField'],
+      float_value: upserted_search_attributes['CustomDoubleField'],
       options: {
         workflow_id: workflow_id,
+        search_attributes: initial_search_attributes,
       },
     )
 
@@ -31,13 +35,13 @@ describe 'Temporal::Workflow::Context.upsert_search_attributes', :integration do
       workflow_id: workflow_id,
       run_id: run_id,
     )
-    expect(added_attributes).to eq(expected_added_attributes)
+    expect(added_attributes).to eq(upserted_search_attributes)
 
     # These attributes are set for the worker in bin/worker
     expected_attributes = {
       # Contains a list of all binary checksums seen for this workflow execution
       'BinaryChecksums' => [expected_binary_checksum]
-    }.merge(expected_added_attributes)
+    }.merge(expected_custom_attributes)
 
     execution_info = Temporal.fetch_workflow_execution_info(
       integration_spec_namespace,

--- a/examples/workflows/upsert_search_attributes_workflow.rb
+++ b/examples/workflows/upsert_search_attributes_workflow.rb
@@ -1,7 +1,7 @@
 require 'activities/hello_world_activity'
 class UpsertSearchAttributesWorkflow < Temporal::Workflow
   # time_value example: use this format: Time.now.utc.strftime("%Y-%m-%dT%H:%M:%SZ")
-  def execute(string_value, bool_value, float_value, int_value, time_value)
+  def execute(string_value: nil, bool_value: nil, float_value: nil, int_value: nil, time_value: nil)
     # These are included in the default temporal docker setup.
     # Run tctl admin cluster get-search-attributes to list the options and
     # See https://docs.temporal.io/docs/tctl/how-to-add-a-custom-search-attribute-to-a-cluster-using-tctl
@@ -13,6 +13,7 @@ class UpsertSearchAttributesWorkflow < Temporal::Workflow
       'CustomIntField' => int_value,
       'CustomDatetimeField' => time_value,
     }
+    attributes.compact!
     workflow.upsert_search_attributes(attributes)
     # The following lines are extra complexity to test if upsert_search_attributes is tracked properly in the internal
     # state machine.

--- a/lib/temporal/client.rb
+++ b/lib/temporal/client.rb
@@ -36,6 +36,7 @@ module Temporal
     # @option options [Hash] :retry_policy check Temporal::RetryPolicy for available options
     # @option options [Hash] :timeouts check Temporal::Configuration::DEFAULT_TIMEOUTS
     # @option options [Hash] :headers
+    # @option options [Hash] :search_attributes
     #
     # @return [String] workflow's run ID
     def start_workflow(workflow, *input, options: {}, **args)
@@ -61,6 +62,7 @@ module Temporal
           workflow_id_reuse_policy: options[:workflow_id_reuse_policy],
           headers: execution_options.headers,
           memo: execution_options.memo,
+          search_attributes: execution_options.search_attributes,
         )
       else
         raise ArgumentError, 'If signal_input is provided, you must also provide signal_name' if signal_name.nil?
@@ -77,6 +79,7 @@ module Temporal
           workflow_id_reuse_policy: options[:workflow_id_reuse_policy],
           headers: execution_options.headers,
           memo: execution_options.memo,
+          search_attributes: execution_options.search_attributes,
           signal_name: signal_name,
           signal_input: signal_input
         )
@@ -101,6 +104,7 @@ module Temporal
     # @option options [Hash] :retry_policy check Temporal::RetryPolicy for available options
     # @option options [Hash] :timeouts check Temporal::Configuration::DEFAULT_TIMEOUTS
     # @option options [Hash] :headers
+    # @option options [Hash] :search_attributes
     #
     # @return [String] workflow's run ID
     def schedule_workflow(workflow, cron_schedule, *input, options: {}, **args)
@@ -124,7 +128,8 @@ module Temporal
         workflow_id_reuse_policy: options[:workflow_id_reuse_policy],
         headers: execution_options.headers,
         cron_schedule: cron_schedule,
-        memo: execution_options.memo
+        memo: execution_options.memo,
+        search_attributes: execution_options.search_attributes,
       )
 
       response.run_id

--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -93,7 +93,8 @@ module Temporal
         workflow_id_reuse_policy: nil,
         headers: nil,
         cron_schedule: nil,
-        memo: nil
+        memo: nil,
+        search_attributes: nil
       )
         request = Temporal::Api::WorkflowService::V1::StartWorkflowExecutionRequest.new(
           identity: identity,
@@ -117,7 +118,10 @@ module Temporal
           cron_schedule: cron_schedule,
           memo: Temporal::Api::Common::V1::Memo.new(
             fields: to_payload_map(memo || {})
-          )
+          ),
+          search_attributes: Temporal::Api::Common::V1::SearchAttributes.new(
+            indexed_fields: to_payload_map(search_attributes || {})
+          ),
         )
 
         client.start_workflow_execution(request)
@@ -339,7 +343,8 @@ module Temporal
         cron_schedule: nil,
         signal_name:,
         signal_input:,
-        memo: nil
+        memo: nil,
+        search_attributes: nil
       )
         proto_header_fields = if headers.nil?
             to_payload_map({})
@@ -375,6 +380,9 @@ module Temporal
           signal_input: to_signal_payloads(signal_input),
           memo: Temporal::Api::Common::V1::Memo.new(
             fields: to_payload_map(memo || {})
+          ),
+          search_attributes: Temporal::Api::Common::V1::SearchAttributes.new(
+            indexed_fields: to_payload_map(search_attributes || {})
           ),
         )
 

--- a/lib/temporal/connection/serializer/continue_as_new.rb
+++ b/lib/temporal/connection/serializer/continue_as_new.rb
@@ -20,7 +20,8 @@ module Temporal
                 workflow_task_timeout: object.timeouts[:task],
                 retry_policy: Temporal::Connection::Serializer::RetryPolicy.new(object.retry_policy).to_proto,
                 header: serialize_headers(object.headers),
-                memo: serialize_memo(object.memo)
+                memo: serialize_memo(object.memo),
+                search_attributes: serialize_search_attributes(object.search_attributes),
               )
           )
         end
@@ -37,6 +38,12 @@ module Temporal
           return unless memo
 
           Temporal::Api::Common::V1::Memo.new(fields: to_payload_map(memo))
+        end
+
+        def serialize_search_attributes(search_attributes)
+          return unless search_attributes
+
+          Temporal::Api::Common::V1::SearchAttributes.new(indexed_fields: to_payload_map(search_attributes))
         end
       end
     end

--- a/lib/temporal/connection/serializer/start_child_workflow.rb
+++ b/lib/temporal/connection/serializer/start_child_workflow.rb
@@ -32,7 +32,8 @@ module Temporal
                 parent_close_policy: serialize_parent_close_policy(object.parent_close_policy),
                 header: serialize_headers(object.headers),
                 memo: serialize_memo(object.memo),
-                workflow_id_reuse_policy: Temporal::Connection::Serializer::WorkflowIdReusePolicy.new(object.workflow_id_reuse_policy).to_proto
+                workflow_id_reuse_policy: Temporal::Connection::Serializer::WorkflowIdReusePolicy.new(object.workflow_id_reuse_policy).to_proto,
+                search_attributes: serialize_search_attributes(object.search_attributes),
               )
           )
         end
@@ -59,6 +60,12 @@ module Temporal
           end
 
           PARENT_CLOSE_POLICY[parent_close_policy]
+        end
+
+        def serialize_search_attributes(search_attributes)
+          return unless search_attributes
+
+          Temporal::Api::Common::V1::SearchAttributes.new(indexed_fields: to_payload_map(search_attributes))
         end
       end
     end

--- a/lib/temporal/execution_options.rb
+++ b/lib/temporal/execution_options.rb
@@ -1,9 +1,10 @@
 require 'temporal/concerns/executable'
 require 'temporal/retry_policy'
+require 'temporal/workflow/context_helpers'
 
 module Temporal
   class ExecutionOptions
-    attr_reader :name, :namespace, :task_queue, :retry_policy, :timeouts, :headers, :memo
+    attr_reader :name, :namespace, :task_queue, :retry_policy, :timeouts, :headers, :memo, :search_attributes
 
     def initialize(object, options, defaults = nil)
       # Options are treated as overrides and take precedence
@@ -14,6 +15,7 @@ module Temporal
       @timeouts = options[:timeouts] || {}
       @headers = options[:headers] || {}
       @memo = options[:memo] || {}
+      @search_attributes = Temporal::Workflow::Context::Helpers.process_search_attributes(options[:search_attributes] || {}, allow_empty: true)
 
       # For Temporal::Workflow and Temporal::Activity use defined values as the next option
       if has_executable_concern?(object)

--- a/lib/temporal/testing/local_workflow_context.rb
+++ b/lib/temporal/testing/local_workflow_context.rb
@@ -225,7 +225,7 @@ module Temporal
       end
 
       def upsert_search_attributes(search_attributes)
-        search_attributes = Temporal::Workflow::Context::Helpers.process_search_attributes(search_attributes)
+        search_attributes = Temporal::Workflow::Context::Helpers.process_search_attributes(search_attributes, allow_empty: false)
         execution.upsert_search_attributes(search_attributes)
       end
 

--- a/lib/temporal/testing/temporal_override.rb
+++ b/lib/temporal/testing/temporal_override.rb
@@ -83,6 +83,7 @@ module Temporal
         workflow_id = options[:workflow_id] || SecureRandom.uuid
         run_id = SecureRandom.uuid
         memo = options[:memo] || {}
+        initial_search_attributes = options[:search_attributes] || {}
 
         if !allowed?(workflow_id, reuse_policy)
           raise Temporal::WorkflowExecutionAlreadyStartedFailure.new(
@@ -91,7 +92,7 @@ module Temporal
           )
         end
 
-        execution = WorkflowExecution.new
+        execution = WorkflowExecution.new(initial_search_attributes: initial_search_attributes)
         executions[[workflow_id, run_id]] = execution
 
         execution_options = ExecutionOptions.new(workflow, options)

--- a/lib/temporal/testing/workflow_execution.rb
+++ b/lib/temporal/testing/workflow_execution.rb
@@ -6,10 +6,10 @@ module Temporal
     class WorkflowExecution
       attr_reader :status, :search_attributes
 
-      def initialize
+      def initialize(initial_search_attributes: {})
         @status = Workflow::Status::RUNNING
         @futures = FutureRegistry.new
-        @search_attributes = {}
+        @search_attributes = initial_search_attributes
       end
 
       def run(&block)

--- a/lib/temporal/workflow/command.rb
+++ b/lib/temporal/workflow/command.rb
@@ -3,8 +3,8 @@ module Temporal
     module Command
       # TODO: Move these classes into their own directories under workflow/command/*
       ScheduleActivity = Struct.new(:activity_type, :activity_id, :input, :namespace, :task_queue, :retry_policy, :timeouts, :headers, keyword_init: true)
-      StartChildWorkflow = Struct.new(:workflow_type, :workflow_id, :input, :namespace, :task_queue, :retry_policy, :parent_close_policy, :timeouts, :headers, :memo, :workflow_id_reuse_policy, keyword_init: true)
-      ContinueAsNew = Struct.new(:workflow_type, :task_queue, :input, :timeouts, :retry_policy, :headers, :memo, keyword_init: true)
+      StartChildWorkflow = Struct.new(:workflow_type, :workflow_id, :input, :namespace, :task_queue, :retry_policy, :parent_close_policy, :timeouts, :headers, :memo, :workflow_id_reuse_policy, :search_attributes, keyword_init: true)
+      ContinueAsNew = Struct.new(:workflow_type, :task_queue, :input, :timeouts, :retry_policy, :headers, :memo, :search_attributes, keyword_init: true)
       RequestActivityCancellation = Struct.new(:activity_id, keyword_init: true)
       RecordMarker = Struct.new(:name, :details, keyword_init: true)
       StartTimer = Struct.new(:timeout, :timer_id, keyword_init: true)

--- a/lib/temporal/workflow/context.rb
+++ b/lib/temporal/workflow/context.rb
@@ -131,7 +131,8 @@ module Temporal
           timeouts: execution_options.timeouts,
           headers: execution_options.headers,
           memo: execution_options.memo,
-          workflow_id_reuse_policy: workflow_id_reuse_policy
+          workflow_id_reuse_policy: workflow_id_reuse_policy,
+          search_attributes: execution_options.search_attributes,
         )
 
         target, cancelation_id = schedule_command(command)
@@ -245,6 +246,7 @@ module Temporal
           retry_policy: execution_options.retry_policy,
           headers: execution_options.headers,
           memo: execution_options.memo,
+          search_attributes: execution_options.search_attributes,
         )
         schedule_command(command)
         completed!
@@ -409,7 +411,7 @@ module Temporal
       # @return [Hash] the search attributes after any preprocessing.
       #
       def upsert_search_attributes(search_attributes)
-        search_attributes = Helpers.process_search_attributes(search_attributes)
+        search_attributes = Helpers.process_search_attributes(search_attributes, allow_empty: false)
         command = Command::UpsertSearchAttributes.new(
           search_attributes: search_attributes
         )

--- a/lib/temporal/workflow/context_helpers.rb
+++ b/lib/temporal/workflow/context_helpers.rb
@@ -2,17 +2,17 @@ require 'time'
 module Temporal
   class Workflow
     class Context
-      # Shared between Context and LocalWorkflowContext so we can do the same validations in test and production.
+      # Shared between Context, and LocalWorkflowContext, and ExecutionOptions so we can do the same validations in test and production.
       module Helpers
 
-        def self.process_search_attributes(search_attributes)
+        def self.process_search_attributes(search_attributes, allow_empty:)
           if search_attributes.nil?
             raise ArgumentError, 'search_attributes cannot be nil'
           end
           if !search_attributes.is_a?(Hash)
             raise ArgumentError, "for search_attributes, expecting a Hash, not #{search_attributes.class}"
           end
-          if search_attributes.empty?
+          if search_attributes.empty? && !allow_empty
             raise ArgumentError, "Cannot upsert an empty hash for search_attributes, as this would do nothing."
           end
           search_attributes.transform_values do |attribute|

--- a/spec/unit/lib/temporal/client_spec.rb
+++ b/spec/unit/lib/temporal/client_spec.rb
@@ -63,6 +63,7 @@ describe Temporal::Client do
             workflow_id_reuse_policy: nil,
             headers: {},
             memo: {},
+            search_attributes: {},
           )
       end
 
@@ -76,7 +77,8 @@ describe Temporal::Client do
             task_queue: 'test-task-queue',
             headers: { 'Foo' => 'Bar' },
             workflow_id_reuse_policy: :reject,
-            memo: { 'MemoKey1' => 'MemoValue1' }
+            memo: { 'MemoKey1' => 'MemoValue1' },
+            search_attributes: { 'SearchAttribute1' => 256 },
           }
         )
 
@@ -93,7 +95,8 @@ describe Temporal::Client do
             execution_timeout: Temporal.configuration.timeouts[:execution],
             workflow_id_reuse_policy: :reject,
             headers: { 'Foo' => 'Bar' },
-            memo: { 'MemoKey1' => 'MemoValue1' }
+            memo: { 'MemoKey1' => 'MemoValue1' },
+            search_attributes: { 'SearchAttribute1' => 256 },
           )
       end
 
@@ -119,7 +122,8 @@ describe Temporal::Client do
             execution_timeout: Temporal.configuration.timeouts[:execution],
             workflow_id_reuse_policy: nil,
             headers: {},
-            memo: {}
+            memo: {},
+            search_attributes: {},
           )
       end
 
@@ -139,7 +143,8 @@ describe Temporal::Client do
             execution_timeout: Temporal.configuration.timeouts[:execution],
             workflow_id_reuse_policy: nil,
             headers: {},
-            memo: {}
+            memo: {},
+            search_attributes: {},
           )
       end
 
@@ -161,7 +166,8 @@ describe Temporal::Client do
             execution_timeout: Temporal.configuration.timeouts[:execution],
             workflow_id_reuse_policy: :allow,
             headers: {},
-            memo: {}
+            memo: {},
+            search_attributes: {},
           )
       end
     end
@@ -187,7 +193,8 @@ describe Temporal::Client do
             execution_timeout: Temporal.configuration.timeouts[:execution],
             workflow_id_reuse_policy: nil,
             headers: {},
-            memo: {}
+            memo: {},
+            search_attributes: {},
           )
       end
     end
@@ -215,6 +222,7 @@ describe Temporal::Client do
           workflow_id_reuse_policy: nil,
           headers: {},
           memo: {},
+          search_attributes: {},
           signal_name: 'the question',
           signal_input: expected_signal_argument,
         )
@@ -295,6 +303,7 @@ describe Temporal::Client do
           execution_timeout: Temporal.configuration.timeouts[:execution],
           workflow_id_reuse_policy: nil,
           memo: {},
+          search_attributes: {},
           headers: {},
         )
     end

--- a/spec/unit/lib/temporal/connection/serializer/continue_as_new_spec.rb
+++ b/spec/unit/lib/temporal/connection/serializer/continue_as_new_spec.rb
@@ -11,6 +11,7 @@ describe Temporal::Connection::Serializer::ContinueAsNew do
         timeouts: Temporal.configuration.timeouts,
         headers: {'foo-header': 'bar'},
         memo: {'foo-memo': 'baz'},
+        search_attributes: {'foo-search-attribute': 'qux'},
       )
 
       result = described_class.new(command).to_proto
@@ -31,6 +32,7 @@ describe Temporal::Connection::Serializer::ContinueAsNew do
 
       expect(attribs.header.fields['foo-header'].data).to eq('"bar"')
       expect(attribs.memo.fields['foo-memo'].data).to eq('"baz"')
+      expect(attribs.search_attributes.indexed_fields['foo-search-attribute'].data).to eq('"qux"')
     end
   end
 end

--- a/spec/unit/lib/temporal/connection/serializer/start_child_workflow_spec.rb
+++ b/spec/unit/lib/temporal/connection/serializer/start_child_workflow_spec.rb
@@ -14,6 +14,7 @@ describe Temporal::Connection::Serializer::StartChildWorkflow do
       timeouts: { execution: 1, run: 1, task: 1 },
       headers: nil,
       memo: {},
+      search_attributes: {},
     )
   end
 

--- a/spec/unit/lib/temporal/grpc_spec.rb
+++ b/spec/unit/lib/temporal/grpc_spec.rb
@@ -39,6 +39,7 @@ describe Temporal::Connection::GRPC do
           run_timeout: 0,
           task_timeout: 0,
           memo: {},
+          search_attributes: {},
           workflow_id_reuse_policy: :allow,
         )
       end.to raise_error(Temporal::WorkflowExecutionAlreadyStartedFailure) do |e|
@@ -59,6 +60,7 @@ describe Temporal::Connection::GRPC do
         run_timeout: 2,
         task_timeout: 3,
         memo: {},
+        search_attributes: {},
         workflow_id_reuse_policy: :reject,
       )
 
@@ -87,6 +89,7 @@ describe Temporal::Connection::GRPC do
           run_timeout: 0,
           task_timeout: 0,
           memo: {},
+          search_attributes: {},
           workflow_id_reuse_policy: :not_a_valid_policy
         )
       end.to raise_error(Temporal::Connection::ArgumentError) do |e|
@@ -144,6 +147,7 @@ describe Temporal::Connection::GRPC do
           run_timeout: 0,
           task_timeout: 0,
           memo: {},
+          search_attributes: {},
           workflow_id_reuse_policy: :not_a_valid_policy,
           signal_name: 'the question',
           signal_input: 'what do you get if you multiply six by nine?'

--- a/spec/unit/lib/temporal/testing/temporal_override_spec.rb
+++ b/spec/unit/lib/temporal/testing/temporal_override_spec.rb
@@ -278,11 +278,17 @@ describe Temporal::Testing::TemporalOverride do
             UpsertSearchAttributesWorkflow,
             options: {
               workflow_id: workflow_id,
+              search_attributes: {
+                'AdditionalSearchAttribute' => 189,
+              },
             },
           )
 
           info = client.fetch_workflow_execution_info('default-namespace', workflow_id, run_id)
-          expect(info.search_attributes).to eq({'CustomIntField' => 5})
+          expect(info.search_attributes).to eq({
+            'CustomIntField' => 5,
+            'AdditionalSearchAttribute' => 189,
+          })
         end
 
       end

--- a/spec/unit/lib/temporal/workflow/execution_info_spec.rb
+++ b/spec/unit/lib/temporal/workflow/execution_info_spec.rb
@@ -15,6 +15,7 @@ describe Temporal::Workflow::ExecutionInfo do
       expect(subject.status).to eq(:COMPLETED)
       expect(subject.history_length).to eq(api_info.history_length)
       expect(subject.memo).to eq({ 'foo' => 'bar' })
+      expect(subject.search_attributes).to eq({ 'foo' => 'bar' })
     end
 
     it 'freezes the info' do


### PR DESCRIPTION
### Summary
This PR allows initial search attributes to be specified when starting workflows, including the various different ways of doing so (normal start, start with signal, continue as new, child workflows). It passes the search attributes to the constructor of `ExecutionOptions`, which performs the common processing (ensure it is a hash, isn't nil, convert date-times to ISO strings) consistent with what the `upsert_search_attributes` method does.

I am new to temporal-ruby (and Ruby in general), so I based the changes in this PR on prior work in https://github.com/coinbase/temporal-ruby/pull/121 and https://github.com/coinbase/temporal-ruby/pull/145.

### Testing
- Changes to the unit tests based on the changes in https://github.com/coinbase/temporal-ruby/pull/121.
- Round-trip integration test in `examples/spec/integration/initial_search_attributes_spec.rb`
