### PR TITLE
Add sleep after bad poll

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,18 @@ worker.register_activity(HelloActivity)
 worker.start # runs forever
 ```
 
+You can add several options when initializing worker (here defaults are provided as values):
+
+```ruby
+Temporal::Worker.new(
+  activity_thread_pool_size: 20, # how many threads poll for activities
+  workflow_thread_pool_size: 10, # how many threads poll for workflows
+  binary_checksum: nil, # identifies the version of workflow worker code
+  activity_poll_retry_seconds: 0, # how many seconds to wait after unsuccessful poll for activities
+  workflow_poll_retry_seconds: 0  # how many seconds to wait after unsuccessful poll for workflows
+)
+```
+
 And finally start your workflow in another terminal shell:
 
 ```ruby

--- a/lib/temporal/activity/poller.rb
+++ b/lib/temporal/activity/poller.rb
@@ -91,7 +91,7 @@ module Temporal
 
         Temporal::ErrorHandler.handle(error, config)
 
-        sleep poll_retry_seconds unless poll_retry_seconds.zero?
+        sleep_before_retry(poll_retry_seconds) unless poll_retry_seconds.zero?
 
         nil
       end
@@ -115,6 +115,10 @@ module Temporal
 
       def poll_retry_seconds
         @options[:poll_retry_seconds]
+      end
+
+      def sleep_before_retry(seconds)
+        sleep seconds
       end
     end
   end

--- a/lib/temporal/activity/poller.rb
+++ b/lib/temporal/activity/poller.rb
@@ -91,7 +91,7 @@ module Temporal
 
         Temporal::ErrorHandler.handle(error, config)
 
-        sleep_before_retry(poll_retry_seconds) unless poll_retry_seconds.zero?
+        sleep(poll_retry_seconds)
 
         nil
       end
@@ -115,10 +115,6 @@ module Temporal
 
       def poll_retry_seconds
         @options[:poll_retry_seconds]
-      end
-
-      def sleep_before_retry(seconds)
-        sleep seconds
       end
     end
   end

--- a/lib/temporal/activity/poller.rb
+++ b/lib/temporal/activity/poller.rb
@@ -9,7 +9,8 @@ module Temporal
   class Activity
     class Poller
       DEFAULT_OPTIONS = {
-        thread_pool_size: 20
+        thread_pool_size: 20,
+        poll_retry_seconds: 0
       }.freeze
 
       def initialize(namespace, task_queue, activity_lookup, config, middleware = [], options = {})
@@ -90,6 +91,8 @@ module Temporal
 
         Temporal::ErrorHandler.handle(error, config)
 
+        sleep poll_retry_seconds unless poll_retry_seconds.zero?
+
         nil
       end
 
@@ -108,6 +111,10 @@ module Temporal
             task_queue: task_queue
           }
         )
+      end
+
+      def poll_retry_seconds
+        @options[:poll_retry_seconds]
       end
     end
   end

--- a/lib/temporal/worker.rb
+++ b/lib/temporal/worker.rb
@@ -24,7 +24,9 @@ module Temporal
       config = Temporal.configuration,
       activity_thread_pool_size: Temporal::Activity::Poller::DEFAULT_OPTIONS[:thread_pool_size],
       workflow_thread_pool_size: Temporal::Workflow::Poller::DEFAULT_OPTIONS[:thread_pool_size],
-      binary_checksum: Temporal::Workflow::Poller::DEFAULT_OPTIONS[:binary_checksum]
+      binary_checksum: Temporal::Workflow::Poller::DEFAULT_OPTIONS[:binary_checksum],
+      activity_poll_retry_seconds: Temporal::Activity::Poller::DEFAULT_OPTIONS[:poll_retry_seconds],
+      workflow_poll_retry_seconds: Temporal::Workflow::Poller::DEFAULT_OPTIONS[:poll_retry_seconds]
     )
       @config = config
       @workflows = Hash.new { |hash, key| hash[key] = ExecutableLookup.new }
@@ -36,10 +38,12 @@ module Temporal
       @shutting_down = false
       @activity_poller_options = {
         thread_pool_size: activity_thread_pool_size,
+        poll_retry_seconds: activity_poll_retry_seconds
       }
       @workflow_poller_options = {
         thread_pool_size: workflow_thread_pool_size,
-        binary_checksum: binary_checksum
+        binary_checksum: binary_checksum,
+        poll_retry_seconds: workflow_poll_retry_seconds
       }
     end
 

--- a/lib/temporal/workflow/poller.rb
+++ b/lib/temporal/workflow/poller.rb
@@ -11,7 +11,8 @@ module Temporal
     class Poller
       DEFAULT_OPTIONS = {
         thread_pool_size: 10,
-        binary_checksum: nil
+        binary_checksum: nil,
+        poll_retry_seconds: 0
       }.freeze
 
       def initialize(namespace, task_queue, workflow_lookup, config, middleware = [], workflow_middleware = [], options = {})
@@ -92,6 +93,8 @@ module Temporal
         Temporal.logger.error("Unable to poll Workflow task queue", { namespace: namespace, task_queue: task_queue, error: error.inspect })
         Temporal::ErrorHandler.handle(error, config)
 
+        sleep poll_retry_seconds unless poll_retry_seconds.zero?
+
         nil
       end
 
@@ -115,6 +118,10 @@ module Temporal
 
       def binary_checksum
         @options[:binary_checksum]
+      end
+
+      def poll_retry_seconds
+        @options[:poll_retry_seconds]
       end
     end
   end

--- a/lib/temporal/workflow/poller.rb
+++ b/lib/temporal/workflow/poller.rb
@@ -93,7 +93,7 @@ module Temporal
         Temporal.logger.error("Unable to poll Workflow task queue", { namespace: namespace, task_queue: task_queue, error: error.inspect })
         Temporal::ErrorHandler.handle(error, config)
 
-        sleep poll_retry_seconds unless poll_retry_seconds.zero?
+        sleep_before_retry(poll_retry_seconds) unless poll_retry_seconds.zero?
 
         nil
       end
@@ -122,6 +122,10 @@ module Temporal
 
       def poll_retry_seconds
         @options[:poll_retry_seconds]
+      end
+
+      def sleep_before_retry(seconds)
+        sleep seconds
       end
     end
   end

--- a/lib/temporal/workflow/poller.rb
+++ b/lib/temporal/workflow/poller.rb
@@ -93,7 +93,7 @@ module Temporal
         Temporal.logger.error("Unable to poll Workflow task queue", { namespace: namespace, task_queue: task_queue, error: error.inspect })
         Temporal::ErrorHandler.handle(error, config)
 
-        sleep_before_retry(poll_retry_seconds) unless poll_retry_seconds.zero?
+        sleep(poll_retry_seconds)
 
         nil
       end
@@ -122,10 +122,6 @@ module Temporal
 
       def poll_retry_seconds
         @options[:poll_retry_seconds]
-      end
-
-      def sleep_before_retry(seconds)
-        sleep seconds
       end
     end
   end

--- a/spec/unit/lib/temporal/activity/poller_spec.rb
+++ b/spec/unit/lib/temporal/activity/poller_spec.rb
@@ -159,6 +159,7 @@ describe Temporal::Activity::Poller do
       before do
         allow(subject).to receive(:shutting_down?).and_return(false, true)
         allow(connection).to receive(:poll_activity_task_queue).and_raise(StandardError)
+        allow(subject).to receive(:sleep_before_retry).and_return(nil)
       end
 
       it 'logs' do
@@ -173,6 +174,45 @@ describe Temporal::Activity::Poller do
           .to have_received(:error)
           .with('Unable to poll activity task queue', { namespace: 'test-namespace', task_queue: 'test-task-queue', error: '#<StandardError: StandardError>' })
       end
+
+      it 'does not sleep' do
+        subject.start
+
+        # stop poller before inspecting
+        subject.stop_polling; subject.wait
+
+        expect(subject).to_not have_received(:sleep_before_retry)
+      end
+    end
+  end
+
+  context 'when connection is unable to poll and poll_retry_seconds is set' do
+    subject do
+      described_class.new(
+        namespace,
+        task_queue,
+        lookup,
+        config,
+        middleware,
+        {
+          poll_retry_seconds: 5
+        }
+      )
+    end
+
+    before do
+      allow(subject).to receive(:shutting_down?).and_return(false, true)
+      allow(connection).to receive(:poll_activity_task_queue).and_raise(StandardError)
+      allow(subject).to receive(:sleep_before_retry).and_return(nil)
+    end
+
+    it 'sleeps' do
+      subject.start
+
+      # stop poller before inspecting
+      subject.stop_polling; subject.wait
+
+      expect(subject).to have_received(:sleep_before_retry).with(5).once
     end
   end
 

--- a/spec/unit/lib/temporal/activity/poller_spec.rb
+++ b/spec/unit/lib/temporal/activity/poller_spec.rb
@@ -159,7 +159,7 @@ describe Temporal::Activity::Poller do
       before do
         allow(subject).to receive(:shutting_down?).and_return(false, true)
         allow(connection).to receive(:poll_activity_task_queue).and_raise(StandardError)
-        allow(subject).to receive(:sleep_before_retry).and_return(nil)
+        allow(subject).to receive(:sleep).and_return(nil)
       end
 
       it 'logs' do
@@ -181,7 +181,7 @@ describe Temporal::Activity::Poller do
         # stop poller before inspecting
         subject.stop_polling; subject.wait
 
-        expect(subject).to_not have_received(:sleep_before_retry)
+        expect(subject).to have_received(:sleep).with(0).once
       end
     end
   end
@@ -203,7 +203,7 @@ describe Temporal::Activity::Poller do
     before do
       allow(subject).to receive(:shutting_down?).and_return(false, true)
       allow(connection).to receive(:poll_activity_task_queue).and_raise(StandardError)
-      allow(subject).to receive(:sleep_before_retry).and_return(nil)
+      allow(subject).to receive(:sleep).and_return(nil)
     end
 
     it 'sleeps' do
@@ -212,7 +212,7 @@ describe Temporal::Activity::Poller do
       # stop poller before inspecting
       subject.stop_polling; subject.wait
 
-      expect(subject).to have_received(:sleep_before_retry).with(5).once
+      expect(subject).to have_received(:sleep).with(5).once
     end
   end
 

--- a/spec/unit/lib/temporal/worker_spec.rb
+++ b/spec/unit/lib/temporal/worker_spec.rb
@@ -376,6 +376,7 @@ describe Temporal::Worker do
           an_instance_of(Temporal::ExecutableLookup),
           an_instance_of(Temporal::Configuration),
           [],
+          [],
           {binary_checksum: nil, poll_retry_seconds: 10, thread_pool_size: 10}
         )
         .and_return(workflow_poller)

--- a/spec/unit/lib/temporal/workflow/poller_spec.rb
+++ b/spec/unit/lib/temporal/workflow/poller_spec.rb
@@ -207,6 +207,7 @@ describe Temporal::Workflow::Poller do
           lookup,
           config,
           middleware,
+          workflow_middleware,
           {
             binary_checksum: binary_checksum,
             poll_retry_seconds: 5

--- a/spec/unit/lib/temporal/workflow/poller_spec.rb
+++ b/spec/unit/lib/temporal/workflow/poller_spec.rb
@@ -168,6 +168,7 @@ describe Temporal::Workflow::Poller do
       before do
         allow(subject).to receive(:shutting_down?).and_return(false, true)
         allow(connection).to receive(:poll_workflow_task_queue).and_raise(StandardError)
+        allow(subject).to receive(:sleep_before_retry).and_return(nil)
       end
 
       it 'logs' do
@@ -186,6 +187,46 @@ describe Temporal::Workflow::Poller do
             task_queue: task_queue,
             error: '#<StandardError: StandardError>'
           )
+      end
+
+      it 'does not sleep' do
+        subject.start
+
+        # stop poller before inspecting
+        subject.stop_polling; subject.wait
+
+        expect(subject).to_not have_received(:sleep_before_retry)
+      end
+    end
+
+    context 'when connection is unable to poll and poll_retry_seconds is set' do
+      subject do
+        described_class.new(
+          namespace,
+          task_queue,
+          lookup,
+          config,
+          middleware,
+          {
+            binary_checksum: binary_checksum,
+            poll_retry_seconds: 5
+          }
+        )
+      end
+
+      before do
+        allow(subject).to receive(:shutting_down?).and_return(false, true)
+        allow(connection).to receive(:poll_workflow_task_queue).and_raise(StandardError)
+        allow(subject).to receive(:sleep_before_retry).and_return(nil)
+      end
+
+      it 'sleeps' do
+        subject.start
+
+        # stop poller before inspecting
+        subject.stop_polling; subject.wait
+
+        expect(subject).to have_received(:sleep_before_retry).with(5).once
       end
     end
   end

--- a/spec/unit/lib/temporal/workflow/poller_spec.rb
+++ b/spec/unit/lib/temporal/workflow/poller_spec.rb
@@ -168,7 +168,7 @@ describe Temporal::Workflow::Poller do
       before do
         allow(subject).to receive(:shutting_down?).and_return(false, true)
         allow(connection).to receive(:poll_workflow_task_queue).and_raise(StandardError)
-        allow(subject).to receive(:sleep_before_retry).and_return(nil)
+        allow(subject).to receive(:sleep).and_return(nil)
       end
 
       it 'logs' do
@@ -195,7 +195,7 @@ describe Temporal::Workflow::Poller do
         # stop poller before inspecting
         subject.stop_polling; subject.wait
 
-        expect(subject).to_not have_received(:sleep_before_retry)
+        expect(subject).to have_received(:sleep).with(0).once
       end
     end
 
@@ -217,7 +217,7 @@ describe Temporal::Workflow::Poller do
       before do
         allow(subject).to receive(:shutting_down?).and_return(false, true)
         allow(connection).to receive(:poll_workflow_task_queue).and_raise(StandardError)
-        allow(subject).to receive(:sleep_before_retry).and_return(nil)
+        allow(subject).to receive(:sleep).and_return(nil)
       end
 
       it 'sleeps' do
@@ -226,7 +226,7 @@ describe Temporal::Workflow::Poller do
         # stop poller before inspecting
         subject.stop_polling; subject.wait
 
-        expect(subject).to have_received(:sleep_before_retry).with(5).once
+        expect(subject).to have_received(:sleep).with(5).once
       end
     end
   end


### PR DESCRIPTION
Closes https://github.com/coinbase/temporal-ruby/issues/215

Add sleep before retrying after unsuccessful poll for workflow and activity tasks. Default value is 0 so without extra configs worker will behave in old way. Sleep duration is specified in seconds.
Also add tests for new functionality.
Add docs to `README.md`.