### PR TITLE
Exposing raw gRPC connection to sdk and count workflow executions

### DIFF
--- a/lib/temporal.rb
+++ b/lib/temporal.rb
@@ -29,7 +29,8 @@ module Temporal
                  :fail_activity,
                  :list_open_workflow_executions,
                  :list_closed_workflow_executions,
-                 :query_workflow_executions
+                 :query_workflow_executions,
+                 :connection
 
   class << self
     def configure(&block)

--- a/lib/temporal/client.rb
+++ b/lib/temporal/client.rb
@@ -409,6 +409,10 @@ module Temporal
       Temporal::Workflow::Executions.new(connection: connection, status: :all, request_options: { namespace: namespace, query: query, next_page_token: next_page_token, max_page_size: max_page_size }.merge(filter))
     end
 
+    def connection
+      @connection ||= Temporal::Connection.generate(config.for_connection)
+    end
+
     class ResultConverter
       extend Concerns::Payloads
     end
@@ -417,10 +421,6 @@ module Temporal
     private
 
     attr_reader :config
-
-    def connection
-      @connection ||= Temporal::Connection.generate(config.for_connection)
-    end
 
     def compute_run_timeout(execution_options)
       execution_options.timeouts[:run] || execution_options.timeouts[:execution]

--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -466,8 +466,12 @@ module Temporal
         raise NotImplementedError
       end
 
-      def count_workflow_executions
-        raise NotImplementedError
+      def count_workflow_executions(namespace:, query:)
+        request = Temporal::Api::WorkflowService::V1::CountWorkflowExecutionsRequest.new(
+          namespace: namespace,
+          query: query
+        )
+        client.count_workflow_executions(request)
       end
 
       def get_search_attributes

--- a/spec/unit/lib/temporal/grpc_spec.rb
+++ b/spec/unit/lib/temporal/grpc_spec.rb
@@ -363,6 +363,29 @@ describe Temporal::Connection::GRPC do
         end
       end
     end
+
+    describe "#count_workflow_executions" do
+      let(:namespace) { 'test-namespace' }
+      let(:query)  { 'StartDate < 2022-04-07T20:48:20Z order by StartTime desc' }
+      let(:args) { { namespace: namespace, query: query } }
+      let(:temporal_response) do
+        Temporal::Api::WorkflowService::V1::CountWorkflowExecutionsResponse.new(count: 0)
+      end
+
+      before do
+        allow(grpc_stub).to receive(:count_workflow_executions).and_return(temporal_response)
+      end
+
+      it 'makes an API request' do
+        subject.count_workflow_executions(**args)
+
+        expect(grpc_stub).to have_received(:count_workflow_executions) do |request|
+          expect(request).to be_an_instance_of(Temporal::Api::WorkflowService::V1::CountWorkflowExecutionsRequest)
+          expect(request.namespace).to eq(namespace)
+          expect(request.query).to eq(query)
+        end
+      end
+    end
     
     describe '#list_workflow_executions' do
       let(:namespace) { 'test-namespace' }


### PR DESCRIPTION
# Summary
This PR fixes implements the count_workflow_executions function. It doesn't directly expose the method, to call it, you will need to do something like
```ruby
Temporal.connection.count_workflow_executions(...)
```

# Test Plan
```
# unit test
bundle exec rspec spec/

# integration test
cd examples
(terminal 1) ./bin/worker
(terminal 2) USE_ENCRYPTION=1 ./bin/worker
(terminal 3) bundle exec rspec spec/integration
```