### PR TITLE
Fix dispatch ordering of wait_until handlers

### DIFF
--- a/examples/spec/integration/signal_with_start_spec.rb
+++ b/examples/spec/integration/signal_with_start_spec.rb
@@ -7,11 +7,11 @@ describe 'signal with start' do
     run_id = Temporal.start_workflow(
       SignalWithStartWorkflow,
       'signal_name',
-      0.1,
       options: {
         workflow_id: workflow_id,
         signal_name: 'signal_name',
         signal_input: 'expected value',
+        timeouts: { execution: 10 },
       }
     )
 
@@ -29,10 +29,10 @@ describe 'signal with start' do
     run_id = Temporal.start_workflow(
       SignalWithStartWorkflow,
       'signal_name',
-      0.1,
       options: {
         workflow_id: workflow_id,
         signal_name: 'signal_name',
+        timeouts: { execution: 10 },
       }
     )
 
@@ -50,22 +50,22 @@ describe 'signal with start' do
     run_id = Temporal.start_workflow(
       SignalWithStartWorkflow,
       'signal_name',
-      10,
       options: {
         workflow_id: workflow_id,
         signal_name: 'signal_name',
         signal_input: 'expected value',
+        timeouts: { execution: 10 },
       }
     )
 
     second_run_id = Temporal.start_workflow(
       SignalWithStartWorkflow,
       'signal_name',
-      0.1,
       options: {
         workflow_id: workflow_id,
         signal_name: 'signal_name',
         signal_input: 'expected value',
+        timeouts: { execution: 10 },
       }
     )
 

--- a/examples/workflows/signal_with_start_workflow.rb
+++ b/examples/workflows/signal_with_start_workflow.rb
@@ -1,16 +1,20 @@
+require 'activities/hello_world_activity'
+
 class SignalWithStartWorkflow < Temporal::Workflow
 
-  def execute(expected_signal, sleep_for)
-    received = 'no signal received'
+  def execute(expected_signal)
+    initial_value = 'no signal received'
+    received = initial_value
 
     workflow.on_signal do |signal, input|
       if signal == expected_signal
+        HelloWorldActivity.execute!('expected signal')
         received = input
       end
     end
 
     # Do something to get descheduled so the signal handler has a chance to run
-    workflow.sleep(sleep_for)
+    workflow.wait_until { received != initial_value }
     received
   end
 end

--- a/lib/temporal/workflow/context.rb
+++ b/lib/temporal/workflow/context.rb
@@ -291,7 +291,14 @@ module Temporal
 
         fiber = Fiber.current
 
-        handler = dispatcher.register_wait_until_handler do
+        # wait_until condition blocks often read state modified by target-specfic handlers like
+        # signal handlers or callbacks for timer or activity completion. Running the wait_until
+        # handlers after the other handlers ensures that state is correctly updated before being
+        # read.
+        handler = dispatcher.register_handler(
+          Dispatcher::WILDCARD, # any target
+          Dispatcher::WILDCARD, # any event type
+          Dispatcher::Order::AT_END) do
           fiber.resume if unblock_condition.call
         end
 

--- a/lib/temporal/workflow/context.rb
+++ b/lib/temporal/workflow/context.rb
@@ -291,7 +291,7 @@ module Temporal
 
         fiber = Fiber.current
 
-        handler = dispatcher.register_handler(Dispatcher::TARGET_WILDCARD, Dispatcher::WILDCARD) do
+        handler = dispatcher.register_wait_until_handler do
           fiber.resume if unblock_condition.call
         end
 
@@ -325,7 +325,7 @@ module Temporal
             call_in_fiber(block, input)
           end
         else
-          dispatcher.register_handler(Dispatcher::TARGET_WILDCARD, 'signaled') do |signal, input|
+          dispatcher.register_handler(Dispatcher::WILDCARD, 'signaled') do |signal, input|
             call_in_fiber(block, signal, input)
           end
         end

--- a/lib/temporal/workflow/dispatcher.rb
+++ b/lib/temporal/workflow/dispatcher.rb
@@ -9,11 +9,6 @@ module Temporal
     # elsewhere in the system we may dispatch the event and execute the handler.
     # We *always* execute the handler associated with the event_name.
     #
-    # Optionally, we may register a named handler that is triggered when an event _and
-    # an optional handler_name key_ are provided. In this situation, we dispatch to both
-    # the handler associated to event_name+handler_name and to the handler associated with
-    # the event_name. The order of this dispatch is not guaranteed.
-    #
     class Dispatcher
       # Raised if a duplicate ID is encountered during dispatch handling.
       # This likely indicates a bug in temporal-ruby or that unsupported multithreaded

--- a/spec/unit/lib/temporal/workflow/dispatcher_spec.rb
+++ b/spec/unit/lib/temporal/workflow/dispatcher_spec.rb
@@ -14,51 +14,23 @@ describe Temporal::Workflow::Dispatcher do
     end
     let(:handlers) { dispatcher.send(:handlers) }
 
-    context 'with default handler_name' do
-      let(:handler_name) { nil }
-
-      it 'stores the target' do
-        expect(handlers.key?(target)).to be true
-      end
-
-      it 'stores the target and handler once' do
-        expect(handlers[target]).to be_kind_of(Hash)
-        expect(handlers[target].count).to eq 1
-      end
-
-      it 'associates the event name with the target' do
-        event = handlers[target][1]
-        expect(event.event_name).to eq(event_name)
-      end
-
-      it 'associates the handler with the target' do
-        event = handlers[target][1]
-        expect(event.handler).to eq(block)
-      end
+    it 'stores the target' do
+      expect(handlers.key?(target)).to be true
     end
 
-    context 'with a specific handler_name' do
-      let(:handler_name) { 'specific name' }
-      let(:event_name) { "signaled:#{handler_name}" }
+    it 'stores the target and handler once' do
+      expect(handlers[target]).to be_kind_of(Hash)
+      expect(handlers[target].count).to eq 1
+    end
 
-      it 'stores the target' do
-        expect(handlers.key?(target)).to be true
-      end
+    it 'associates the event name with the target' do
+      event = handlers[target][1]
+      expect(event.event_name).to eq(event_name)
+    end
 
-      it 'stores the target and handler once' do
-        expect(handlers[target]).to be_kind_of(Hash)
-        expect(handlers[target].count).to eq 1
-      end
-
-      it 'associates the event name and handler name with the target' do
-        event = handlers[target][1]
-        expect(event.event_name).to eq(event_name)
-      end
-
-      it 'associates the handler with the target' do
-        event = handlers[target][1]
-        expect(event.handler).to eq(block)
-      end
+    it 'associates the handler with the target' do
+      event = handlers[target][1]
+      expect(event.handler).to eq(block)
     end
 
     it 'removes a given handler against the target' do
@@ -70,19 +42,19 @@ describe Temporal::Workflow::Dispatcher do
       subject.register_handler(target, 'signaled', &block2)
       subject.register_handler(other_target, 'signaled', &block3)
 
-      expect(subject.send(:handlers)[target][1].event_name).to eq('signaled')
-      expect(subject.send(:handlers)[target][1].handler).to be(block1)
+      expect(handlers[target][1].event_name).to eq('signaled')
+      expect(handlers[target][1].handler).to be(block1)
 
-      expect(subject.send(:handlers)[target][2].event_name).to eq('signaled')
-      expect(subject.send(:handlers)[target][2].handler).to be(block2)
+      expect(handlers[target][2].event_name).to eq('signaled')
+      expect(handlers[target][2].handler).to be(block2)
 
-      expect(subject.send(:handlers)[other_target][3].event_name).to eq('signaled')
-      expect(subject.send(:handlers)[other_target][3].handler).to be(block3)
+      expect(handlers[other_target][3].event_name).to eq('signaled')
+      expect(handlers[other_target][3].handler).to be(block3)
 
       handle1.unregister
-      expect(subject.send(:handlers)[target][1]).to be(nil)
-      expect(subject.send(:handlers)[target][2]).to_not be(nil)
-      expect(subject.send(:handlers)[other_target][3]).to_not be(nil)
+      expect(handlers[target][1]).to be(nil)
+      expect(handlers[target][2]).to_not be(nil)
+      expect(handlers[other_target][3]).to_not be(nil)
     end
   end
 
@@ -162,29 +134,6 @@ describe Temporal::Workflow::Dispatcher do
 
       it 'TARGET_WILDCARD can be compared to an EventTarget object' do
         expect(target.eql?(described_class::TARGET_WILDCARD)).to be(false)
-      end
-    end
-
-    context 'with a named handler' do
-      let(:handler_7) { -> { 'seventh block' } }
-      let(:handler_name) { 'specific name' }
-      before do
-        allow(handler_7).to receive(:call)
-
-        subject.register_handler(target, 'completed', &handler_7)
-      end
-
-      it 'calls the named handler and the default' do
-        subject.dispatch(target, 'completed', handler_name: handler_name)
-
-        # the parent context "before" block registers the handlers with the target
-        # so look there for why handlers 1 and 4 are also called
-        expect(handler_7).to have_received(:call)
-        expect(handler_1).to have_received(:call)
-        expect(handler_4).to have_received(:call)
-
-        expect(handler_2).not_to have_received(:call)
-        expect(handler_3).not_to have_received(:call)
       end
     end
   end

--- a/spec/unit/lib/temporal/workflow/dispatcher_spec.rb
+++ b/spec/unit/lib/temporal/workflow/dispatcher_spec.rb
@@ -137,7 +137,7 @@ describe Temporal::Workflow::Dispatcher do
       end
     end
 
-    context 'with wait_until handler' do
+    context 'with AT_END order' do
       let(:handler_5) { -> { 'fifth block' } }
       let(:handler_6) { -> { 'sixth block' } }
       let(:handler_7) { -> { 'seventh block' } }
@@ -146,8 +146,8 @@ describe Temporal::Workflow::Dispatcher do
         allow(handler_6).to receive(:call)
         allow(handler_7).to receive(:call)
 
-        subject.register_wait_until_handler(&handler_5)
-        subject.register_wait_until_handler(&handler_6)
+        subject.register_handler(described_class::WILDCARD, described_class::WILDCARD, described_class::Order::AT_END, &handler_5)
+        subject.register_handler(described_class::WILDCARD, described_class::WILDCARD, described_class::Order::AT_END, &handler_6)
         subject.register_handler(target, 'completed', &handler_7)
       end
 
@@ -159,7 +159,7 @@ describe Temporal::Workflow::Dispatcher do
         expect(handler_4).to have_received(:call).ordered
         expect(handler_7).to have_received(:call).ordered
 
-        # wait_until handlers are invoked at the end, in order
+        # AT_END handlers are invoked at the end, in order
         expect(handler_5).to have_received(:call).ordered
         expect(handler_6).to have_received(:call).ordered
       end


### PR DESCRIPTION
@dwillett discovered a bug in the ordering of the evaluation of `wait_until` handlers that was introduced in https://github.com/coinbase/temporal-ruby/pull/183. The short version is that sometimes workflows end up stuck because a `wait_until` condition evaluates to false before another handler, such as a signal handler, is executed that would change the condition to true. The `wait_until` handler should always be called after the handlers for a specific event have been called.

More details of the bug and its behavior can be found in https://github.com/dwillett/temporal-ruby/pull/3. 

### Summary of change
`wait_until` handlers are now called after event-specific handlers, undoing this part of the earlier PR. The behavior of signal handlers that do not specify a name, which also use dispatch target wildcards, has been preserved. Handlers for `wait_until`s have further separated from the other handlers to make this behavior difference clearer in code.

@chuckremes2 Some specs referencing `dispatch_name` and accompanying comments on the `Dispatcher` have been removed while I was in here. As far as I can tell, this is dead code. It appears to be left over from some changes you made at @antstorm's request on https://github.com/coinbase/temporal-ruby/pull/157.

### Testing
The dispatcher unit specs have been updated:
```
bundle exec rspec ./spec/unit/lib/temporal/workflow/dispatcher_spec.rb
```

The `StartWithSignalWorkflow` sample has been modified to cover @dwillett's repro of the issue. The sleeps in this workflow have also been replaced with `wait_until` which minorly improves execution performance. I've confirmed this modified test does indeed fail without the ordering fix in this PR.

This workflow runs as part of this existing integration spec:
```
cd examples
bundle exec rspec spec/integration/signal_with_start_spec.rb
```