### PR TITLE
Send client-name and client-version headers

### DIFF
--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -8,6 +8,7 @@ require 'gen/temporal/api/operatorservice/v1/service_services_pb'
 require 'gen/temporal/api/enums/v1/workflow_pb'
 require 'gen/temporal/api/enums/v1/common_pb'
 require 'temporal/connection/errors'
+require 'temporal/connection/interceptors/client_name_version_interceptor'
 require 'temporal/connection/serializer'
 require 'temporal/connection/serializer/failure'
 require 'temporal/connection/serializer/workflow_id_reuse_policy'
@@ -611,7 +612,8 @@ module Temporal
         @client ||= Temporalio::Api::WorkflowService::V1::WorkflowService::Stub.new(
           url,
           credentials,
-          timeout: CONNECTION_TIMEOUT_SECONDS
+          timeout: CONNECTION_TIMEOUT_SECONDS,
+          interceptors: [ ClientNameVersionInterceptor.new() ]
         )
       end
 
@@ -619,7 +621,8 @@ module Temporal
         @operator_client ||= Temporalio::Api::OperatorService::V1::OperatorService::Stub.new(
           url,
           credentials,
-          timeout: CONNECTION_TIMEOUT_SECONDS
+          timeout: CONNECTION_TIMEOUT_SECONDS,
+          interceptors: [ ClientNameVersionInterceptor.new() ]
         )
       end
 

--- a/lib/temporal/connection/interceptors/client_name_version_interceptor.rb
+++ b/lib/temporal/connection/interceptors/client_name_version_interceptor.rb
@@ -1,0 +1,13 @@
+require 'grpc'
+
+module Temporal
+  module Connection
+    class ClientNameVersionInterceptor < GRPC::ClientInterceptor
+      def request_response(request: nil, call: nil, method: nil, metadata: nil)
+        metadata['client-name'] = 'community-ruby'
+        metadata['client-version'] = Temporal::VERSION
+        yield
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What changed

- Add gRPC headers 'client-name' and 'client-version'
- This SDK will identity itself as `community-ruby`

## Why

- These headers allow Temporal to collect SDK usage metrics. Adding these headers now will help measuring impact and adoption of the current community-supported SDK vs the new Temporal-supported SDK.