### PR TITLE
Make workflow id reuse policy configurable

### DIFF
--- a/lib/temporal/client.rb
+++ b/lib/temporal/client.rb
@@ -60,7 +60,7 @@ module Temporal
           # If unspecified, individual runs should have the full time for the execution (which includes retries).
           run_timeout: compute_run_timeout(execution_options),
           task_timeout: execution_options.timeouts[:task],
-          workflow_id_reuse_policy: options[:workflow_id_reuse_policy],
+          workflow_id_reuse_policy: options[:workflow_id_reuse_policy] || execution_options.workflow_id_reuse_policy,
           headers: execution_options.headers,
           memo: execution_options.memo,
           search_attributes: Workflow::Context::Helpers.process_search_attributes(execution_options.search_attributes),
@@ -77,7 +77,7 @@ module Temporal
           execution_timeout: execution_options.timeouts[:execution],
           run_timeout: compute_run_timeout(execution_options),
           task_timeout: execution_options.timeouts[:task],
-          workflow_id_reuse_policy: options[:workflow_id_reuse_policy],
+          workflow_id_reuse_policy: options[:workflow_id_reuse_policy] || execution_options.workflow_id_reuse_policy,
           headers: execution_options.headers,
           memo: execution_options.memo,
           search_attributes: Workflow::Context::Helpers.process_search_attributes(execution_options.search_attributes),
@@ -126,7 +126,7 @@ module Temporal
         # than the execution timeout.
         run_timeout: compute_run_timeout(execution_options),
         task_timeout: execution_options.timeouts[:task],
-        workflow_id_reuse_policy: options[:workflow_id_reuse_policy],
+        workflow_id_reuse_policy: options[:workflow_id_reuse_policy] || execution_options.workflow_id_reuse_policy,
         headers: execution_options.headers,
         cron_schedule: cron_schedule,
         memo: execution_options.memo,

--- a/lib/temporal/concerns/executable.rb
+++ b/lib/temporal/concerns/executable.rb
@@ -29,6 +29,11 @@ module Temporal
         return @headers if args.empty?
         @headers = args.first
       end
+
+      def workflow_id_reuse_policy(*args)
+        return @workflow_id_reuse_policy if args.empty?
+        @workflow_id_reuse_policy = args.first
+      end
     end
   end
 end

--- a/lib/temporal/connection/serializer/workflow_id_reuse_policy.rb
+++ b/lib/temporal/connection/serializer/workflow_id_reuse_policy.rb
@@ -4,7 +4,6 @@ module Temporal
   module Connection
     module Serializer
       class WorkflowIdReusePolicy < Base
-
         WORKFLOW_ID_REUSE_POLICY = {
           allow_failed: Temporal::Api::Enums::V1::WorkflowIdReusePolicy::WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
           allow: Temporal::Api::Enums::V1::WorkflowIdReusePolicy::WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
@@ -14,7 +13,7 @@ module Temporal
         def to_proto
           return unless object
 
-          policy = WORKFLOW_ID_REUSE_POLICY[object]
+          policy = WORKFLOW_ID_REUSE_POLICY[object.to_sym]
           raise ArgumentError, "Unknown workflow_id_reuse_policy specified: #{object}" unless policy
 
           policy

--- a/lib/temporal/execution_options.rb
+++ b/lib/temporal/execution_options.rb
@@ -3,7 +3,7 @@ require 'temporal/retry_policy'
 
 module Temporal
   class ExecutionOptions
-    attr_reader :name, :namespace, :task_queue, :retry_policy, :timeouts, :headers, :memo, :search_attributes
+    attr_reader :name, :namespace, :task_queue, :retry_policy, :timeouts, :headers, :memo, :search_attributes, :workflow_id_reuse_policy
 
     def initialize(object, options, defaults = nil)
       # Options are treated as overrides and take precedence
@@ -15,6 +15,7 @@ module Temporal
       @headers = options[:headers] || {}
       @memo = options[:memo] || {}
       @search_attributes = options[:search_attributes] || {}
+      @workflow_id_reuse_policy = options[:workflow_id_reuse_policy]
 
       # For Temporal::Workflow and Temporal::Activity use defined values as the next option
       if has_executable_concern?(object)
@@ -23,6 +24,7 @@ module Temporal
         @retry_policy = object.retry_policy.merge(@retry_policy) if object.retry_policy
         @timeouts = object.timeouts.merge(@timeouts) if object.timeouts
         @headers = object.headers.merge(@headers) if object.headers
+        @workflow_id_reuse_policy ||= object.workflow_id_reuse_policy
       end
 
       # Lastly consider defaults if they are given
@@ -32,6 +34,7 @@ module Temporal
         @timeouts = defaults.timeouts.merge(@timeouts)
         @headers = defaults.headers.merge(@headers)
         @search_attributes = defaults.search_attributes.merge(@search_attributes)
+        @workflow_id_reuse_policy ||= defaults.workflow_id_reuse_policy
       end
 
       if @retry_policy.empty?

--- a/lib/temporal/workflow/context.rb
+++ b/lib/temporal/workflow/context.rb
@@ -133,7 +133,7 @@ module Temporal
           headers: execution_options.headers,
           cron_schedule: cron_schedule,
           memo: execution_options.memo,
-          workflow_id_reuse_policy: workflow_id_reuse_policy,
+          workflow_id_reuse_policy: workflow_id_reuse_policy || execution_options.workflow_id_reuse_policy,
           search_attributes: Helpers.process_search_attributes(execution_options.search_attributes),
         )
 


### PR DESCRIPTION
- A default workflow_id_reuse_policy can now be set in configuration. It can also be set directly on workflows via the executable concern. Previously, the only way to set it was to provide it as an option to the *_workflow methods directly (this is also still supported).

Sorry, my lint autofix snuck in some whitespace removal.  Throw ?w=1 in the url of the PR if it's distracting 😁 