### PR TITLE
Read search attributes from inside workflow code

### DIFF
--- a/examples/spec/integration/initial_search_attributes_spec.rb
+++ b/examples/spec/integration/initial_search_attributes_spec.rb
@@ -40,13 +40,12 @@ describe 'starting workflow with initial search attributes', :integration do
     )
 
     # UpsertSearchAttributesWorkflow returns the search attributes it upserted during its execution
-    added_attributes = Temporal.await_workflow_result(
+    attributes_at_end = Temporal.await_workflow_result(
       UpsertSearchAttributesWorkflow,
       workflow_id: workflow_id,
       run_id: run_id,
     )
-    expect(added_attributes[:from_code]).to eq(upserted_search_attributes)
-    expect(added_attributes[:from_context]).to eq(expected_custom_attributes)
+    expect(attributes_at_end).to eq(expected_custom_attributes)
 
     # These attributes are set for the worker in bin/worker
     expected_attributes = {

--- a/examples/spec/integration/initial_search_attributes_spec.rb
+++ b/examples/spec/integration/initial_search_attributes_spec.rb
@@ -45,7 +45,8 @@ describe 'starting workflow with initial search attributes', :integration do
       workflow_id: workflow_id,
       run_id: run_id,
     )
-    expect(added_attributes).to eq(upserted_search_attributes)
+    expect(added_attributes[:from_code]).to eq(upserted_search_attributes)
+    expect(added_attributes[:from_context]).to eq(expected_custom_attributes)
 
     # These attributes are set for the worker in bin/worker
     expected_attributes = {

--- a/examples/spec/integration/upsert_search_attributes_spec.rb
+++ b/examples/spec/integration/upsert_search_attributes_spec.rb
@@ -31,8 +31,7 @@ describe 'Temporal::Workflow::Context.upsert_search_attributes', :integration do
       workflow_id: workflow_id,
       run_id: run_id,
     )
-    expect(added_attributes[:from_code]).to eq(expected_added_attributes)
-    expect(added_attributes[:from_context]).to eq(expected_added_attributes)
+    expect(added_attributes).to eq(expected_added_attributes)
 
     # These attributes are set for the worker in bin/worker
     expected_attributes = {

--- a/examples/spec/integration/upsert_search_attributes_spec.rb
+++ b/examples/spec/integration/upsert_search_attributes_spec.rb
@@ -31,7 +31,8 @@ describe 'Temporal::Workflow::Context.upsert_search_attributes', :integration do
       workflow_id: workflow_id,
       run_id: run_id,
     )
-    expect(added_attributes).to eq(expected_added_attributes)
+    expect(added_attributes[:from_code]).to eq(expected_added_attributes)
+    expect(added_attributes[:from_context]).to eq(expected_added_attributes)
 
     # These attributes are set for the worker in bin/worker
     expected_attributes = {

--- a/examples/workflows/upsert_search_attributes_workflow.rb
+++ b/examples/workflows/upsert_search_attributes_workflow.rb
@@ -24,6 +24,9 @@ class UpsertSearchAttributesWorkflow < Temporal::Workflow
     workflow.wait_for_all(future)
 
     HelloWorldActivity.execute!(name)
-    attributes
+    {
+      from_code: attributes,
+      from_context: workflow.search_attributes
+    }
   end
 end

--- a/examples/workflows/upsert_search_attributes_workflow.rb
+++ b/examples/workflows/upsert_search_attributes_workflow.rb
@@ -16,6 +16,10 @@ class UpsertSearchAttributesWorkflow < Temporal::Workflow
     }
     attributes.compact!
     workflow.upsert_search_attributes(attributes)
+    # .dup because the same backing hash may be used throughout the workflow, causing
+    # the equality check at the end to succeed incorrectly
+    attributes_after_upsert = workflow.search_attributes.dup
+
     # The following lines are extra complexity to test if upsert_search_attributes is tracked properly in the internal
     # state machine.
     future = HelloWorldActivity.execute("Moon")
@@ -24,9 +28,12 @@ class UpsertSearchAttributesWorkflow < Temporal::Workflow
     workflow.wait_for_all(future)
 
     HelloWorldActivity.execute!(name)
-    {
-      from_code: attributes,
-      from_context: workflow.search_attributes
-    }
+
+    attributes_at_end = workflow.search_attributes
+    if attributes_at_end != attributes_after_upsert
+      raise "Attributes at end #{attributes_at_end} don't match after upsert #{attributes_after_upsert}"
+    end
+
+    attributes_at_end
   end
 end

--- a/lib/temporal/workflow/context.rb
+++ b/lib/temporal/workflow/context.rb
@@ -55,6 +55,10 @@ module Temporal
         metadata.headers
       end
 
+      def search_attributes
+        state_manager.search_attributes
+      end
+
       def has_release?(release_name)
         state_manager.release?(release_name.to_s)
       end
@@ -256,7 +260,7 @@ module Temporal
           retry_policy: execution_options.retry_policy,
           headers: execution_options.headers,
           memo: execution_options.memo,
-          search_attributes: Helpers.process_search_attributes(execution_options.search_attributes),
+          search_attributes: Helpers.process_search_attributes(execution_options.search_attributes)
         )
         schedule_command(command)
         completed!

--- a/lib/temporal/workflow/context.rb
+++ b/lib/temporal/workflow/context.rb
@@ -423,8 +423,18 @@ module Temporal
       end
 
       # Replaces or adds the values of your custom search attributes specified during a workflow's execution.
-      # To use this your server must support Elasticsearch, and the attributes must be pre-configured
+      # To use this your server must enable advanced visibility using SQL starting with version 1.20 or
+      # Elasticsearch on all versions. The attributes must be pre-configured.
       # See https://docs.temporal.io/docs/concepts/what-is-a-search-attribute/
+      #
+      # Do be aware that non-deterministic upserting of search attributes can lead to "phantom"
+      # attributes that are available in code but not on Temporal server. For example, if your code
+      # upserted {"foo" => 1} then changed to upsert {"bar" => 2} without proper versioning, you
+      # will see {"foo" => 1, "bar" => 2} in search attributes in workflow code even though
+      # {"bar" => 2} was never upserted on Temporal server. When the same search attribute
+      # name is used with a different value, you will see a similar case where the new value will
+      # be present until the end of the history window, then change to the old version after that. This
+      # does at least match the "old" value that will be present on the server.
       #
       # @param search_attributes [Hash]
       #   If an attribute is registered as a Datetime, you can pass in a Time: e.g.

--- a/lib/temporal/workflow/context.rb
+++ b/lib/temporal/workflow/context.rb
@@ -55,6 +55,9 @@ module Temporal
         metadata.headers
       end
 
+      # Retrieves a hash of all current search attributes on this workflow run. Attributes
+      # can be set in a workflow by calling upsert_search_attributes or when starting a
+      # workflow by specifying the search_attributes option.
       def search_attributes
         state_manager.search_attributes
       end

--- a/lib/temporal/workflow/state_manager.rb
+++ b/lib/temporal/workflow/state_manager.rb
@@ -295,7 +295,7 @@ module Temporal
           dispatch(history_target, 'completed')
 
         when 'UPSERT_WORKFLOW_SEARCH_ATTRIBUTES'
-          search_attributes.merge!(from_payload_map(event.attributes.search_attributes&.indexed_fields))
+          search_attributes.merge!(from_payload_map(event.attributes.search_attributes&.indexed_fields || {}))
           # no need to track state; this is just a synchronous API call.
           discard_command(history_target)
 

--- a/lib/temporal/workflow/state_manager.rb
+++ b/lib/temporal/workflow/state_manager.rb
@@ -53,6 +53,11 @@ module Temporal
             command.workflow_id ||= command_id
           when Command::StartTimer
             command.timer_id ||= command_id
+          when Command::UpsertSearchAttributes
+            # This allows newly upserted search attributes to be read
+            # immediately. Without this, attributes would not be available
+            # until the next history window is applied on replay.
+            search_attributes.merge!(command.search_attributes)
           end
 
         state_machine = command_tracker[command_id]

--- a/spec/fabricators/grpc/history_event_fabricator.rb
+++ b/spec/fabricators/grpc/history_event_fabricator.rb
@@ -31,6 +31,11 @@ Fabricator(:api_workflow_execution_started_event, from: :api_history_event) do
       retry_policy: nil,
       attempt: 0,
       header: header,
+      search_attributes: Temporalio::Api::Common::V1::SearchAttributes.new(
+        indexed_fields: {
+          'CustomIntAttribute' => Temporal.configuration.converter.to_payload(42)
+        }
+      )
     )
   end
 end
@@ -177,6 +182,20 @@ Fabricator(:api_timer_canceled_event, from: :api_history_event) do
       started_event_id: attrs[:event_id] - 4,
       workflow_task_completed_event_id: attrs[:event_id] - 1,
       identity: 'test-worker@test-host'
+    )
+  end
+end
+
+Fabricator(:api_upsert_search_attributes_event, from: :api_history_event) do
+  event_type { Temporalio::Api::Enums::V1::EventType::EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES }
+  upsert_workflow_search_attributes_event_attributes do |attrs|
+    Temporalio::Api::History::V1::UpsertWorkflowSearchAttributesEventAttributes.new(
+      workflow_task_completed_event_id: attrs[:event_id] - 1,
+      search_attributes: Temporalio::Api::Common::V1::SearchAttributes.new(
+        indexed_fields: {
+          'CustomStringAttribute' => Temporal.configuration.converter.to_payload('foo')
+        }
+      )
     )
   end
 end

--- a/spec/fabricators/grpc/history_event_fabricator.rb
+++ b/spec/fabricators/grpc/history_event_fabricator.rb
@@ -1,8 +1,11 @@
 require 'securerandom'
+require 'temporal/concerns/payloads'
 
 class TestSerializer
   extend Temporal::Concerns::Payloads
 end
+
+include Temporal::Concerns::Payloads
 
 Fabricator(:api_history_event, from: Temporalio::Api::History::V1::HistoryEvent) do
   event_id { 1 }
@@ -10,14 +13,13 @@ Fabricator(:api_history_event, from: Temporalio::Api::History::V1::HistoryEvent)
 end
 
 Fabricator(:api_workflow_execution_started_event, from: :api_history_event) do
-  transient :headers
+  transient :headers, :search_attributes
   event_type { Temporalio::Api::Enums::V1::EventType::EVENT_TYPE_WORKFLOW_EXECUTION_STARTED }
   event_time { Time.now }
   workflow_execution_started_event_attributes do |attrs|
-    header_fields = (attrs[:headers] || {}).each_with_object({}) do |(field, value), h|
-      h[field] = Temporal.configuration.converter.to_payload(value)
-    end
+    header_fields = to_payload_map(attrs[:headers] || {})
     header = Temporalio::Api::Common::V1::Header.new(fields: header_fields)
+    indexed_fields = attrs[:search_attributes] ? to_payload_map(attrs[:search_attributes]) : nil
 
     Temporalio::Api::History::V1::WorkflowExecutionStartedEventAttributes.new(
       workflow_type: Fabricate(:api_workflow_type),
@@ -32,9 +34,7 @@ Fabricator(:api_workflow_execution_started_event, from: :api_history_event) do
       attempt: 0,
       header: header,
       search_attributes: Temporalio::Api::Common::V1::SearchAttributes.new(
-        indexed_fields: {
-          'CustomIntAttribute' => Temporal.configuration.converter.to_payload(42)
-        }
+        indexed_fields: indexed_fields
       )
     )
   end
@@ -187,14 +187,14 @@ Fabricator(:api_timer_canceled_event, from: :api_history_event) do
 end
 
 Fabricator(:api_upsert_search_attributes_event, from: :api_history_event) do
+  transient :search_attributes
   event_type { Temporalio::Api::Enums::V1::EventType::EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES }
   upsert_workflow_search_attributes_event_attributes do |attrs|
+    indexed_fields = attrs[:search_attributes] ? to_payload_map(attrs[:search_attributes]) : nil
     Temporalio::Api::History::V1::UpsertWorkflowSearchAttributesEventAttributes.new(
       workflow_task_completed_event_id: attrs[:event_id] - 1,
       search_attributes: Temporalio::Api::Common::V1::SearchAttributes.new(
-        indexed_fields: {
-          'CustomStringAttribute' => Temporal.configuration.converter.to_payload('foo')
-        }
+        indexed_fields: indexed_fields
       )
     )
   end

--- a/spec/unit/lib/temporal/workflow/context_spec.rb
+++ b/spec/unit/lib/temporal/workflow/context_spec.rb
@@ -248,6 +248,12 @@ describe Temporal::Workflow::Context do
         workflow_context.upsert_search_attributes({'CustomDatetimeField' => time})
       ).to eq({ 'CustomDatetimeField' => time.utc.iso8601 })
     end
+
+    it 'gets latest search attributes from state_manager' do
+      search_attributes = { 'CustomIntField' => 42 }
+      expect(state_manager).to receive(:search_attributes).and_return(search_attributes)
+      expect(workflow_context.search_attributes).to eq(search_attributes)
+    end
   end
 
   describe '#name' do

--- a/spec/unit/lib/temporal/workflow/state_manager_spec.rb
+++ b/spec/unit/lib/temporal/workflow/state_manager_spec.rb
@@ -1,5 +1,7 @@
 require 'temporal/workflow'
 require 'temporal/workflow/dispatcher'
+require 'temporal/workflow/history/event'
+require 'temporal/workflow/history/window'
 require 'temporal/workflow/state_manager'
 require 'temporal/errors'
 
@@ -34,6 +36,32 @@ describe Temporal::Workflow::StateManager do
           state_manager.schedule(next_command)
         end.to raise_error(Temporal::WorkflowAlreadyCompletingError)
       end
+    end
+  end
+
+  describe '#search_attributes' do
+    let(:start_workflow_execution_event) { Fabricate(:api_workflow_execution_started_event) }
+    let(:upsert_search_attribute_event) { Fabricate(:api_upsert_search_attributes_event) }
+
+    it 'initial merges with upserted' do
+      state_manager = described_class.new(Temporal::Workflow::Dispatcher.new)
+
+      window = Temporal::Workflow::History::Window.new
+      window.add(Temporal::Workflow::History::Event.new(start_workflow_execution_event))
+      window.add(Temporal::Workflow::History::Event.new(upsert_search_attribute_event))
+
+      command = Temporal::Workflow::Command::UpsertSearchAttributes.new
+      # No arguments because the arguments do not need to match
+
+      state_manager.schedule(command)
+      state_manager.apply(window)
+
+      expect(state_manager.search_attributes).to eq(
+        {
+          'CustomIntAttribute' => 42, # from initial
+          'CustomStringAttribute' => 'foo' # from upsert
+        }
+      )
     end
   end
 end


### PR DESCRIPTION
### Summary

Adds the ability to use `workflow.search_attributes` to read all current search attributes in workflow code

### Testing

New specs for state_manager:
```
bundle exec rspec spec/unit/lib/temporal/workflow/state_manager_spec.rb:42
```

Updated example specs for initial and upsert search attributes:
```
cd examples
bundle exec rspec spec/integration/initial_search_attributes_spec.rb spec/integration/upsert_search_attributes_spec.rb
```