### PR TITLE
APIs for managing custom search attributes

### DIFF
--- a/examples/spec/integration/search_attributes_spec.rb
+++ b/examples/spec/integration/search_attributes_spec.rb
@@ -1,0 +1,88 @@
+require 'temporal/errors'
+
+describe 'search attributes' do
+  let(:attribute_1) { 'Age' }
+  let(:attribute_2) { 'Name' }
+
+  def cleanup
+    custom_attributes = Temporal.list_custom_search_attributes
+    Temporal.remove_custom_search_attributes(attribute_1) if custom_attributes.include?(attribute_1)
+    Temporal.remove_custom_search_attributes(attribute_2) if custom_attributes.include?(attribute_2)
+  end
+
+  before do
+    cleanup
+  end
+
+  after do
+    cleanup
+  end
+
+  it 'add' do
+    Temporal.add_custom_search_attributes(
+      {
+        attribute_1 => :int,
+        attribute_2 => :keyword
+      }
+    )
+
+    custom_attributes = Temporal.list_custom_search_attributes
+    expect(custom_attributes).to include(attribute_1 => :int)
+    expect(custom_attributes).to include(attribute_2 => :keyword)
+  end
+
+  it 'add duplicate fails' do
+    Temporal.add_custom_search_attributes(
+      {
+        attribute_1 => :int
+      }
+    )
+
+    expect do
+      Temporal.add_custom_search_attributes(
+        {
+          attribute_1 => :int
+        }
+      )
+    end.to raise_error(Temporal::SearchAttributeAlreadyExistsFailure)
+  end
+
+  it 'type change fails' do
+    Temporal.add_custom_search_attributes(
+      {
+        attribute_1 => :int
+      }
+    )
+
+    Temporal.remove_custom_search_attributes(attribute_1)
+
+    expect do
+      Temporal.add_custom_search_attributes(
+        {
+          attribute_1 => :keyword
+        }
+      )
+    end.to raise_error(an_instance_of(Temporal::SearchAttributeFailure))
+  end
+
+  it 'remove' do
+    Temporal.add_custom_search_attributes(
+      {
+        attribute_1 => :int,
+        attribute_2 => :keyword
+      }
+    )
+
+    Temporal.remove_custom_search_attributes(attribute_1, attribute_2)
+
+    custom_attributes = Temporal.list_custom_search_attributes
+    expect(custom_attributes).not_to include(attribute_1 => :int)
+    expect(custom_attributes).not_to include(attribute_2 => :keyword)
+  end
+
+  it 'remove non-existent fails' do
+    expect do
+      Temporal.remove_custom_search_attributes(attribute_1, attribute_2)
+    end.to raise_error(Temporal::NotFoundFailure)
+  end
+end

--- a/lib/temporal.rb
+++ b/lib/temporal.rb
@@ -30,6 +30,9 @@ module Temporal
                  :list_open_workflow_executions,
                  :list_closed_workflow_executions,
                  :query_workflow_executions,
+                 :add_custom_search_attributes,
+                 :list_custom_search_attributes,
+                 :remove_custom_search_attributes,
                  :connection
 
   class << self

--- a/lib/temporal/client.rb
+++ b/lib/temporal/client.rb
@@ -409,6 +409,21 @@ module Temporal
       Temporal::Workflow::Executions.new(connection: connection, status: :all, request_options: { namespace: namespace, query: query, next_page_token: next_page_token, max_page_size: max_page_size }.merge(filter))
     end
 
+    # @param attributes [Hash[String, Symbol]] name to symbol for type, see INDEXED_VALUE_TYPE above
+    def add_custom_search_attributes(attributes)
+      connection.add_custom_search_attributes(attributes)
+    end
+
+    # @return Hash[String, Symbol] name to symbol for type, see INDEXED_VALUE_TYPE above
+    def list_custom_search_attributes
+      connection.list_custom_search_attributes
+    end
+
+    # @param attribute_names [Array[String]] Attributes to remove
+    def remove_custom_search_attributes(*attribute_names)
+      connection.remove_custom_search_attributes(attribute_names)
+    end
+
     def connection
       @connection ||= Temporal::Connection.generate(config.for_connection)
     end

--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -4,7 +4,9 @@ require 'google/protobuf/well_known_types'
 require 'securerandom'
 require 'gen/temporal/api/filter/v1/message_pb'
 require 'gen/temporal/api/workflowservice/v1/service_services_pb'
+require 'gen/temporal/api/operatorservice/v1/service_services_pb'
 require 'gen/temporal/api/enums/v1/workflow_pb'
+require 'gen/temporal/api/enums/v1/common_pb'
 require 'temporal/connection/errors'
 require 'temporal/connection/serializer'
 require 'temporal/connection/serializer/failure'
@@ -27,9 +29,25 @@ module Temporal
         not_completed_cleanly: Temporalio::Api::Enums::V1::QueryRejectCondition::QUERY_REJECT_CONDITION_NOT_COMPLETED_CLEANLY
       }.freeze
 
+      SYMBOL_TO_INDEXED_VALUE_TYPE = {
+        text: Temporalio::Api::Enums::V1::IndexedValueType::INDEXED_VALUE_TYPE_TEXT,
+        keyword: Temporalio::Api::Enums::V1::IndexedValueType::INDEXED_VALUE_TYPE_KEYWORD,
+        int: Temporalio::Api::Enums::V1::IndexedValueType::INDEXED_VALUE_TYPE_INT,
+        double: Temporalio::Api::Enums::V1::IndexedValueType::INDEXED_VALUE_TYPE_DOUBLE,
+        bool: Temporalio::Api::Enums::V1::IndexedValueType::INDEXED_VALUE_TYPE_BOOL,
+        datetime: Temporalio::Api::Enums::V1::IndexedValueType::INDEXED_VALUE_TYPE_DATETIME,
+        keyword_list: Temporalio::Api::Enums::V1::IndexedValueType::INDEXED_VALUE_TYPE_KEYWORD_LIST,
+      }.freeze
+
+      INDEXED_VALUE_TYPE_TO_SYMBOL = SYMBOL_TO_INDEXED_VALUE_TYPE.map do |symbol, int_value|
+        [Temporalio::Api::Enums::V1::IndexedValueType.lookup(int_value), symbol]
+      end.to_h.freeze
+
       DEFAULT_OPTIONS = {
         max_page_size: 100
       }.freeze
+
+      CONNECTION_TIMEOUT_SECONDS = 60
 
       def initialize(host, port, identity, credentials, options = {})
         @url = "#{host}:#{port}"
@@ -475,8 +493,45 @@ module Temporal
         client.count_workflow_executions(request)
       end
 
-      def get_search_attributes
-        raise NotImplementedError
+      def add_custom_search_attributes(attributes)
+        attributes.each_value do |symbol_type|
+          next if SYMBOL_TO_INDEXED_VALUE_TYPE.include?(symbol_type)
+
+          raise Temporal::InvalidSearchAttributeTypeFailure.new(
+            "Cannot add search attributes (#{attributes}): unknown search attribute type :#{symbol_type}, supported types: #{SYMBOL_TO_INDEXED_VALUE_TYPE.keys}"
+          )
+        end
+
+        request = Temporalio::Api::OperatorService::V1::AddSearchAttributesRequest.new(
+          search_attributes: attributes.map { |name, type| [name, SYMBOL_TO_INDEXED_VALUE_TYPE[type]] }.to_h
+        )
+        begin
+          operator_client.add_search_attributes(request)
+        rescue ::GRPC::AlreadyExists => e
+          raise Temporal::SearchAttributeAlreadyExistsFailure.new(e)
+        rescue ::GRPC::Internal => e
+          # The internal workflow that adds search attributes can fail for a variety of reasons such
+          # as recreating a removed attribute with a new type. Wrap these all up into a fall through
+          # exception.
+          raise Temporal::SearchAttributeFailure.new(e)
+        end
+      end
+
+      def list_custom_search_attributes
+        request = Temporalio::Api::OperatorService::V1::ListSearchAttributesRequest.new
+        response = operator_client.list_search_attributes(request)
+        response.custom_attributes.map { |name, type| [name, INDEXED_VALUE_TYPE_TO_SYMBOL[type]] }.to_h
+      end
+
+      def remove_custom_search_attributes(attribute_names)
+        request = Temporalio::Api::OperatorService::V1::RemoveSearchAttributesRequest.new(
+          search_attributes: attribute_names
+        )
+        begin
+          operator_client.remove_search_attributes(request)
+        rescue ::GRPC::NotFound => e
+          raise Temporal::NotFoundFailure.new(e)
+        end
       end
 
       def reset_sticky_task_queue
@@ -556,7 +611,15 @@ module Temporal
         @client ||= Temporalio::Api::WorkflowService::V1::WorkflowService::Stub.new(
           url,
           credentials,
-          timeout: 60
+          timeout: CONNECTION_TIMEOUT_SECONDS
+        )
+      end
+
+      def operator_client
+        @operator_client ||= Temporalio::Api::OperatorService::V1::OperatorService::Stub.new(
+          url,
+          credentials,
+          timeout: CONNECTION_TIMEOUT_SECONDS
         )
       end
 

--- a/lib/temporal/errors.rb
+++ b/lib/temporal/errors.rb
@@ -78,4 +78,8 @@ module Temporal
   class CancellationAlreadyRequestedFailure < ApiError; end
   class QueryFailed < ApiError; end
   class UnexpectedResponse < ApiError; end
+
+  class SearchAttributeAlreadyExistsFailure < ApiError; end
+  class SearchAttributeFailure < ApiError; end
+  class InvalidSearchAttributeTypeFailure < ClientError; end
 end

--- a/spec/unit/lib/temporal/client_spec.rb
+++ b/spec/unit/lib/temporal/client_spec.rb
@@ -787,6 +787,47 @@ describe Temporal::Client do
     end
   end
 
+  describe '#add_custom_search_attributes' do
+    before { allow(connection).to receive(:add_custom_search_attributes) }
+
+    let(:attributes) { { SomeTextField: :text, SomeIntField: :int } }
+
+    it 'passes through to connection' do
+      subject.add_custom_search_attributes(attributes)
+
+      expect(connection)
+        .to have_received(:add_custom_search_attributes)
+        .with(attributes)
+    end
+  end
+
+  describe '#list_custom_search_attributes' do
+    let(:attributes) { { 'SomeIntField' => :int, 'SomeBoolField' => :bool } }
+
+    before { allow(connection).to receive(:list_custom_search_attributes).and_return(attributes) }
+
+    it 'passes through to connection' do
+      response = subject.list_custom_search_attributes
+
+      expect(response).to eq(attributes)
+
+      expect(connection)
+        .to have_received(:list_custom_search_attributes)
+    end
+  end
+
+  describe '#remove_custom_search_attributes' do
+    before { allow(connection).to receive(:remove_custom_search_attributes) }
+
+    it 'passes through to connection' do
+      subject.remove_custom_search_attributes(:SomeTextField, :SomeIntField)
+
+      expect(connection)
+        .to have_received(:remove_custom_search_attributes)
+        .with(%i[SomeTextField SomeIntField])
+    end
+  end
+
   describe '#list_open_workflow_executions' do
     let(:from) { Time.now - 600 }
     let(:now) { Time.now }
@@ -931,7 +972,6 @@ describe Temporal::Client do
           .to have_received(:list_open_workflow_executions)
           .with(namespace: namespace, from: from, to: now, next_page_token: 'a', max_page_size: 10)
           .once
-
       end
     end
 


### PR DESCRIPTION
### Summary

Adds add, list, and remove APIs for custom search attributes. Since these operations live on the OperatorService in the GRPC contract, a client for this has also been introduced into `grpc.rb`.

### Testing

New unit specs at client and GRPC connection level:
```
bundle exec rspec spec/unit/lib/temporal/client_spec.rb:790:804:819
bundle exec rspec spec/unit/lib/temporal/grpc_spec.rb:649:733:789
```

New example specs:
```
bundle exec rspec spec/integration/search_attributes_spec.rb
```