### PR TITLE
Paginate through empty workflow history pages

### DIFF
--- a/examples/bin/register_namespace
+++ b/examples/bin/register_namespace
@@ -4,7 +4,7 @@ require_relative '../init'
 namespace = ARGV[0]
 description = ARGV[1]
 
-fail 'Missing namespace name, please run register_namespace <namespace_name>' unless namespace
+raise 'Missing namespace name, please run register_namespace <namespace_name>' unless namespace
 
 begin
   Temporal.register_namespace(namespace, description)
@@ -13,4 +13,17 @@ rescue Temporal::NamespaceAlreadyExistsFailure
   Temporal.logger.info 'Namespace already exists', { namespace: namespace }
 end
 
-
+# Register a variety of search attributes for ease of integration testing
+attributes_to_add = {
+  'CustomStringField' => :text,
+  'CustomDoubleField' => :double,
+  'CustomBoolField' => :bool,
+  'CustomIntField' => :int,
+  'CustomDatetimeField' => :datetime
+}
+begin
+  Temporal.add_custom_search_attributes(attributes_to_add)
+  Temporal.logger.info('Registered search attributes', { namespace: namespace, attributes: attributes_to_add })
+rescue Temporal::SearchAttributeAlreadyExistsFailure
+  Temporal.logger.info('Default search attributes already exist for namespace', { namespace: namespace })
+end

--- a/examples/spec/integration/search_attributes_spec.rb
+++ b/examples/spec/integration/search_attributes_spec.rb
@@ -47,24 +47,6 @@ describe 'search attributes' do
     end.to raise_error(Temporal::SearchAttributeAlreadyExistsFailure)
   end
 
-  it 'type change fails' do
-    Temporal.add_custom_search_attributes(
-      {
-        attribute_1 => :int
-      }
-    )
-
-    Temporal.remove_custom_search_attributes(attribute_1)
-
-    expect do
-      Temporal.add_custom_search_attributes(
-        {
-          attribute_1 => :keyword
-        }
-      )
-    end.to raise_error(an_instance_of(Temporal::SearchAttributeFailure))
-  end
-
   it 'remove' do
     Temporal.add_custom_search_attributes(
       {

--- a/lib/temporal/errors.rb
+++ b/lib/temporal/errors.rb
@@ -77,7 +77,6 @@ module Temporal
   class NamespaceAlreadyExistsFailure < ApiError; end
   class CancellationAlreadyRequestedFailure < ApiError; end
   class QueryFailed < ApiError; end
-  class UnexpectedResponse < ApiError; end
 
   class SearchAttributeAlreadyExistsFailure < ApiError; end
   class SearchAttributeFailure < ApiError; end

--- a/lib/temporal/workflow/task_processor.rb
+++ b/lib/temporal/workflow/task_processor.rb
@@ -94,7 +94,6 @@ module Temporal
       def fetch_full_history
         events = task.history.events.to_a
         next_page_token = task.next_page_token
-
         while !next_page_token.empty? do
           response = connection.get_workflow_execution_history(
             namespace: namespace,
@@ -102,12 +101,8 @@ module Temporal
             run_id: task.workflow_execution.run_id,
             next_page_token: next_page_token
           )
-
-          if response.history.events.empty?
-            raise Temporal::UnexpectedResponse, 'Received empty history page'
-          end
-
           events += response.history.events.to_a
+
           next_page_token = response.next_page_token
         end
 

--- a/spec/fabricators/grpc/workflow_task_fabricator.rb
+++ b/spec/fabricators/grpc/workflow_task_fabricator.rb
@@ -12,7 +12,3 @@ Fabricator(:api_workflow_task, from: Temporalio::Api::WorkflowService::V1::PollW
   history { |attrs| Temporalio::Api::History::V1::History.new(events: attrs[:events]) }
   query { nil }
 end
-
-Fabricator(:api_paginated_workflow_task, from: :api_workflow_task) do
-  next_page_token 'page-1'
-end

--- a/spec/fabricators/workflow_execution_history_fabricator.rb
+++ b/spec/fabricators/workflow_execution_history_fabricator.rb
@@ -1,5 +1,5 @@
 Fabricator(:workflow_execution_history, from: Temporalio::Api::WorkflowService::V1::GetWorkflowExecutionHistoryResponse) do
-  transient :events
+  transient :events, :_next_page_token
   history { |attrs| Temporalio::Api::History::V1::History.new(events: attrs[:events]) }
-  next_page_token ''
+  next_page_token { |attrs| attrs[:_next_page_token] || '' }
 end


### PR DESCRIPTION
# Description
Temporal server sometimes sends empty history pages but with a next_page_token.  Best practice across the SDKs is to keep paginating.

But temporal ruby was frequently returning a `Temporal::UnexpectedResponse`. This caused workflow tasks to fail and delay ten seconds until the next retry.  Especially prevalent on long workflow histories.

This change simply removes the check since this is supported behavior.

Update: I threw in a couple of unrelated test fixes to get the CircleCI tests to pass.

# Test plan

Note : I OKed this with Chad Retz from Temporal.  We've had this change active for months at Stripe and have been happy with it.

New test:
`rspec spec/unit/lib/temporal/workflow/task_processor_spec.rb`


