### PR TITLE
Heartbeat throttling

### DIFF
--- a/examples/activities/long_running_activity.rb
+++ b/examples/activities/long_running_activity.rb
@@ -3,9 +3,14 @@ class LongRunningActivity < Temporal::Activity
 
   def execute(cycles, interval)
     cycles.times do
-      response = activity.heartbeat
+      # To detect if the activity has been canceled, you can check activity.cancel_requested or
+      # simply heartbeat in which case an ActivityCanceled error will be raised. Cancellation
+      # is only detected through heartbeating, but the setting of this bit can be delayed by
+      # heartbeat throttling which sends the heartbeat on a background thread.
+      activity.logger.info("activity.cancel_requested: #{activity.cancel_requested}")
 
-      if response.cancel_requested
+      activity.heartbeat
+      if activity.cancel_requested
         raise Canceled, 'cancel activity request received'
       end
 

--- a/examples/workflows/long_workflow.rb
+++ b/examples/workflows/long_workflow.rb
@@ -2,7 +2,7 @@ require 'activities/long_running_activity'
 
 class LongWorkflow < Temporal::Workflow
   def execute(cycles = 10, interval = 1)
-    future = LongRunningActivity.execute(cycles, interval)
+    future = LongRunningActivity.execute(cycles, interval, options: { timeouts: { heartbeat: interval * 2 } })
 
     workflow.on_signal do |signal, input|
       logger.warn "Signal received", { signal: signal, input: input }

--- a/lib/temporal/activity/context.rb
+++ b/lib/temporal/activity/context.rb
@@ -17,9 +17,10 @@ module Temporal
         @heartbeat_mutex = Mutex.new
         @async = false
         @cancel_requested = false
+        @last_heartbeat_throttled = false
       end
 
-      attr_reader :heartbeat_check_scheduled, :cancel_requested
+      attr_reader :heartbeat_check_scheduled, :cancel_requested, :last_heartbeat_throttled
 
       def async
         @async = true
@@ -69,10 +70,12 @@ module Temporal
           if heartbeat_check_scheduled.nil?
             send_heartbeat(details)
             @last_heartbeat_details = []
+            @last_heartbeat_throttled = false
             @heartbeat_check_scheduled = schedule_check_heartbeat(heartbeat_throttle_interval)
           else
             logger.debug('Throttling heartbeat for sending later', metadata.to_h)
             @last_heartbeat_details = [details]
+            @last_heartbeat_throttled = true
           end
         end
 

--- a/lib/temporal/activity/context.rb
+++ b/lib/temporal/activity/context.rb
@@ -145,6 +145,8 @@ module Temporal
       end
 
       def schedule_check_heartbeat(delay)
+        return nil if delay <= 0
+
         heartbeat_thread_pool.schedule([metadata.workflow_run_id, metadata.id, metadata.attempt], delay) do
           details = heartbeat_mutex.synchronize do
             @heartbeat_check_scheduled = nil

--- a/lib/temporal/activity/context.rb
+++ b/lib/temporal/activity/context.rb
@@ -117,6 +117,8 @@ module Temporal
       end
 
       def heartbeat_throttle_interval
+        # This is a port of logic in the Go SDK
+        # https://github.com/temporalio/sdk-go/blob/eaa3802876de77500164f80f378559c51d6bb0e2/internal/internal_task_handlers.go#L1990
         interval = if metadata.heartbeat_timeout > 0
           metadata.heartbeat_timeout * 0.8
         else

--- a/lib/temporal/activity/context.rb
+++ b/lib/temporal/activity/context.rb
@@ -7,11 +7,19 @@ require 'temporal/activity/async_token'
 module Temporal
   class Activity
     class Context
-      def initialize(connection, metadata)
+      def initialize(connection, metadata, config, heartbeat_thread_pool)
         @connection = connection
         @metadata = metadata
+        @config = config
+        @heartbeat_thread_pool = heartbeat_thread_pool
+        @last_heartbeat_details = [] # an array to differentiate nil hearbeat from no heartbeat queued
+        @heartbeat_scheduled = nil
+        @heartbeat_mutex = Mutex.new
         @async = false
+        @cancel_requested = false
       end
+
+      attr_reader :heartbeat_scheduled, :cancel_requested
 
       def async
         @async = true
@@ -32,7 +40,45 @@ module Temporal
 
       def heartbeat(details = nil)
         logger.debug('Activity heartbeat', metadata.to_h)
-        connection.record_activity_task_heartbeat(namespace: metadata.namespace, task_token: task_token, details: details)
+        # Heartbeat throttling limits the number of calls made to Temporal server, reducing load on the server
+        # and improving activity performance. The first heartbeat in an activity will always be sent immediately.
+        # After that, a timer is scheduled on a background thread. While this check heartbeat thread is scheduled,
+        # heartbeats will not be directly sent to the server, but rather the value will be saved for later. When
+        # this timer fires and the thread resumes, it will send any heartbeats that came in while waiting, and
+        # begin the process over again.
+        #
+        # The interval is determined by the following criteria:
+        # - if a heartbeat timeout is set, 80% of it
+        # - or if there is no heartbeat timeout set, use the configuration for default_heartbeat_throttle_interval
+        # - any duration is capped by the max_heartbeat_throttle_interval configuration
+        #
+        # Example:
+        # Assume a heartbeat timeout of 10s
+        # Throttle interval will be 8s, below the 60s maximum interval cap
+        # Assume the following timeline:
+        # t = 0, heartbeat, sent, timer scheduled for 8s
+        # t = 1, heartbeat, saved
+        # t = 6, heartbeat, saved
+        # t = 8, timer wakes up, sends the saved heartbeat from t = 6, new timer scheduled for 16s
+        # ... no heartbeats
+        # t = 16, timer wakes up, no saved hearbeat to send, no new timer scheduled
+        # t = 20, heartbeat, sent, timer scheduled for 28s
+        # ...
+
+        heartbeat_mutex.synchronize do
+          if heartbeat_scheduled.nil?
+            send_heartbeat(details)
+            @last_heartbeat_details = []
+            @heartbeat_scheduled = schedule_heartbeat(heartbeat_throttle_interval)
+          else
+            logger.debug('Throttling heartbeat for sending later', metadata.to_h)
+            @last_heartbeat_details = [details]
+          end
+        end
+
+        # Return back the context so that .cancel_requested works similarly to before when the
+        # GRPC response was returned back directly
+        self
       end
 
       def heartbeat_details
@@ -64,10 +110,53 @@ module Temporal
 
       private
 
-      attr_reader :connection, :metadata
+      attr_reader :connection, :metadata, :heartbeat_thread_pool, :config, :heartbeat_mutex, :last_heartbeat_details
 
       def task_token
         metadata.task_token
+      end
+
+      def heartbeat_throttle_interval
+        interval = if metadata.heartbeat_timeout > 0
+          metadata.heartbeat_timeout * 0.8
+        else
+          config.timeouts[:default_heartbeat_throttle_interval]
+        end
+
+        [interval, config.timeouts[:max_heartbeat_throttle_interval]].min
+      end
+
+      def send_heartbeat(details)
+        begin
+          response = connection.record_activity_task_heartbeat(
+            namespace: metadata.namespace,
+            task_token: task_token,
+            details: details)
+          if response.cancel_requested
+            logger.info('Activity has been canceled', metadata.to_h)
+            @cancel_requested = true
+          end
+        rescue => error
+          Temporal::ErrorHandler.handle(error, config, metadata: metadata)
+          raise
+        end
+      end
+
+      def schedule_heartbeat(delay)
+        heartbeat_thread_pool.schedule([metadata.workflow_run_id, metadata.id, metadata.attempt], delay) do
+          details = heartbeat_mutex.synchronize do
+            @heartbeat_scheduled = nil
+            last_heartbeat_details
+          end
+          begin
+            if !details.nil?
+              heartbeat(details.first)
+            end
+          rescue
+            # Can swallow any errors here since this only runs on a background thread. Any error will be
+            # sent to the error handler above in send_heartbeat.
+          end
+        end
       end
     end
   end

--- a/lib/temporal/activity/task_processor.rb
+++ b/lib/temporal/activity/task_processor.rb
@@ -47,8 +47,8 @@ module Temporal
 
         respond_failed(error)
       ensure
-        unless context.heartbeat_scheduled.nil?
-          heartbeat_thread_pool.cancel(context.heartbeat_scheduled)
+        unless context.heartbeat_check_scheduled.nil?
+          heartbeat_thread_pool.cancel(context.heartbeat_check_scheduled)
         end
 
         time_diff_ms = ((Time.now - start_time) * 1000).round

--- a/lib/temporal/activity/task_processor.rb
+++ b/lib/temporal/activity/task_processor.rb
@@ -12,7 +12,7 @@ module Temporal
     class TaskProcessor
       include Concerns::Payloads
 
-      def initialize(task, namespace, activity_lookup, middleware_chain, config)
+      def initialize(task, namespace, activity_lookup, middleware_chain, config, heartbeat_thread_pool)
         @task = task
         @namespace = namespace
         @metadata = Metadata.generate_activity_metadata(task, namespace)
@@ -21,6 +21,7 @@ module Temporal
         @activity_class = activity_lookup.find(activity_name)
         @middleware_chain = middleware_chain
         @config = config
+        @heartbeat_thread_pool = heartbeat_thread_pool
       end
 
       def process
@@ -29,7 +30,7 @@ module Temporal
         Temporal.logger.debug("Processing Activity task", metadata.to_h)
         Temporal.metrics.timing(Temporal::MetricKeys::ACTIVITY_TASK_QUEUE_TIME, queue_time_ms, activity: activity_name, namespace: namespace, workflow: metadata.workflow_name)
 
-        context = Activity::Context.new(connection, metadata)
+        context = Activity::Context.new(connection, metadata, config, heartbeat_thread_pool)
 
         if !activity_class
           raise ActivityNotRegistered, 'Activity is not registered with this worker'
@@ -46,6 +47,10 @@ module Temporal
 
         respond_failed(error)
       ensure
+        unless context.heartbeat_scheduled.nil?
+          heartbeat_thread_pool.cancel(context.heartbeat_scheduled)
+        end
+
         time_diff_ms = ((Time.now - start_time) * 1000).round
         Temporal.metrics.timing(Temporal::MetricKeys::ACTIVITY_TASK_LATENCY, time_diff_ms, activity: activity_name, namespace: namespace, workflow: metadata.workflow_name)
         Temporal.logger.debug("Activity task processed", metadata.to_h.merge(execution_time: time_diff_ms))
@@ -54,7 +59,7 @@ module Temporal
       private
 
       attr_reader :task, :namespace, :task_token, :activity_name, :activity_class,
-      :middleware_chain, :metadata, :config
+      :middleware_chain, :metadata, :config, :heartbeat_thread_pool
 
       def connection
         @connection ||= Temporal::Connection.generate(config.for_connection)

--- a/lib/temporal/configuration.rb
+++ b/lib/temporal/configuration.rb
@@ -15,7 +15,9 @@ module Temporal
     Execution = Struct.new(:namespace, :task_queue, :timeouts, :headers, :search_attributes, keyword_init: true)
 
     attr_reader :timeouts, :error_handlers
-    attr_accessor :connection_type, :converter, :use_error_serialization_v2, :host, :port, :credentials, :identity, :logger, :metrics_adapter, :namespace, :task_queue, :headers, :search_attributes, :header_propagators, :payload_codec
+    attr_accessor :connection_type, :converter, :use_error_serialization_v2, :host, :port, :credentials, :identity,
+                  :logger, :metrics_adapter, :namespace, :task_queue, :headers, :search_attributes, :header_propagators,
+                  :payload_codec
 
     # See https://docs.temporal.io/blog/activity-timeouts/ for general docs.
     # We want an infinite execution timeout for cron schedules and other perpetual workflows.
@@ -32,7 +34,12 @@ module Temporal
       # See       # https://docs.temporal.io/blog/activity-timeouts/#schedule-to-start-timeout
       schedule_to_start: nil,
       start_to_close: 30,     # Time spent processing an activity
-      heartbeat: nil          # Max time between heartbeats (off by default)
+      heartbeat: nil,         # Max time between heartbeats (off by default)
+      # If a heartbeat timeout is specified, 80% of that value will be used for throttling. If not specified, this
+      # value will be used.
+      default_heartbeat_throttle_interval: 30,
+      # Heartbeat throttling interval will always be capped by this value
+      max_heartbeat_throttle_interval: 60
     }.freeze
 
     DEFAULT_HEADERS = {}.freeze

--- a/lib/temporal/configuration.rb
+++ b/lib/temporal/configuration.rb
@@ -36,9 +36,11 @@ module Temporal
       start_to_close: 30,     # Time spent processing an activity
       heartbeat: nil,         # Max time between heartbeats (off by default)
       # If a heartbeat timeout is specified, 80% of that value will be used for throttling. If not specified, this
-      # value will be used.
+      # value will be used. This default comes from the Go SDK.
+      # https://github.com/temporalio/sdk-go/blob/eaa3802876de77500164f80f378559c51d6bb0e2/internal/internal_task_handlers.go#L65
       default_heartbeat_throttle_interval: 30,
-      # Heartbeat throttling interval will always be capped by this value
+      # Heartbeat throttling interval will always be capped by this value. This default comes from the Go SDK.
+      # https://github.com/temporalio/sdk-go/blob/eaa3802876de77500164f80f378559c51d6bb0e2/internal/internal_task_handlers.go#L66
       max_heartbeat_throttle_interval: 60
     }.freeze
 

--- a/lib/temporal/configuration.rb
+++ b/lib/temporal/configuration.rb
@@ -41,6 +41,8 @@ module Temporal
       default_heartbeat_throttle_interval: 30,
       # Heartbeat throttling interval will always be capped by this value. This default comes from the Go SDK.
       # https://github.com/temporalio/sdk-go/blob/eaa3802876de77500164f80f378559c51d6bb0e2/internal/internal_task_handlers.go#L66
+      #
+      # To disable heartbeat throttling, set this timeout to 0.
       max_heartbeat_throttle_interval: 60
     }.freeze
 

--- a/lib/temporal/metadata.rb
+++ b/lib/temporal/metadata.rb
@@ -23,7 +23,8 @@ module Temporal
           headers: from_payload_map(task.header&.fields || {}),
           heartbeat_details: from_details_payloads(task.heartbeat_details),
           scheduled_at: task.scheduled_time.to_time,
-          current_attempt_scheduled_at: task.current_attempt_scheduled_time.to_time
+          current_attempt_scheduled_at: task.current_attempt_scheduled_time.to_time,
+          heartbeat_timeout: task.heartbeat_timeout.seconds
         )
       end
 

--- a/lib/temporal/metadata/activity.rb
+++ b/lib/temporal/metadata/activity.rb
@@ -3,9 +3,9 @@ require 'temporal/metadata/base'
 module Temporal
   module Metadata
     class Activity < Base
-      attr_reader :namespace, :id, :name, :task_token, :attempt, :workflow_run_id, :workflow_id, :workflow_name, :headers, :heartbeat_details, :scheduled_at, :current_attempt_scheduled_at
+      attr_reader :namespace, :id, :name, :task_token, :attempt, :workflow_run_id, :workflow_id, :workflow_name, :headers, :heartbeat_details, :scheduled_at, :current_attempt_scheduled_at, :heartbeat_timeout
 
-      def initialize(namespace:, id:, name:, task_token:, attempt:, workflow_run_id:, workflow_id:, workflow_name:, headers: {}, heartbeat_details:, scheduled_at:, current_attempt_scheduled_at:)
+      def initialize(namespace:, id:, name:, task_token:, attempt:, workflow_run_id:, workflow_id:, workflow_name:, headers: {}, heartbeat_details:, scheduled_at:, current_attempt_scheduled_at:, heartbeat_timeout:)
         @namespace = namespace
         @id = id
         @name = name
@@ -18,6 +18,7 @@ module Temporal
         @heartbeat_details = heartbeat_details
         @scheduled_at = scheduled_at
         @current_attempt_scheduled_at = current_attempt_scheduled_at
+        @heartbeat_timeout = heartbeat_timeout
 
         freeze
       end
@@ -36,7 +37,7 @@ module Temporal
           'activity_name' => name,
           'attempt' => attempt,
           'scheduled_at' => scheduled_at.to_s,
-          'current_attempt_scheduled_at' => current_attempt_scheduled_at.to_s,
+          'current_attempt_scheduled_at' => current_attempt_scheduled_at.to_s
         }
       end
     end

--- a/lib/temporal/scheduled_thread_pool.rb
+++ b/lib/temporal/scheduled_thread_pool.rb
@@ -1,0 +1,111 @@
+require 'temporal/metric_keys'
+
+# This class implements a thread pool for scheduling tasks with a delay.
+# If threads are all occupied when a task is scheduled, it will be queued
+# with the sleep delay adjusted based on the wait time. 
+module Temporal
+  class ScheduledThreadPool
+    attr_reader :size
+
+    ScheduledItem = Struct.new(:id, :job, :fire_at, :canceled, keyword_init: true)
+
+    def initialize(size, metrics_tags)
+      @size = size
+      @metrics_tags = metrics_tags
+      @queue = Queue.new
+      @mutex = Mutex.new
+      @available_threads = size
+      @occupied_threads = {}
+      @pool = Array.new(size) do |_i|
+        Thread.new { poll }
+      end
+    end
+
+    def schedule(id, delay, &block)
+      item = ScheduledItem.new(
+        id: id,
+        job: block,
+        fire_at: Time.now + delay,
+        canceled: false)
+      @mutex.synchronize do
+        @available_threads -= 1
+        @queue << item
+      end
+
+      report_metrics
+
+      item
+    end
+
+    def cancel(item)
+      thread = @mutex.synchronize do
+        @occupied_threads[item.id]
+      end
+
+      item.canceled = true
+      unless thread.nil?
+        thread.raise(CancelError.new)
+      end
+
+      item
+    end
+
+    def shutdown
+      size.times do
+        @mutex.synchronize do
+          @queue << EXIT_SYMBOL
+        end
+      end
+
+      @pool.each(&:join)
+    end
+
+    private
+
+    class CancelError < StandardError; end
+    EXIT_SYMBOL = :exit
+
+    def poll
+      loop do
+        item = @queue.pop
+        if item == EXIT_SYMBOL
+          return
+        end
+
+        begin
+          Thread.handle_interrupt(CancelError => :immediate) do
+            @mutex.synchronize do
+              @occupied_threads[item.id] = Thread.current
+            end
+
+            if !item.canceled
+              delay = item.fire_at - Time.now
+              if delay > 0
+                sleep delay
+              end
+            end
+          end
+
+          # Job call is outside cancel handle interrupt block because the job can't
+          # reliably be stopped once running. It's still in the begin/rescue block
+          # so that it won't be executed if the thread gets canceled.
+          if !item.canceled
+            item.job.call
+          end
+        rescue CancelError
+        end
+
+        @mutex.synchronize do
+          @available_threads += 1
+          @occupied_threads.delete(item.id)
+        end
+
+        report_metrics
+      end
+    end
+
+    def report_metrics
+      Temporal.metrics.gauge(Temporal::MetricKeys::THREAD_POOL_AVAILABLE_THREADS, @available_threads, @metrics_tags)
+    end
+  end
+end

--- a/lib/temporal/testing/local_activity_context.rb
+++ b/lib/temporal/testing/local_activity_context.rb
@@ -6,7 +6,7 @@ module Temporal
   module Testing
     class LocalActivityContext < Activity::Context
       def initialize(metadata)
-        super(nil, metadata)
+        super(nil, metadata, nil, nil)
       end
 
       def heartbeat(details = nil)

--- a/lib/temporal/testing/local_workflow_context.rb
+++ b/lib/temporal/testing/local_workflow_context.rb
@@ -63,6 +63,7 @@ module Temporal
           heartbeat_details: nil,
           scheduled_at: Time.now,
           current_attempt_scheduled_at: Time.now,
+          heartbeat_timeout: 0
         )
         context = LocalActivityContext.new(metadata)
 
@@ -113,6 +114,7 @@ module Temporal
           heartbeat_details: nil,
           scheduled_at: Time.now,
           current_attempt_scheduled_at: Time.now,
+          heartbeat_timeout: 0
         )
         context = LocalActivityContext.new(metadata)
 

--- a/spec/fabricators/activity_metadata_fabricator.rb
+++ b/spec/fabricators/activity_metadata_fabricator.rb
@@ -13,4 +13,5 @@ Fabricator(:activity_metadata, from: :open_struct) do
   heartbeat_details nil
   scheduled_at { Time.now }
   current_attempt_scheduled_at { Time.now }
+  heartbeat_timeout 0
 end

--- a/spec/fabricators/grpc/activity_task_fabricator.rb
+++ b/spec/fabricators/grpc/activity_task_fabricator.rb
@@ -19,4 +19,5 @@ Fabricator(:api_activity_task, from: Temporalio::Api::WorkflowService::V1::PollA
     end
     Temporalio::Api::Common::V1::Header.new(fields: fields)
   end
+  heartbeat_timeout { Google::Protobuf::Duration.new }
 end

--- a/spec/fabricators/grpc/record_activity_heartbeat_fabricator.rb
+++ b/spec/fabricators/grpc/record_activity_heartbeat_fabricator.rb
@@ -1,0 +1,3 @@
+Fabricator(:api_record_activity_heartbeat_response, from: Temporalio::Api::WorkflowService::V1::RecordActivityTaskHeartbeatResponse) do
+  cancel_requested false
+end

--- a/spec/unit/lib/temporal/activity/context_spec.rb
+++ b/spec/unit/lib/temporal/activity/context_spec.rb
@@ -1,16 +1,20 @@
 require 'temporal/activity/context'
 require 'temporal/metadata/activity'
+require 'temporal/scheduled_thread_pool'
 
 describe Temporal::Activity::Context do
   let(:client) { instance_double('Temporal::Client::GRPCClient') }
   let(:metadata_hash) { Fabricate(:activity_metadata).to_h }
   let(:metadata) { Temporal::Metadata::Activity.new(**metadata_hash) }
+  let(:config) { Temporal::Configuration.new }
   let(:task_token) { SecureRandom.uuid }
+  let(:heartbeat_thread_pool) { Temporal::ScheduledThreadPool.new(1, {}) }
+  let(:heartbeat_response) { Fabricate(:api_record_activity_heartbeat_response) }
 
-  subject { described_class.new(client, metadata) }
+  subject { described_class.new(client, metadata, config, heartbeat_thread_pool) }
 
   describe '#heartbeat' do
-    before { allow(client).to receive(:record_activity_task_heartbeat) }
+    before { allow(client).to receive(:record_activity_task_heartbeat).and_return(heartbeat_response) }
 
     it 'records heartbeat' do
       subject.heartbeat
@@ -26,6 +30,50 @@ describe Temporal::Activity::Context do
       expect(client)
         .to have_received(:record_activity_task_heartbeat)
         .with(namespace: metadata.namespace, task_token: metadata.task_token, details: { foo: :bar })
+    end
+
+    context 'cancellation' do
+      let(:heartbeat_response) { Fabricate(:api_record_activity_heartbeat_response, cancel_requested: true) }
+      it 'sets when cancelled' do
+        subject.heartbeat
+        expect(subject.cancel_requested).to be(true)
+      end
+    end
+
+    context 'throttling' do
+      context 'skips after the first heartbeat' do
+        let(:metadata_hash) { Fabricate(:activity_metadata, heartbeat_timeout: 30).to_h }
+        it 'discard duplicates after first when quickly completes' do
+          10.times do |i|
+            subject.heartbeat(iteration: i)
+          end
+
+          expect(client)
+            .to have_received(:record_activity_task_heartbeat)
+            .with(namespace: metadata.namespace, task_token: metadata.task_token, details: { iteration: 0 })
+        end
+      end
+
+      context 'resumes' do
+        let(:metadata_hash) { Fabricate(:activity_metadata, heartbeat_timeout: 1).to_h }
+        it 'more heartbeats after time passes' do
+          subject.heartbeat(iteration: 1)
+          subject.heartbeat(iteration: 2) # skipped because 3 will overwrite
+          subject.heartbeat(iteration: 3)
+          sleep 1
+          subject.heartbeat(iteration: 4)
+
+          # Shutdown to drain remaining threads
+          heartbeat_thread_pool.shutdown
+
+          expect(client)
+            .to have_received(:record_activity_task_heartbeat)
+            .ordered
+            .with(namespace: metadata.namespace, task_token: metadata.task_token, details: { iteration: 1 })
+            .with(namespace: metadata.namespace, task_token: metadata.task_token, details: { iteration: 3 })
+            .with(namespace: metadata.namespace, task_token: metadata.task_token, details: { iteration: 4 })
+        end
+      end
     end
   end
 
@@ -45,7 +93,7 @@ describe Temporal::Activity::Context do
 
   describe '#async?' do
     subject { context.async? }
-    let(:context) { described_class.new(client, metadata) }
+    let(:context) { described_class.new(client, metadata, nil, nil) }
 
     context 'when context is sync' do
       it { is_expected.to eq(false) }

--- a/spec/unit/lib/temporal/activity/context_spec.rb
+++ b/spec/unit/lib/temporal/activity/context_spec.rb
@@ -74,6 +74,17 @@ describe Temporal::Activity::Context do
             .with(namespace: metadata.namespace, task_token: metadata.task_token, details: { iteration: 4 })
         end
       end
+
+      it 'no heartbeat check scheduled when max interval is zero' do
+        config.timeouts = { max_heartbeat_throttle_interval: 0 }
+        subject.heartbeat
+
+        expect(client)
+          .to have_received(:record_activity_task_heartbeat)
+          .with(namespace: metadata.namespace, task_token: metadata.task_token, details: nil)
+
+        expect(subject.heartbeat_check_scheduled).to be_nil
+      end
     end
   end
 

--- a/spec/unit/lib/temporal/activity/context_spec.rb
+++ b/spec/unit/lib/temporal/activity/context_spec.rb
@@ -55,12 +55,12 @@ describe Temporal::Activity::Context do
       end
 
       context 'resumes' do
-        let(:metadata_hash) { Fabricate(:activity_metadata, heartbeat_timeout: 1).to_h }
+        let(:metadata_hash) { Fabricate(:activity_metadata, heartbeat_timeout: 0.1).to_h }
         it 'more heartbeats after time passes' do
           subject.heartbeat(iteration: 1)
           subject.heartbeat(iteration: 2) # skipped because 3 will overwrite
           subject.heartbeat(iteration: 3)
-          sleep 1
+          sleep 0.1
           subject.heartbeat(iteration: 4)
 
           # Shutdown to drain remaining threads

--- a/spec/unit/lib/temporal/activity/poller_spec.rb
+++ b/spec/unit/lib/temporal/activity/poller_spec.rb
@@ -11,6 +11,9 @@ describe Temporal::Activity::Poller do
   let(:thread_pool) do
     instance_double(Temporal::ThreadPool, wait_for_available_threads: nil, shutdown: nil)
   end
+  let(:heartbeat_thread_pool) do
+    instance_double(Temporal::ScheduledThreadPool, shutdown: nil)
+  end
   let(:config) { Temporal::Configuration.new }
   let(:middleware_chain) { instance_double(Temporal::Middleware::Chain) }
   let(:middleware) { [] }
@@ -21,6 +24,7 @@ describe Temporal::Activity::Poller do
   before do
     allow(Temporal::Connection).to receive(:generate).and_return(connection)
     allow(Temporal::ThreadPool).to receive(:new).and_return(thread_pool)
+    allow(Temporal::ScheduledThreadPool).to receive(:new).and_return(heartbeat_thread_pool)
     allow(Temporal::Middleware::Chain).to receive(:new).and_return(middleware_chain)
     allow(Temporal.metrics).to receive(:timing)
     allow(Temporal.metrics).to receive(:increment)
@@ -104,7 +108,7 @@ describe Temporal::Activity::Poller do
 
         expect(Temporal::Activity::TaskProcessor)
           .to have_received(:new)
-          .with(task, namespace, lookup, middleware_chain, config)
+          .with(task, namespace, lookup, middleware_chain, config, heartbeat_thread_pool)
         expect(task_processor).to have_received(:process)
       end
 
@@ -139,7 +143,7 @@ describe Temporal::Activity::Poller do
           expect(Temporal::Middleware::Chain).to have_received(:new).with(middleware)
           expect(Temporal::Activity::TaskProcessor)
             .to have_received(:new)
-            .with(task, namespace, lookup, middleware_chain, config)
+            .with(task, namespace, lookup, middleware_chain, config, heartbeat_thread_pool)
         end
       end
     end

--- a/spec/unit/lib/temporal/activity/task_processor_spec.rb
+++ b/spec/unit/lib/temporal/activity/task_processor_spec.rb
@@ -26,8 +26,8 @@ describe Temporal::Activity::TaskProcessor do
   let(:input) { %w[arg1 arg2] }
 
   describe '#process' do
-    let(:heartbeat_scheduled) { nil }
-    let(:context) { instance_double('Temporal::Activity::Context', async?: false, heartbeat_scheduled: heartbeat_scheduled) }
+    let(:heartbeat_check_scheduled) { nil }
+    let(:context) { instance_double('Temporal::Activity::Context', async?: false, heartbeat_check_scheduled: heartbeat_check_scheduled) }
 
     before do
       allow(Temporal::Connection)
@@ -119,11 +119,11 @@ describe Temporal::Activity::TaskProcessor do
         end
 
         context 'when there is an outstanding scheduled heartbeat' do
-          let(:heartbeat_scheduled) { Temporal::ScheduledThreadPool::ScheduledItem.new(id: :foo, canceled: false) }
+          let(:heartbeat_check_scheduled) { Temporal::ScheduledThreadPool::ScheduledItem.new(id: :foo, canceled: false) }
           it 'it gets canceled' do
             subject.process
 
-            expect(heartbeat_scheduled.canceled).to eq(true)
+            expect(heartbeat_check_scheduled.canceled).to eq(true)
           end
         end
 

--- a/spec/unit/lib/temporal/activity/task_processor_spec.rb
+++ b/spec/unit/lib/temporal/activity/task_processor_spec.rb
@@ -2,9 +2,10 @@ require 'temporal/activity/task_processor'
 require 'temporal/configuration'
 require 'temporal/metric_keys'
 require 'temporal/middleware/chain'
+require 'temporal/scheduled_thread_pool'
 
 describe Temporal::Activity::TaskProcessor do
-  subject { described_class.new(task, namespace, lookup, middleware_chain, config) }
+  subject { described_class.new(task, namespace, lookup, middleware_chain, config, heartbeat_thread_pool) }
 
   let(:namespace) { 'test-namespace' }
   let(:lookup) { instance_double('Temporal::ExecutableLookup', find: nil) }
@@ -21,10 +22,12 @@ describe Temporal::Activity::TaskProcessor do
   let(:connection) { instance_double('Temporal::Connection::GRPC') }
   let(:middleware_chain) { Temporal::Middleware::Chain.new }
   let(:config) { Temporal::Configuration.new }
+  let(:heartbeat_thread_pool) { Temporal::ScheduledThreadPool.new(2, {}) }
   let(:input) { %w[arg1 arg2] }
 
   describe '#process' do
-    let(:context) { instance_double('Temporal::Activity::Context', async?: false) }
+    let(:heartbeat_scheduled) { nil }
+    let(:context) { instance_double('Temporal::Activity::Context', async?: false, heartbeat_scheduled: heartbeat_scheduled) }
 
     before do
       allow(Temporal::Connection)
@@ -35,7 +38,7 @@ describe Temporal::Activity::TaskProcessor do
         .to receive(:generate_activity_metadata)
         .with(task, namespace)
         .and_return(metadata)
-      allow(Temporal::Activity::Context).to receive(:new).with(connection, metadata).and_return(context)
+      allow(Temporal::Activity::Context).to receive(:new).with(connection, metadata, config, heartbeat_thread_pool).and_return(context)
 
       allow(connection).to receive(:respond_activity_task_completed)
       allow(connection).to receive(:respond_activity_task_failed)
@@ -113,6 +116,15 @@ describe Temporal::Activity::TaskProcessor do
           expect(connection)
             .to have_received(:respond_activity_task_completed)
             .with(namespace: namespace, task_token: task.task_token, result: 'result')
+        end
+
+        context 'when there is an outstanding scheduled heartbeat' do
+          let(:heartbeat_scheduled) { Temporal::ScheduledThreadPool::ScheduledItem.new(id: :foo, canceled: false) }
+          it 'it gets canceled' do
+            subject.process
+
+            expect(heartbeat_scheduled.canceled).to eq(true)
+          end
         end
 
         it 'ignores connection exception' do

--- a/spec/unit/lib/temporal/metadata/activity_spec.rb
+++ b/spec/unit/lib/temporal/metadata/activity_spec.rb
@@ -40,7 +40,7 @@ describe Temporal::Metadata::Activity do
         'workflow_name' => subject.workflow_name,
         'workflow_run_id' => subject.workflow_run_id,
         'scheduled_at' => subject.scheduled_at.to_s,
-        'current_attempt_scheduled_at' => subject.current_attempt_scheduled_at.to_s,
+        'current_attempt_scheduled_at' => subject.current_attempt_scheduled_at.to_s
       })
     end
   end

--- a/spec/unit/lib/temporal/scheduled_thread_pool_spec.rb
+++ b/spec/unit/lib/temporal/scheduled_thread_pool_spec.rb
@@ -1,0 +1,127 @@
+require 'temporal/scheduled_thread_pool'
+
+describe Temporal::ScheduledThreadPool do
+  before do
+    allow(Temporal.metrics).to receive(:gauge)
+  end
+
+  let(:size) { 2 }
+  let(:tags) { { foo: 'bar', bat: 'baz' } }
+  let(:thread_pool) { described_class.new(size, tags) }
+
+  describe '#schedule' do
+    it 'executes one task with zero delay on a thread and exits' do
+      times = 0
+
+      thread_pool.schedule(:foo, 0) do
+        times += 1
+      end
+
+      thread_pool.shutdown
+
+      expect(times).to eq(1)
+    end
+
+    it 'executes tasks with delays in time order' do
+      answers = Queue.new
+
+      thread_pool.schedule(:second, 0.2) do
+        answers << :second
+      end
+
+      thread_pool.schedule(:first, 0.1) do
+        answers << :first
+      end
+
+      thread_pool.shutdown
+
+      expect(answers.size).to eq(2)
+      expect(answers.pop).to eq(:first)
+      expect(answers.pop).to eq(:second)
+    end
+  end
+
+  describe '#cancel' do
+    it 'cancels already waiting task' do
+      answers = Queue.new
+      handles = []
+
+      handles << thread_pool.schedule(:foo, 30) do
+        answers << :foo
+      end
+
+      handles << thread_pool.schedule(:bar, 30) do
+        answers << :bar
+      end
+
+      # Even though this has no wait, it will be blocked by the above
+      # two long running tasks until one is finished or cancels.
+      handles << thread_pool.schedule(:baz, 0) do
+        answers << :baz
+      end
+
+      # Canceling one waiting item (foo) will let a blocked one (baz) through
+      thread_pool.cancel(handles[0])
+
+      # Canceling the other waiting item (bar) will prevent it from blocking
+      # on shutdown
+      thread_pool.cancel(handles[1])
+
+      thread_pool.shutdown
+
+      expect(answers.size).to eq(1)
+      expect(answers.pop).to eq(:baz)
+    end
+
+    it 'cancels blocked task' do
+      times = 0
+      handles = []
+
+      handles << thread_pool.schedule(:foo, 30) do
+        times += 1
+      end
+
+      handles << thread_pool.schedule(:bar, 30) do
+        times += 1
+      end
+
+      # Even though this has no wait, it will be blocked by the above
+      # two long running tasks. This test ensures it can be canceled
+      # even while waiting to run.
+      handles << thread_pool.schedule(:baz, 0) do
+        times += 1
+      end
+
+      # Cancel this one before it can start running
+      thread_pool.cancel(handles[0])
+
+      # Cancel the others so that they don't block shutdown
+      thread_pool.cancel(handles[1])
+      thread_pool.cancel(handles[2])
+
+      thread_pool.shutdown
+
+      expect(times).to eq(0)
+    end
+  end
+
+  describe '#new' do
+    it 'reports thread available metrics' do
+      thread_pool.schedule(:foo, 0) do
+      end
+
+      thread_pool.shutdown
+
+      # Thread behavior is not deterministic. Ensure the calls match without
+      # verifying exact gauge values.
+      expect(Temporal.metrics)
+        .to have_received(:gauge)
+        .with(
+          Temporal::MetricKeys::THREAD_POOL_AVAILABLE_THREADS,
+          instance_of(Integer),
+          tags
+        )
+        .at_least(:once)
+    end
+  end
+end

--- a/spec/unit/lib/temporal/workflow/context_spec.rb
+++ b/spec/unit/lib/temporal/workflow/context_spec.rb
@@ -82,7 +82,7 @@ describe Temporal::Workflow::Context do
           input: [],
           task_queue: 'default-task-queue',
           retry_policy: nil,
-          timeouts: {:execution => 315360000, :run => 315360000, :task => 10, :schedule_to_close => nil, :schedule_to_start => nil, :start_to_close => 30, :heartbeat => nil},
+          timeouts: {execution: 315360000, run: 315360000, task: 10, schedule_to_close: nil, schedule_to_start: nil, start_to_close: 30, heartbeat: nil, default_heartbeat_throttle_interval: 30, max_heartbeat_throttle_interval: 60},
           headers: { 'test' => 'asdf' }
         ))
         allow(dispatcher).to receive(:register_handler)


### PR DESCRIPTION
### Summary

In order to reduce load and potential denial of service of the Temporal server, the Go and Java SDKs limit the number of heartbeats sent by activities. This also has cost implications for Temporal Cloud which charges per heartbeat. This change adds this same kind of throttling here.

If no heartbeat has been sent yet, it will still be immediately sent, just like before this change. Any error or cancellation will be returned back to the caller. However, it will schedule a timer at the desired heartbeating interval on a background thread. While this timer is scheduled, any heartbeat payloads will be saved in memory but not actually sent to Temporal server. Once the interval has passed, any the latest saved heartbeat payload will be sent. If there is an unsent heartbeat when an activity completes, it will be discarded.

The timer functionality is facilitated by sleeping on a thread. To avoid the overhead of creating a new thread for each activity execution, a secondary heartbeat thread pool has been created of the same size as the main activity thread pool. A `ScheduledThreadPool` class is introduced for scheduling items on the thread pool threads. These items are cancelable.

### Testing

There are unit dedicated specs for the scheduled thread pool at,
```
bundle exec rspec spec/unit/lib/temporal/scheduled_thread_pool_spec.rb
```

Many other specs have updated or extended to cover this functionality,
```
bundle exec rspec \
  spec/unit/lib/temporal/activity/context_spec.rb \
  spec/unit/lib/temporal/activity/poller_spec.rb \
  spec/unit/lib/temporal/activity/task_processor_spec.rb \
  spec/unit/lib/temporal/metadata/activity_spec.rb \
  spec/unit/lib/temporal/activity/context_spec.rb
```

The existing example spec for activity cancellation still works without change, even though some of the underlying mechanisms for activity cancellation have changed:
```
cd examples # run 3 workers according to README.md
bundle exec rspec spec/integration/activity_cancellation_spec.rb
```