### PR TITLE
Terminate-if-running workflow ID reuse policy

### DIFF
--- a/lib/temporal/connection/serializer/workflow_id_reuse_policy.rb
+++ b/lib/temporal/connection/serializer/workflow_id_reuse_policy.rb
@@ -8,7 +8,8 @@ module Temporal
         WORKFLOW_ID_REUSE_POLICY = {
           allow_failed: Temporalio::Api::Enums::V1::WorkflowIdReusePolicy::WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
           allow: Temporalio::Api::Enums::V1::WorkflowIdReusePolicy::WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
-          reject: Temporalio::Api::Enums::V1::WorkflowIdReusePolicy::WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE
+          reject: Temporalio::Api::Enums::V1::WorkflowIdReusePolicy::WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE,
+          terminate_if_running: Temporalio::Api::Enums::V1::WorkflowIdReusePolicy::WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING
         }.freeze
 
         def to_proto

--- a/spec/unit/lib/temporal/connection/serializer/workflow_id_reuse_policy_spec.rb
+++ b/spec/unit/lib/temporal/connection/serializer/workflow_id_reuse_policy_spec.rb
@@ -6,7 +6,8 @@ describe Temporal::Connection::Serializer::WorkflowIdReusePolicy do
     SYM_TO_PROTO = {
       allow_failed: Temporalio::Api::Enums::V1::WorkflowIdReusePolicy::WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
       allow: Temporalio::Api::Enums::V1::WorkflowIdReusePolicy::WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
-      reject: Temporalio::Api::Enums::V1::WorkflowIdReusePolicy::WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE
+      reject: Temporalio::Api::Enums::V1::WorkflowIdReusePolicy::WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE,
+      terminate_if_running: Temporalio::Api::Enums::V1::WorkflowIdReusePolicy::WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING
     }.freeze
 
     def self.test_valid_policy(policy_sym)
@@ -20,6 +21,7 @@ describe Temporal::Connection::Serializer::WorkflowIdReusePolicy do
     test_valid_policy(:allow)
     test_valid_policy(:allow_failed)
     test_valid_policy(:reject)
+    test_valid_policy(:terminate_if_running)
 
     it "rejects invalid policies" do
       expect do


### PR DESCRIPTION
### Summary

This new workflow ID reuse policy was added with the updated protobuf in #217. While the underlying GRPC connection layer already supports this with that updated proto, this change adds mapping code and tests for actually using it in temporal-ruby.

### Testing

New unit spec for mapper:
```
bundle exec rpsec spec/unit/lib/temporal/connection/serializer/workflow_id_reuse_policy_spec.rb
```

New example spec:
```
pushd examples
bin/worker # in separate terminal
bundle exec rspecspec/integration/start_workflow_spec.rb:73
popd
```