### PR TITLE
Derive client identity from pid, make configurable

### DIFF
--- a/lib/temporal/configuration.rb
+++ b/lib/temporal/configuration.rb
@@ -90,9 +90,9 @@ module Temporal
 
     def default_identity
       hostname = `hostname`
-      thread_id = Thread.current.object_id
+      pid = Process.pid
 
-      "#{thread_id}@#{hostname}"
+      "#{pid}@#{hostname}"
     end
 
     def default_execution_options

--- a/lib/temporal/connection.rb
+++ b/lib/temporal/connection.rb
@@ -11,10 +11,7 @@ module Temporal
       host = configuration.host
       port = configuration.port
       credentials = configuration.credentials
-
-      hostname = `hostname`
-      thread_id = Thread.current.object_id
-      identity = "#{thread_id}@#{hostname}"
+      identity = configuration.identity
 
       connection_class.new(host, port, identity, credentials)
     end

--- a/spec/unit/lib/temporal/configuration_spec.rb
+++ b/spec/unit/lib/temporal/configuration_spec.rb
@@ -31,7 +31,7 @@ describe Temporal::Configuration do
     let (:new_identity) { 'new_identity' }
 
     it 'default identity' do
-      expect(subject.for_connection).to have_attributes(identity: "#{Thread.current.object_id}@#{`hostname`}")
+      expect(subject.for_connection).to have_attributes(identity: "#{Process.pid}@#{`hostname`}")
     end
 
     it 'override identity' do

--- a/spec/unit/lib/temporal/configuration_spec.rb
+++ b/spec/unit/lib/temporal/configuration_spec.rb
@@ -26,4 +26,17 @@ describe Temporal::Configuration do
       expect(timeouts[:heartbeat]).to be(nil)
     end
   end
+
+  describe '#for_connection' do
+    let (:new_identity) { 'new_identity' }
+
+    it 'default identity' do
+      expect(subject.for_connection).to have_attributes(identity: "#{Thread.current.object_id}@#{`hostname`}")
+    end
+
+    it 'override identity' do
+      subject.identity = new_identity
+      expect(subject.for_connection).to have_attributes(identity: new_identity)
+    end
+  end
 end

--- a/spec/unit/lib/temporal/connection_spec.rb
+++ b/spec/unit/lib/temporal/connection_spec.rb
@@ -10,6 +10,14 @@ describe Temporal::Connection do
     config
   end
 
+  context 'identity' do
+    let(:identity) { 'my_identity' }
+    it 'overrides' do
+      config.identity = identity
+      expect(subject.send(:identity)).to eq(identity)
+    end
+  end
+
   context 'insecure' do
     let(:credentials) { :this_channel_is_insecure }
 


### PR DESCRIPTION
This change makes two changes in the client identity reported to Temporal server. These identities are used to show active activity and workflow pollers in tctl, temporal-web, and most prominently in the newer temporal-ui. They also appear in workflow histories, indicating where a workflow or activity task was processed.

The first commit makes these identities configurable in the client. This allows a user of temporal-ruby to set whichever arbitrary identity they would like to identify their worker.

The second commit changes the default identity to be based on the process ID (pid) of the worker plus hostname. Prior to this change, the object_id of the current thread was used. Unlike the pid, a current thread's object ID cannot easily be correlated with logs. Moreover, thread IDs are not guaranteed to be unique across worker processes. When running multiple worker processes on a single host, this can lead to different workers having the same client identifier. This behavior is consistent with the Temporal Java SDK.