### PR TITLE
Task metrics

### DIFF
--- a/lib/temporal/activity/poller.rb
+++ b/lib/temporal/activity/poller.rb
@@ -68,6 +68,12 @@ module Temporal
 
           task = poll_for_task
           last_poll_time = Time.now
+
+          Temporal.metrics.increment(
+            Temporal::MetricKeys::ACTIVITY_POLLER_POLL_COMPLETED,
+            metrics_tags.merge(received_task: (!task.nil?).to_s)
+          )
+
           next unless task&.activity_type
 
           thread_pool.schedule { process(task) }

--- a/lib/temporal/activity/poller.rb
+++ b/lib/temporal/activity/poller.rb
@@ -100,7 +100,14 @@ module Temporal
       end
 
       def thread_pool
-        @thread_pool ||= ThreadPool.new(options[:thread_pool_size])
+        @thread_pool ||= ThreadPool.new(
+          options[:thread_pool_size],
+          {
+            pool_name: 'activity_task_poller',
+            namespace: namespace,
+            task_queue: task_queue
+          }
+        )
       end
     end
   end

--- a/lib/temporal/activity/poller.rb
+++ b/lib/temporal/activity/poller.rb
@@ -3,6 +3,7 @@ require 'temporal/thread_pool'
 require 'temporal/middleware/chain'
 require 'temporal/activity/task_processor'
 require 'temporal/error_handler'
+require 'temporal/metric_keys'
 
 module Temporal
   class Activity
@@ -62,7 +63,7 @@ module Temporal
           return if shutting_down?
 
           time_diff_ms = ((Time.now - last_poll_time) * 1000).round
-          Temporal.metrics.timing('activity_poller.time_since_last_poll', time_diff_ms, metrics_tags)
+          Temporal.metrics.timing(Temporal::MetricKeys::ACTIVITY_POLLER_TIME_SINCE_LAST_POLL, time_diff_ms, metrics_tags)
           Temporal.logger.debug("Polling activity task queue", { namespace: namespace, task_queue: task_queue })
 
           task = poll_for_task

--- a/lib/temporal/activity/task_processor.rb
+++ b/lib/temporal/activity/task_processor.rb
@@ -5,6 +5,7 @@ require 'temporal/activity/context'
 require 'temporal/concerns/payloads'
 require 'temporal/connection/retryer'
 require 'temporal/connection'
+require 'temporal/metric_keys'
 
 module Temporal
   class Activity
@@ -26,7 +27,7 @@ module Temporal
         start_time = Time.now
 
         Temporal.logger.debug("Processing Activity task", metadata.to_h)
-        Temporal.metrics.timing('activity_task.queue_time', queue_time_ms, activity: activity_name, namespace: namespace, workflow: metadata.workflow_name)
+        Temporal.metrics.timing(Temporal::MetricKeys::ACTIVITY_TASK_QUEUE_TIME, queue_time_ms, activity: activity_name, namespace: namespace, workflow: metadata.workflow_name)
 
         context = Activity::Context.new(connection, metadata)
 
@@ -46,7 +47,7 @@ module Temporal
         respond_failed(error)
       ensure
         time_diff_ms = ((Time.now - start_time) * 1000).round
-        Temporal.metrics.timing('activity_task.latency', time_diff_ms, activity: activity_name, namespace: namespace, workflow: metadata.workflow_name)
+        Temporal.metrics.timing(Temporal::MetricKeys::ACTIVITY_TASK_LATENCY, time_diff_ms, activity: activity_name, namespace: namespace, workflow: metadata.workflow_name)
         Temporal.logger.debug("Activity task processed", metadata.to_h.merge(execution_time: time_diff_ms))
       end
 

--- a/lib/temporal/metric_keys.rb
+++ b/lib/temporal/metric_keys.rb
@@ -10,5 +10,8 @@ module Temporal
     WORKFLOW_TASK_QUEUE_TIME = 'workflow_task.queue_time'.freeze
     WORKFLOW_TASK_LATENCY = 'workflow_task.latency'.freeze
     WORKFLOW_TASK_EXECUTION_FAILED = 'workflow_task.execution_failed'.freeze
+
+    THREAD_POOL_AVAILABLE_THREADS = 'thread_pool.available_threads'.freeze
+    THREAD_POOL_QUEUE_SIZE = 'thread_pool.queue_size'.freeze
   end
 end

--- a/lib/temporal/metric_keys.rb
+++ b/lib/temporal/metric_keys.rb
@@ -1,0 +1,11 @@
+module Temporal
+  class MetricKeys
+    ACTIVITY_POLLER_TIME_SINCE_LAST_POLL = 'activity_poller.time_since_last_poll'.freeze
+    ACTIVITY_TASK_QUEUE_TIME = 'activity_task.queue_time'.freeze
+    ACTIVITY_TASK_LATENCY = 'activity_task.latency'.freeze
+
+    WORKFLOW_POLLER_TIME_SINCE_LAST_POLL = 'workflow_poller.time_since_last_poll'.freeze
+    WORKFLOW_TASK_QUEUE_TIME = 'workflow_task.queue_time'.freeze
+    WORKFLOW_TASK_LATENCY = 'workflow_task.latency'.freeze
+  end
+end

--- a/lib/temporal/metric_keys.rb
+++ b/lib/temporal/metric_keys.rb
@@ -7,5 +7,6 @@ module Temporal
     WORKFLOW_POLLER_TIME_SINCE_LAST_POLL = 'workflow_poller.time_since_last_poll'.freeze
     WORKFLOW_TASK_QUEUE_TIME = 'workflow_task.queue_time'.freeze
     WORKFLOW_TASK_LATENCY = 'workflow_task.latency'.freeze
+    WORKFLOW_TASK_EXECUTION_FAILED = 'workflow_task.execution_failed'.freeze
   end
 end

--- a/lib/temporal/metric_keys.rb
+++ b/lib/temporal/metric_keys.rb
@@ -12,6 +12,5 @@ module Temporal
     WORKFLOW_TASK_EXECUTION_FAILED = 'workflow_task.execution_failed'.freeze
 
     THREAD_POOL_AVAILABLE_THREADS = 'thread_pool.available_threads'.freeze
-    THREAD_POOL_QUEUE_SIZE = 'thread_pool.queue_size'.freeze
   end
 end

--- a/lib/temporal/metric_keys.rb
+++ b/lib/temporal/metric_keys.rb
@@ -1,10 +1,12 @@
 module Temporal
   class MetricKeys
     ACTIVITY_POLLER_TIME_SINCE_LAST_POLL = 'activity_poller.time_since_last_poll'.freeze
+    ACTIVITY_POLLER_POLL_COMPLETED = 'activity_poller.poll_completed'.freeze
     ACTIVITY_TASK_QUEUE_TIME = 'activity_task.queue_time'.freeze
     ACTIVITY_TASK_LATENCY = 'activity_task.latency'.freeze
 
     WORKFLOW_POLLER_TIME_SINCE_LAST_POLL = 'workflow_poller.time_since_last_poll'.freeze
+    WORKFLOW_POLLER_POLL_COMPLETED = 'workflow_poller.poll_completed'.freeze
     WORKFLOW_TASK_QUEUE_TIME = 'workflow_task.queue_time'.freeze
     WORKFLOW_TASK_LATENCY = 'workflow_task.latency'.freeze
     WORKFLOW_TASK_EXECUTION_FAILED = 'workflow_task.execution_failed'.freeze

--- a/lib/temporal/metric_keys.rb
+++ b/lib/temporal/metric_keys.rb
@@ -1,5 +1,5 @@
 module Temporal
-  class MetricKeys
+  module MetricKeys
     ACTIVITY_POLLER_TIME_SINCE_LAST_POLL = 'activity_poller.time_since_last_poll'.freeze
     ACTIVITY_POLLER_POLL_COMPLETED = 'activity_poller.poll_completed'.freeze
     ACTIVITY_TASK_QUEUE_TIME = 'activity_task.queue_time'.freeze

--- a/lib/temporal/thread_pool.rb
+++ b/lib/temporal/thread_pool.rb
@@ -1,3 +1,5 @@
+require 'temporal/metric_keys'
+
 # This class implements a very simple ThreadPool with the ability to
 # block until at least one thread becomes available. This allows Pollers
 # to only poll when there's an available thread in the pool.

--- a/lib/temporal/thread_pool.rb
+++ b/lib/temporal/thread_pool.rb
@@ -16,21 +16,18 @@ module Temporal
       @mutex = Mutex.new
       @availability = ConditionVariable.new
       @available_threads = size
-      @pool = Array.new(size) do |i|
+      @pool = Array.new(size) do |_i|
         Thread.new { poll }
       end
     end
 
     def report_metrics
       Temporal.metrics.gauge(Temporal::MetricKeys::THREAD_POOL_AVAILABLE_THREADS, @available_threads, @metrics_tags)
-      Temporal.metrics.gauge(Temporal::MetricKeys::THREAD_POOL_QUEUE_SIZE, @queue.size, @metrics_tags)
     end
 
     def wait_for_available_threads
       @mutex.synchronize do
-        while @available_threads <= 0
-          @availability.wait(@mutex)
-        end
+        @availability.wait(@mutex) while @available_threads <= 0
       end
     end
 

--- a/lib/temporal/workflow/poller.rb
+++ b/lib/temporal/workflow/poller.rb
@@ -70,6 +70,12 @@ module Temporal
 
           task = poll_for_task
           last_poll_time = Time.now
+
+          Temporal.metrics.increment(
+            Temporal::MetricKeys::WORKFLOW_POLLER_POLL_COMPLETED,
+            metrics_tags.merge(received_task: (!task.nil?).to_s)
+          )
+
           next unless task&.workflow_type
 
           thread_pool.schedule { process(task) }

--- a/lib/temporal/workflow/poller.rb
+++ b/lib/temporal/workflow/poller.rb
@@ -4,6 +4,7 @@ require 'temporal/thread_pool'
 require 'temporal/middleware/chain'
 require 'temporal/workflow/task_processor'
 require 'temporal/error_handler'
+require 'temporal/metric_keys'
 
 module Temporal
   class Workflow
@@ -64,7 +65,7 @@ module Temporal
           return if shutting_down?
 
           time_diff_ms = ((Time.now - last_poll_time) * 1000).round
-          Temporal.metrics.timing('workflow_poller.time_since_last_poll', time_diff_ms, metrics_tags)
+          Temporal.metrics.timing(Temporal::MetricKeys::WORKFLOW_POLLER_TIME_SINCE_LAST_POLL, time_diff_ms, metrics_tags)
           Temporal.logger.debug("Polling workflow task queue", { namespace: namespace, task_queue: task_queue })
 
           task = poll_for_task

--- a/lib/temporal/workflow/poller.rb
+++ b/lib/temporal/workflow/poller.rb
@@ -101,7 +101,14 @@ module Temporal
       end
 
       def thread_pool
-        @thread_pool ||= ThreadPool.new(options[:thread_pool_size])
+        @thread_pool ||= ThreadPool.new(
+          options[:thread_pool_size],
+          {
+            pool_name: 'workflow_task_poller',
+            namespace: namespace,
+            task_queue: task_queue
+          }
+        )
       end
 
       def binary_checksum

--- a/lib/temporal/workflow/task_processor.rb
+++ b/lib/temporal/workflow/task_processor.rb
@@ -156,6 +156,7 @@ module Temporal
       end
 
       def fail_task(error)
+        Temporal.metrics.increment(Temporal::MetricKeys::WORKFLOW_TASK_EXECUTION_FAILED, workflow: workflow_name, namespace: namespace)
         Temporal.logger.error('Workflow task failed', metadata.to_h.merge(error: error.inspect))
         Temporal.logger.debug(error.backtrace.join("\n"))
 

--- a/lib/temporal/workflow/task_processor.rb
+++ b/lib/temporal/workflow/task_processor.rb
@@ -4,6 +4,7 @@ require 'temporal/metadata'
 require 'temporal/workflow/executor'
 require 'temporal/workflow/history'
 require 'temporal/workflow/stack_trace_tracker'
+require 'temporal/metric_keys'
 
 module Temporal
   class Workflow
@@ -39,7 +40,7 @@ module Temporal
         start_time = Time.now
 
         Temporal.logger.debug("Processing Workflow task", metadata.to_h)
-        Temporal.metrics.timing('workflow_task.queue_time', queue_time_ms, workflow: workflow_name, namespace: namespace)
+        Temporal.metrics.timing(Temporal::MetricKeys::WORKFLOW_TASK_QUEUE_TIME, queue_time_ms, workflow: workflow_name, namespace: namespace)
 
         if !workflow_class
           raise Temporal::WorkflowNotRegistered, 'Workflow is not registered with this worker'
@@ -71,7 +72,7 @@ module Temporal
         fail_task(error)
       ensure
         time_diff_ms = ((Time.now - start_time) * 1000).round
-        Temporal.metrics.timing('workflow_task.latency', time_diff_ms, workflow: workflow_name, namespace: namespace)
+        Temporal.metrics.timing(Temporal::MetricKeys::WORKFLOW_TASK_LATENCY, time_diff_ms, workflow: workflow_name, namespace: namespace)
         Temporal.logger.debug("Workflow task processed", metadata.to_h.merge(execution_time: time_diff_ms))
       end
 
@@ -155,7 +156,7 @@ module Temporal
       end
 
       def fail_task(error)
-        Temporal.logger.error("Workflow task failed", metadata.to_h.merge(error: error.inspect))
+        Temporal.logger.error('Workflow task failed', metadata.to_h.merge(error: error.inspect))
         Temporal.logger.debug(error.backtrace.join("\n"))
 
         # Only fail the workflow task on the first attempt. Subsequent failures of the same workflow task

--- a/spec/unit/lib/temporal/activity/poller_spec.rb
+++ b/spec/unit/lib/temporal/activity/poller_spec.rb
@@ -1,6 +1,7 @@
 require 'temporal/activity/poller'
-require 'temporal/middleware/entry'
 require 'temporal/configuration'
+require 'temporal/metric_keys'
+require 'temporal/middleware/entry'
 
 describe Temporal::Activity::Poller do
   let(:connection) { instance_double('Temporal::Connection::GRPC', cancel_polling_request: nil) }

--- a/spec/unit/lib/temporal/activity/poller_spec.rb
+++ b/spec/unit/lib/temporal/activity/poller_spec.rb
@@ -51,8 +51,8 @@ describe Temporal::Activity::Poller do
       expect(Temporal.metrics)
         .to have_received(:timing)
         .with(
-          'activity_poller.time_since_last_poll',
-          an_instance_of(Fixnum),
+          Temporal::MetricKeys::ACTIVITY_POLLER_TIME_SINCE_LAST_POLL,
+          an_instance_of(Integer),
           namespace: namespace,
           task_queue: task_queue
         )
@@ -94,6 +94,7 @@ describe Temporal::Activity::Poller do
       context 'with middleware configured' do
         class TestPollerMiddleware
           def initialize(_); end
+
           def call(_); end
         end
 
@@ -131,7 +132,7 @@ describe Temporal::Activity::Poller do
 
         expect(Temporal.logger)
           .to have_received(:error)
-          .with('Unable to poll activity task queue', { namespace: 'test-namespace', task_queue: 'test-task-queue', error: '#<StandardError: StandardError>'})
+          .with('Unable to poll activity task queue', { namespace: 'test-namespace', task_queue: 'test-task-queue', error: '#<StandardError: StandardError>' })
       end
     end
   end

--- a/spec/unit/lib/temporal/activity/task_processor_spec.rb
+++ b/spec/unit/lib/temporal/activity/task_processor_spec.rb
@@ -20,7 +20,7 @@ describe Temporal::Activity::TaskProcessor do
   let(:connection) { instance_double('Temporal::Connection::GRPC') }
   let(:middleware_chain) { Temporal::Middleware::Chain.new }
   let(:config) { Temporal::Configuration.new }
-  let(:input) { ['arg1', 'arg2'] }
+  let(:input) { %w[arg1 arg2] }
 
   describe '#process' do
     let(:context) { instance_double('Temporal::Activity::Context', async?: false) }
@@ -127,7 +127,13 @@ describe Temporal::Activity::TaskProcessor do
 
           expect(Temporal.metrics)
             .to have_received(:timing)
-            .with('activity_task.queue_time', an_instance_of(Integer), activity: activity_name, namespace: namespace, workflow: workflow_name)
+            .with(
+              Temporal::MetricKeys::ACTIVITY_TASK_QUEUE_TIME,
+              an_instance_of(Integer),
+              activity: activity_name,
+              namespace: namespace,
+              workflow: workflow_name
+            )
         end
 
         it 'sends latency metric' do
@@ -135,7 +141,13 @@ describe Temporal::Activity::TaskProcessor do
 
           expect(Temporal.metrics)
             .to have_received(:timing)
-            .with('activity_task.latency', an_instance_of(Integer), activity: activity_name, namespace: namespace, workflow: workflow_name)
+            .with(
+              Temporal::MetricKeys::ACTIVITY_TASK_LATENCY,
+              an_instance_of(Integer),
+              activity: activity_name,
+              namespace: namespace,
+              workflow: workflow_name
+            )
         end
 
         context 'with async activity' do
@@ -206,7 +218,13 @@ describe Temporal::Activity::TaskProcessor do
 
           expect(Temporal.metrics)
             .to have_received(:timing)
-            .with('activity_task.queue_time', an_instance_of(Integer), activity: activity_name, namespace: namespace, workflow: workflow_name)
+            .with(
+              Temporal::MetricKeys::ACTIVITY_TASK_QUEUE_TIME,
+              an_instance_of(Integer),
+              activity: activity_name,
+              namespace: namespace,
+              workflow: workflow_name
+            )
         end
 
         it 'sends latency metric' do
@@ -214,7 +232,13 @@ describe Temporal::Activity::TaskProcessor do
 
           expect(Temporal.metrics)
             .to have_received(:timing)
-            .with('activity_task.latency', an_instance_of(Integer), activity: activity_name, namespace: namespace, workflow: workflow_name)
+            .with(
+              Temporal::MetricKeys::ACTIVITY_TASK_LATENCY,
+              an_instance_of(Integer),
+              activity: activity_name,
+              namespace: namespace,
+              workflow: workflow_name
+            )
         end
 
         context 'with ScriptError exception' do

--- a/spec/unit/lib/temporal/activity/task_processor_spec.rb
+++ b/spec/unit/lib/temporal/activity/task_processor_spec.rb
@@ -1,6 +1,7 @@
 require 'temporal/activity/task_processor'
-require 'temporal/middleware/chain'
 require 'temporal/configuration'
+require 'temporal/metric_keys'
+require 'temporal/middleware/chain'
 
 describe Temporal::Activity::TaskProcessor do
   subject { described_class.new(task, namespace, lookup, middleware_chain, config) }

--- a/spec/unit/lib/temporal/thread_pool_spec.rb
+++ b/spec/unit/lib/temporal/thread_pool_spec.rb
@@ -1,0 +1,43 @@
+require 'temporal/thread_pool'
+
+describe Temporal::ThreadPool do
+  before do
+    allow(Temporal.metrics).to receive(:gauge)
+  end
+
+  let(:size) { 2 }
+  let(:tags) { { foo: 'bar', bat: 'baz' } }
+  let(:thread_pool) { described_class.new(size, tags) }
+
+  describe '#new' do
+    it 'executes one task on a thread and exits' do
+      times = 0
+
+      thread_pool.schedule do
+        times += 1
+      end
+
+      thread_pool.shutdown
+
+      expect(times).to eq(1)
+    end
+
+    it 'reports thread available metrics' do
+      thread_pool.schedule do
+      end
+
+      thread_pool.shutdown
+
+      # Thread behavior is not deterministic. Ensure the calls match without
+      # verifying exact gauge values.
+      expect(Temporal.metrics)
+        .to have_received(:gauge)
+        .with(
+          Temporal::MetricKeys::THREAD_POOL_AVAILABLE_THREADS,
+          instance_of(Integer),
+          tags
+        )
+        .at_least(:once)
+    end
+  end
+end

--- a/spec/unit/lib/temporal/workflow/poller_spec.rb
+++ b/spec/unit/lib/temporal/workflow/poller_spec.rb
@@ -1,6 +1,7 @@
-require 'temporal/workflow/poller'
-require 'temporal/middleware/entry'
 require 'temporal/configuration'
+require 'temporal/metric_keys'
+require 'temporal/middleware/entry'
+require 'temporal/workflow/poller'
 
 describe Temporal::Workflow::Poller do
   let(:connection) { instance_double('Temporal::Connection::GRPC') }

--- a/spec/unit/lib/temporal/workflow/poller_spec.rb
+++ b/spec/unit/lib/temporal/workflow/poller_spec.rb
@@ -59,8 +59,8 @@ describe Temporal::Workflow::Poller do
       expect(Temporal.metrics)
         .to have_received(:timing)
         .with(
-          'workflow_poller.time_since_last_poll',
-          an_instance_of(Fixnum),
+          Temporal::MetricKeys::WORKFLOW_POLLER_TIME_SINCE_LAST_POLL,
+          an_instance_of(Integer),
           namespace: namespace,
           task_queue: task_queue
         )
@@ -94,6 +94,7 @@ describe Temporal::Workflow::Poller do
       context 'with middleware configured' do
         class TestPollerMiddleware
           def initialize(_); end
+
           def call(_); end
         end
 

--- a/spec/unit/lib/temporal/workflow/task_processor_spec.rb
+++ b/spec/unit/lib/temporal/workflow/task_processor_spec.rb
@@ -1,6 +1,7 @@
-require 'temporal/workflow/task_processor'
-require 'temporal/middleware/chain'
 require 'temporal/configuration'
+require 'temporal/metric_keys'
+require 'temporal/middleware/chain'
+require 'temporal/workflow/task_processor'
 
 describe Temporal::Workflow::TaskProcessor do
   subject { described_class.new(task, namespace, lookup, middleware_chain, config, binary_checksum) }

--- a/spec/unit/lib/temporal/workflow/task_processor_spec.rb
+++ b/spec/unit/lib/temporal/workflow/task_processor_spec.rb
@@ -14,7 +14,7 @@ describe Temporal::Workflow::TaskProcessor do
   let(:workflow_name) { 'TestWorkflow' }
   let(:connection) { instance_double('Temporal::Connection::GRPC') }
   let(:middleware_chain) { Temporal::Middleware::Chain.new }
-  let(:input) { ['arg1', 'arg2'] }
+  let(:input) { %w[arg1 arg2] }
   let(:config) { Temporal::Configuration.new }
   let(:binary_checksum) { 'v1.0.0' }
 
@@ -169,7 +169,12 @@ describe Temporal::Workflow::TaskProcessor do
 
           expect(Temporal.metrics)
             .to have_received(:timing)
-            .with('workflow_task.queue_time', an_instance_of(Integer), workflow: workflow_name, namespace: namespace)
+            .with(
+              Temporal::MetricKeys::WORKFLOW_TASK_QUEUE_TIME,
+              an_instance_of(Integer),
+              workflow: workflow_name,
+              namespace: namespace
+            )
         end
 
         it 'sends latency metric' do
@@ -177,7 +182,12 @@ describe Temporal::Workflow::TaskProcessor do
 
           expect(Temporal.metrics)
             .to have_received(:timing)
-            .with('workflow_task.latency', an_instance_of(Integer), workflow: workflow_name, namespace: namespace)
+            .with(
+              Temporal::MetricKeys::WORKFLOW_TASK_LATENCY,
+              an_instance_of(Integer),
+              workflow: workflow_name,
+              namespace: namespace
+            )
         end
       end
 
@@ -256,7 +266,12 @@ describe Temporal::Workflow::TaskProcessor do
 
           expect(Temporal.metrics)
             .to have_received(:timing)
-            .with('workflow_task.queue_time', an_instance_of(Integer), workflow: workflow_name, namespace: namespace)
+            .with(
+              Temporal::MetricKeys::WORKFLOW_TASK_QUEUE_TIME,
+              an_instance_of(Integer),
+              workflow: workflow_name,
+              namespace: namespace
+            )
         end
 
         it 'sends latency metric' do
@@ -264,7 +279,12 @@ describe Temporal::Workflow::TaskProcessor do
 
           expect(Temporal.metrics)
             .to have_received(:timing)
-            .with('workflow_task.latency', an_instance_of(Integer), workflow: workflow_name, namespace: namespace)
+            .with(
+              Temporal::MetricKeys::WORKFLOW_TASK_LATENCY,
+              an_instance_of(Integer),
+              workflow: workflow_name,
+              namespace: namespace
+            )
         end
       end
 


### PR DESCRIPTION
This change emits several new metrics around the processing of workflow and activity tasks. It also consolidates metrics names into constants, in a manner similar to the Java SDK, which makes it easy to see all metrics emitted.

New metrics:
- workflow task failure counter: indicate misversioning and other workflow code defects
- available thread pool size gauge: indicate thread pool utilization
- activity and workflow poll completed counters: indicate performance of pollers, with a special received_task tag indicating if a task was indeed received (or `false` if the call timed out without a task)