### PR TITLE
Don't serialize huge exceptions

### DIFF
--- a/lib/temporal/connection/serializer/failure.rb
+++ b/lib/temporal/connection/serializer/failure.rb
@@ -20,7 +20,8 @@ module Temporal
               Temporal.logger.error(
                 "Could not serialize exception because it's too large, so we are using a fallback that may not "\
                   "deserialize correctly on the client.  First #{@max_bytes} bytes:\n" \
-                "#{details.payloads.first.data[0..@max_bytes - 1]}"
+                "#{details.payloads.first.data[0..@max_bytes - 1]}",
+                {unserializable_error: object.class.name}
               )
               # Fallback to a more conservative serialization if the payload is too big to avoid
               # sending a huge amount of data to temporal and putting it in the history.

--- a/lib/temporal/connection/serializer/failure.rb
+++ b/lib/temporal/connection/serializer/failure.rb
@@ -7,17 +7,28 @@ module Temporal
       class Failure < Base
         include Concerns::Payloads
 
-        def initialize(error, serialize_whole_error: false)
+        def initialize(error, serialize_whole_error: false, max_bytes: 200_000)
           @serialize_whole_error = serialize_whole_error
+          @max_bytes = max_bytes
           super(error)
         end
 
         def to_proto
-          details = if @serialize_whole_error
-                      to_details_payloads(object)
-                    else
-                      to_details_payloads(object.message)
-                    end
+          if @serialize_whole_error
+            details = to_details_payloads(object)
+            if details.payloads.first.data.size > @max_bytes
+              Temporal.logger.error(
+                "Could not serialize exception because it's too large, so we are using a fallback that may not "\
+                  "deserialize correctly on the client.  First #{@max_bytes} bytes:\n" \
+                "#{details.payloads.first.data[0..@max_bytes - 1]}"
+              )
+              # Fallback to a more conservative serialization if the payload is too big to avoid
+              # sending a huge amount of data to temporal and putting it in the history.
+              details = to_details_payloads(object.message)
+            end
+          else
+            details = to_details_payloads(object.message)
+          end
           Temporalio::Api::Failure::V1::Failure.new(
             message: object.message,
             stack_trace: stack_trace_from(object.backtrace),

--- a/lib/temporal/workflow/errors.rb
+++ b/lib/temporal/workflow/errors.rb
@@ -38,9 +38,11 @@ module Temporal
             message = "#{exception_class}: #{message}"
             exception = default_exception_class.new(message)
             Temporal.logger.error(
-              "Could not instantiate original error. Defaulting to StandardError. It's likely that your error's " \
-              "initializer takes something more than just one positional argument. If so, make sure the worker running "\
-              "your activities is setting Temporal.configuration.use_error_serialization_v2 to support this.",
+              "Could not instantiate original error. Defaulting to StandardError. Make sure the worker running " \
+              "your activities is setting Temporal.configuration.use_error_serialization_v2. If so, make sure the " \
+              "original error serialized by searching your logs for 'unserializable_error'. If not, you're using "\
+              "legacy serialization, and it's likely that "\
+              "your error's initializer takes something other than exactly one positional argument.",
               {
                 original_error: error_type,
                 serialized_error: details.payloads.first.data,

--- a/spec/unit/lib/temporal/connection/serializer/failure_spec.rb
+++ b/spec/unit/lib/temporal/connection/serializer/failure_spec.rb
@@ -87,7 +87,9 @@ describe Temporal::Connection::Serializer::Failure do
         .to have_received(:error)
         .with(
           "Could not serialize exception because it's too large, so we are using a fallback that may not deserialize "\
-          "correctly on the client.  First #{max_bytes} bytes:\n{\"^o\":\"MyBigError\",\"big_payload\":\"1234567890123456")
+          "correctly on the client.  First #{max_bytes} bytes:\n{\"^o\":\"MyBigError\",\"big_payload\":\"1234567890123456",
+          { unserializable_error: 'MyBigError' }
+        )
 
     end
 

--- a/spec/unit/lib/temporal/connection/serializer/failure_spec.rb
+++ b/spec/unit/lib/temporal/connection/serializer/failure_spec.rb
@@ -41,5 +41,65 @@ describe Temporal::Connection::Serializer::Failure do
       expect(deserialized_error.bad_class).to eq(NaughtyClass)
     end
 
+    class MyBigError < StandardError
+      attr_reader :big_payload
+      def initialize(message)
+        super(message)
+        @big_payload = '123456789012345678901234567890123456789012345678901234567890'
+      end
+    end
+
+
+    it 'deals with too-large serialization using the old path' do
+      e = MyBigError.new('Uh oh!')
+      # Normal serialization path
+      failure_proto = described_class.new(e, serialize_whole_error: true, max_bytes: 1000).to_proto
+      expect(failure_proto.application_failure_info.type).to eq('MyBigError')
+      deserialized_error = TestDeserializer.new.from_details_payloads(failure_proto.application_failure_info.details)
+      expect(deserialized_error).to be_an_instance_of(MyBigError)
+      expect(deserialized_error.big_payload).to eq('123456789012345678901234567890123456789012345678901234567890')
+
+      # Exercise legacy serialization mechanism
+      failure_proto = described_class.new(e, serialize_whole_error: false).to_proto
+      expect(failure_proto.application_failure_info.type).to eq('MyBigError')
+      old_style_deserialized_error = MyBigError.new(TestDeserializer.new.from_details_payloads(failure_proto.application_failure_info.details))
+      expect(old_style_deserialized_error).to be_an_instance_of(MyBigError)
+      expect(old_style_deserialized_error.message).to eq('Uh oh!')
+
+      # If the payload size exceeds the max_bytes, we fallback to the old-style serialization.
+      failure_proto = described_class.new(e, serialize_whole_error: true, max_bytes: 50).to_proto
+      expect(failure_proto.application_failure_info.type).to eq('MyBigError')
+      avoids_truncation_error = MyBigError.new(TestDeserializer.new.from_details_payloads(failure_proto.application_failure_info.details))
+      expect(avoids_truncation_error).to be_an_instance_of(MyBigError)
+      expect(avoids_truncation_error.message).to eq('Uh oh!')
+
+      # Fallback serialization should exactly match legacy serialization
+      expect(avoids_truncation_error).to eq(old_style_deserialized_error)
+    end
+
+    it 'logs a helpful error when the payload is too large' do 
+      e = MyBigError.new('Uh oh!')
+
+      allow(Temporal.logger).to receive(:error)
+      max_bytes = 50
+      described_class.new(e, serialize_whole_error: true, max_bytes: max_bytes).to_proto
+      expect(Temporal.logger)
+        .to have_received(:error)
+        .with(
+          "Could not serialize exception because it's too large, so we are using a fallback that may not deserialize "\
+          "correctly on the client.  First #{max_bytes} bytes:\n{\"^o\":\"MyBigError\",\"big_payload\":\"1234567890123456")
+
+    end
+
+    class MyArglessError < RuntimeError
+      def initialize; end
+    end
+
+    it 'successfully processes an error with no constructor arguments' do 
+      e = MyArglessError.new
+      failure_proto = described_class.new(e, serialize_whole_error: true).to_proto
+      expect(failure_proto.application_failure_info.type).to eq('MyArglessError')
+    end
+
   end
 end

--- a/spec/unit/lib/temporal/workflow/errors_spec.rb
+++ b/spec/unit/lib/temporal/workflow/errors_spec.rb
@@ -101,10 +101,11 @@ describe Temporal::Workflow::Errors do
       expect(Temporal.logger)
         .to have_received(:error)
         .with(
-          'Could not instantiate original error. Defaulting to StandardError. ' \
-          'It\'s likely that your error\'s initializer takes something more than just one positional argument. '\
-          'If so, make sure the worker running your activities is setting '\
-          'Temporal.configuration.use_error_serialization_v2 to support this.',
+          "Could not instantiate original error. Defaulting to StandardError. "\
+          "Make sure the worker running your activities is setting Temporal.configuration.use_error_serialization_v2. "\
+          "If so, make sure the original error serialized by searching your logs for 'unserializable_error'. "\
+          "If not, you're using legacy serialization, and it's likely that "\
+          "your error's initializer takes something other than exactly one positional argument.",
           {
             original_error: "ErrorWithTwoArgs",
             serialized_error: '"An error message"',
@@ -133,10 +134,11 @@ describe Temporal::Workflow::Errors do
       expect(Temporal.logger)
         .to have_received(:error)
         .with(
-          'Could not instantiate original error. Defaulting to StandardError. ' \
-          'It\'s likely that your error\'s initializer takes something more than just one positional argument. '\
-          'If so, make sure the worker running your activities is setting '\
-          'Temporal.configuration.use_error_serialization_v2 to support this.',
+          "Could not instantiate original error. Defaulting to StandardError. "\
+          "Make sure the worker running your activities is setting Temporal.configuration.use_error_serialization_v2. "\
+          "If so, make sure the original error serialized by searching your logs for 'unserializable_error'. "\
+          "If not, you're using legacy serialization, and it's likely that "\
+          "your error's initializer takes something other than exactly one positional argument.",
           {
             original_error: "ErrorThatRaisesInInitialize",
             serialized_error: '"An error message"',


### PR DESCRIPTION
# Description
The rollout of https://github.com/coinbase/temporal-ruby/pull/214 went well, except one customer was trying to serialize a pathological error that went up to 47MB.

This change will prevent that by falling back to the old serialization path in that case.

# Test Plan
New unit tests: 
`rspec spec/unit/lib/temporal/connection/serializer/failure_spec.rb`
`rspec spec/unit/lib/temporal/workflow/errors_spec.rb`

Reworded some error messages, so

Integration tests to check for regressions:
```
# Terminal 1, exercise new path
USE_ERROR_SERIALIZATION_V2=1 ./bin/worker
# Terminal 2, exercise old path
./bin/worker
# Terminal 3
cd examples
rspec ./spec/
```