### PR TITLE
Use platform agnostic way of acquiring hostname

### DIFF
--- a/lib/temporal/connection.rb
+++ b/lib/temporal/connection.rb
@@ -1,3 +1,4 @@
+require 'socket'
 require 'temporal/connection/grpc'
 
 module Temporal
@@ -12,7 +13,7 @@ module Temporal
       port = configuration.port
       credentials = configuration.credentials
 
-      hostname = `hostname`
+      hostname = Socket.gethostname
       thread_id = Thread.current.object_id
       identity = "#{thread_id}@#{hostname}"
 


### PR DESCRIPTION
The `hostname` binary is deprecated on some distros and is not platform agnostic. Ruby provides a solution to that already through `Socket`.

This is an example error I get on my current linux installation because `/bin/hostname` no longer exists:
```
/home/felipe/.rvm/gems/ruby-3.0.3@spacedust/bundler/gems/temporal-ruby-3220c7858d07/lib/temporal/connection.rb:15:in ``': No such file or directory - hostname (Errno::ENOENT)
	from /home/felipe/.rvm/gems/ruby-3.0.3@spacedust/bundler/gems/temporal-ruby-3220c7858d07/lib/temporal/connection.rb:15:in `generate'
	from /home/felipe/.rvm/gems/ruby-3.0.3@spacedust/bundler/gems/temporal-ruby-3220c7858d07/lib/temporal/client.rb:422:in `connection'
	from /home/felipe/.rvm/gems/ruby-3.0.3@spacedust/bundler/gems/temporal-ruby-3220c7858d07/lib/temporal/client.rb:147:in `register_namespace'
```

By using `Socket.gethostname` there should be no difference in the result, but it will work even on platforms that don't have `/bin/hostname`