### PR TITLE
Drewhoskins schedule public

### DIFF
--- a/examples/bin/worker
+++ b/examples/bin/worker
@@ -67,6 +67,7 @@ worker.register_workflow(UpsertSearchAttributesWorkflow)
 worker.register_workflow(WaitForWorkflow)
 worker.register_workflow(WaitForExternalSignalWorkflow)
 worker.register_workflow(WaitForNamedSignalWorkflow)
+worker.register_dynamic_workflow(DelegatorWorkflow)
 
 worker.register_activity(AsyncActivity)
 worker.register_activity(EchoActivity)

--- a/examples/spec/integration/dynamic_workflow_spec.rb
+++ b/examples/spec/integration/dynamic_workflow_spec.rb
@@ -1,0 +1,37 @@
+require 'workflows/delegator_workflow'
+
+describe 'Dynamic workflows' do
+  let(:workflow_id) { SecureRandom.uuid }
+
+  it 'can delegate to other classes' do
+    # PlusExecutor and TimesExecutor do not subclass Workflow
+    run_id = Temporal.start_workflow(
+      PlusExecutor,
+      {a: 5, b: 3},
+      options: {
+        workflow_id: workflow_id
+      })
+
+    result = Temporal.await_workflow_result(
+      PlusExecutor,
+      workflow_id: workflow_id,
+      run_id: run_id,
+    )
+    expect(result[:computation]).to eq(8)
+
+    run_id = Temporal.start_workflow(
+      TimesExecutor,
+      {a: 5, b: 3},
+      options: {
+        workflow_id: workflow_id
+      })
+
+    result = Temporal.await_workflow_result(
+      TimesExecutor,
+      workflow_id: workflow_id,
+      run_id: run_id,
+    )
+    expect(result[:computation]).to eq(15)
+
+  end
+end

--- a/examples/workflows/delegator_workflow.rb
+++ b/examples/workflows/delegator_workflow.rb
@@ -25,7 +25,6 @@ end
 # Calls into our other class hierarchy.
 class DelegatorWorkflow < Temporal::Workflow
   def execute(input)
-    puts(workflow.name.to_s)
     executor = Object.const_get(workflow.name).new
     raise ArgumentError, "Unknown workflow: #{executor.class}" unless executor.is_a?(MyWorkflowExecutor)
 

--- a/examples/workflows/delegator_workflow.rb
+++ b/examples/workflows/delegator_workflow.rb
@@ -1,0 +1,34 @@
+# This sample illustrates using a dynamic Activity to delegate to another set of non-activity
+# classes.  This is an advanced use case, used, for example, for integrating with an existing framework
+# that doesn't know about temporal.
+# See Temporal::Worker#register_dynamic_activity for more info.
+
+# An example of another non-Activity class hierarchy.
+class MyWorkflowExecutor
+  def do_it(_args)
+    raise NotImplementedError
+  end
+end
+
+class PlusExecutor < MyWorkflowExecutor
+  def do_it(args)
+    args[:a] + args[:b]
+  end
+end
+
+class TimesExecutor < MyWorkflowExecutor
+  def do_it(args)
+    args[:a] * args[:b]
+  end
+end
+
+# Calls into our other class hierarchy.
+class DelegatorWorkflow < Temporal::Workflow
+  def execute(input)
+    puts(workflow.name.to_s)
+    executor = Object.const_get(workflow.name).new
+    raise ArgumentError, "Unknown workflow: #{executor.class}" unless executor.is_a?(MyWorkflowExecutor)
+
+    {computation: executor.do_it(input)}
+  end
+end

--- a/lib/temporal/errors.rb
+++ b/lib/temporal/errors.rb
@@ -33,6 +33,7 @@ module Temporal
   class ActivityNotRegistered < ClientError; end
   class WorkflowNotRegistered < ClientError; end
   class SecondDynamicActivityError < ClientError; end
+  class SecondDynamicWorkflowError < ClientError; end
 
   class ApiError < Error; end
 

--- a/lib/temporal/worker.rb
+++ b/lib/temporal/worker.rb
@@ -43,23 +43,39 @@ module Temporal
     end
 
     def register_workflow(workflow_class, options = {})
-      execution_options = ExecutionOptions.new(workflow_class, options, config.default_execution_options)
-      key = [execution_options.namespace, execution_options.task_queue]
+      key, execution_options = executable_registration(workflow_class, options)
 
       @workflows[key].add(execution_options.name, workflow_class)
     end
 
+    # Register one special workflow that you want to intercept any unknown workflows,
+    # perhaps so you can delegate work to other classes, somewhat analogous to ruby's method_missing.
+    # Only one dynamic Workflow may be registered per task queue.
+    # Within Workflow#execute, you may retrieve the name of the unknown class via workflow.name.
+    def register_dynamic_workflow(workflow_class, options = {})
+      key, execution_options = executable_registration(workflow_class, options)
+
+      begin
+        @workflows[key].add_dynamic(execution_options.name, workflow_class)
+      rescue Temporal::ExecutableLookup::SecondDynamicExecutableError => e
+        raise Temporal::SecondDynamicWorkflowError,
+          "Temporal::Worker#register_dynamic_workflow: cannot register #{execution_options.name} "\
+          "dynamically; #{e.previous_executable_name} was already registered dynamically for task queue "\
+          "'#{execution_options.task_queue}', and there can be only one."
+      end
+    end
+
     def register_activity(activity_class, options = {})
-      key, execution_options = activity_registration(activity_class, options)
+      key, execution_options = executable_registration(activity_class, options)
       @activities[key].add(execution_options.name, activity_class)
     end
 
-    # Register one special activity that you want to intercept any unknown Activities,
+    # Register one special activity that you want to intercept any unknown activities,
     # perhaps so you can delegate work to other classes, somewhat analogous to ruby's method_missing.
     # Only one dynamic Activity may be registered per task queue.
     # Within Activity#execute, you may retrieve the name of the unknown class via activity.name.
     def register_dynamic_activity(activity_class, options = {})
-      key, execution_options = activity_registration(activity_class, options)
+      key, execution_options = executable_registration(activity_class, options)
       begin
         @activities[key].add_dynamic(execution_options.name, activity_class)
       rescue Temporal::ExecutableLookup::SecondDynamicExecutableError => e
@@ -126,8 +142,8 @@ module Temporal
       Activity::Poller.new(namespace, task_queue, lookup.freeze, config, activity_middleware, activity_poller_options)
     end
 
-    def activity_registration(activity_class, options)
-      execution_options = ExecutionOptions.new(activity_class, options, config.default_execution_options)
+    def executable_registration(executable_class, options)
+      execution_options = ExecutionOptions.new(executable_class, options, config.default_execution_options)
       key = [execution_options.namespace, execution_options.task_queue]
       [key, execution_options]
     end

--- a/lib/temporal/worker.rb
+++ b/lib/temporal/worker.rb
@@ -43,9 +43,9 @@ module Temporal
     end
 
     def register_workflow(workflow_class, options = {})
-      key, execution_options = executable_registration(workflow_class, options)
+      namespace_and_task_queue, execution_options = executable_registration(workflow_class, options)
 
-      @workflows[key].add(execution_options.name, workflow_class)
+      @workflows[namespace_and_task_queue].add(execution_options.name, workflow_class)
     end
 
     # Register one special workflow that you want to intercept any unknown workflows,
@@ -53,10 +53,10 @@ module Temporal
     # Only one dynamic Workflow may be registered per task queue.
     # Within Workflow#execute, you may retrieve the name of the unknown class via workflow.name.
     def register_dynamic_workflow(workflow_class, options = {})
-      key, execution_options = executable_registration(workflow_class, options)
+      namespace_and_task_queue, execution_options = executable_registration(workflow_class, options)
 
       begin
-        @workflows[key].add_dynamic(execution_options.name, workflow_class)
+        @workflows[namespace_and_task_queue].add_dynamic(execution_options.name, workflow_class)
       rescue Temporal::ExecutableLookup::SecondDynamicExecutableError => e
         raise Temporal::SecondDynamicWorkflowError,
           "Temporal::Worker#register_dynamic_workflow: cannot register #{execution_options.name} "\
@@ -66,8 +66,8 @@ module Temporal
     end
 
     def register_activity(activity_class, options = {})
-      key, execution_options = executable_registration(activity_class, options)
-      @activities[key].add(execution_options.name, activity_class)
+      namespace_and_task_queue, execution_options = executable_registration(activity_class, options)
+      @activities[namespace_and_task_queue].add(execution_options.name, activity_class)
     end
 
     # Register one special activity that you want to intercept any unknown activities,
@@ -75,9 +75,9 @@ module Temporal
     # Only one dynamic Activity may be registered per task queue.
     # Within Activity#execute, you may retrieve the name of the unknown class via activity.name.
     def register_dynamic_activity(activity_class, options = {})
-      key, execution_options = executable_registration(activity_class, options)
+      namespace_and_task_queue, execution_options = executable_registration(activity_class, options)
       begin
-        @activities[key].add_dynamic(execution_options.name, activity_class)
+        @activities[namespace_and_task_queue].add_dynamic(execution_options.name, activity_class)
       rescue Temporal::ExecutableLookup::SecondDynamicExecutableError => e
         raise Temporal::SecondDynamicActivityError,
           "Temporal::Worker#register_dynamic_activity: cannot register #{execution_options.name} "\

--- a/lib/temporal/workflow/context.rb
+++ b/lib/temporal/workflow/context.rb
@@ -212,6 +212,10 @@ module Temporal
         future
       end
 
+      def name
+        @metadata.name
+      end
+
       def cancel_timer(timer_id)
         command = Command::CancelTimer.new(timer_id: timer_id)
         schedule_command(command)

--- a/spec/unit/lib/temporal/workflow/context_spec.rb
+++ b/spec/unit/lib/temporal/workflow/context_spec.rb
@@ -4,6 +4,7 @@ require 'temporal/workflow/dispatcher'
 require 'temporal/workflow/future'
 require 'temporal/workflow/query_registry'
 require 'temporal/workflow/stack_trace_tracker'
+require 'temporal/metadata/workflow'
 require 'time'
 
 class MyTestWorkflow < Temporal::Workflow; end
@@ -16,7 +17,9 @@ describe Temporal::Workflow::Context do
     allow(double).to receive(:register)
     double
   end
-  let(:metadata) { instance_double('Temporal::Metadata::Workflow') }
+  let(:metadata_hash) { Fabricate(:workflow_metadata).to_h }
+  let(:metadata) { Temporal::Metadata::Workflow.new(**metadata_hash) }
+
   let(:workflow_context) do
     Temporal::Workflow::Context.new(
       state_manager,
@@ -244,6 +247,13 @@ describe Temporal::Workflow::Context do
       expect(
         workflow_context.upsert_search_attributes({'CustomDatetimeField' => time})
       ).to eq({ 'CustomDatetimeField' => time.utc.iso8601 })
+    end
+  end
+
+  describe '#name' do
+    it 'returns the name from the metadata' do
+      # Set in the :workflow_metadata Fabricator
+      expect(workflow_context.name).to eq("TestWorkflow")
     end
   end
 


### PR DESCRIPTION
# Description

Emulates the [DynamicWorkflow](https://github.com/temporalio/sdk-java/blob/master/temporal-sdk/src/main/java/io/temporal/workflow/DynamicWorkflow.java) concept in the Java SDK.

This will allow folks to provide workflow implementations on classes that are not Workflows, an important extensibility mechanism. In particular, you can name your workflow whatever you want, so it will show up properly in Amp.

Using an identical technique to what we used for the [DynamicActivity PR](https://github.com/coinbase/temporal-ruby/pull/208).

# Test plan

New unit test: 
```
rspec spec/unit/lib/temporal/worker_spec.rb
```

New integration test:
```
# Console 1:
cd examples
./bin/worker
# Console 2:
rspec ./spec/integration/dynamic_workflow_spec.rb
```
