### PR TITLE
Fix header in example integration test.

### DIFF
--- a/examples/spec/integration/continue_as_new_spec.rb
+++ b/examples/spec/integration/continue_as_new_spec.rb
@@ -8,6 +8,7 @@ describe LoopWorkflow do
     }
     headers = {
         'my-header' => 'bar',
+        'test-header' => 'test',
     }
     run_id = Temporal.start_workflow(
       LoopWorkflow,


### PR DESCRIPTION
Test was not updated in d0f3ad96d20c60736e71b471e5055bbfdfae79af as it should have been when the example header was updated. This fixes that.