### PR TITLE
Do not fail workflow task if an error occurs when marking it as completed

### DIFF
--- a/lib/temporal/workflow/task_processor.rb
+++ b/lib/temporal/workflow/task_processor.rb
@@ -139,6 +139,10 @@ module Temporal
           binary_checksum: binary_checksum,
           query_results: query_results
         )
+      rescue StandardError => error
+        Temporal.logger.error("Unable to complete the workflow task", metadata.to_h.merge(error: error.inspect))
+
+        Temporal::ErrorHandler.handle(error, config, metadata: metadata)
       end
 
       def complete_query(result)

--- a/spec/unit/lib/temporal/workflow/task_processor_spec.rb
+++ b/spec/unit/lib/temporal/workflow/task_processor_spec.rb
@@ -205,6 +205,33 @@ describe Temporal::Workflow::TaskProcessor do
         end
       end
 
+      context 'when recording the workflow task complete fails' do
+        let(:exception) { StandardError.new('workflow task could not be completed') }
+
+        before { allow(connection).to receive(:respond_workflow_task_completed).and_raise(exception) }
+
+        it 'does not try to fail the workflow task' do
+          subject.process
+
+          expect(connection).to_not have_received(:respond_workflow_task_failed)
+        end
+
+        it 'calls error_handlers' do
+          reported_error = nil
+          reported_metadata = nil
+
+          config.on_error do |error, metadata: nil|
+            reported_error = error
+            reported_metadata = metadata
+          end
+
+          subject.process
+
+          expect(reported_error).to be_an_instance_of(StandardError)
+          expect(reported_metadata).to be_an_instance_of(Temporal::Metadata::WorkflowTask)
+        end
+      end
+
       context 'when workflow task raises an exception' do
         let(:exception) { StandardError.new('workflow task failed') }
 


### PR DESCRIPTION
It's possible for a workflow task to fail to complete even during normal operation. For example, if a signal is added to the workflow history concurrently with a workflow task attempting to complete the workflow then the `RespondWorkflowTaskCompleted` call will recieve an `InvalidArgument` error with an `UnhandledCommand` cause.

If this happens then the Ruby SDK would get this error and then try and fail the workflow task due to how the `rescue` block encompasses the completion function. This would then lead to the `RespondWorkflowTaskFailed` call failing because the server doesn't recognize the task anymore. This is because the task was actually finalized when the original `RespondWorkflowTaskCompleted` call was made and so it should not be interacted with anymore.

This PR catches the `RespondWorkflowTaskCompleted` error sooner (similar to the query branch) so that it does not cause the workflow task to be failed and therefore avoids the `Workflow task not found` error from the `RespondWorkflowTaskFailed` call. The error is still logged and passed to the error reporter though.