### PR TITLE
Temporal CLI and SQL-based enhanced visibility compatibility

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -34,6 +34,12 @@ To run tests, make sure the temporal server is running:
 docker-compose up
 ```
 
+Run the register_namespace script to ensure the ruby-samples namespace and necessary
+search attributes have been created:
+```shell
+bin/register_namespace
+```
+
 Follow the instructions above to start the three worker proceses.
 
 To execute the tests, run:

--- a/examples/bin/register_namespace
+++ b/examples/bin/register_namespace
@@ -1,16 +1,26 @@
 #!/usr/bin/env ruby
 require_relative '../init'
 
-namespace = ARGV[0]
+namespace = ARGV[0] || 'ruby-samples'
 description = ARGV[1]
-
-raise 'Missing namespace name, please run register_namespace <namespace_name>' unless namespace
 
 begin
   Temporal.register_namespace(namespace, description)
   Temporal.logger.info 'Namespace created', { namespace: namespace }
 rescue Temporal::NamespaceAlreadyExistsFailure
   Temporal.logger.info 'Namespace already exists', { namespace: namespace }
+end
+
+loop do
+  begin
+    Temporal.list_custom_search_attributes(namespace: namespace)
+    Temporal.logger.info("Namespace is ready", { namespace: namespace })
+    break
+  rescue GRPC::NotFound
+    Temporal.logger.info("Namespace not yet found, waiting and retrying", { namespace: namespace })
+    sleep 1
+    next
+  end
 end
 
 # Register a variety of search attributes for ease of integration testing
@@ -21,9 +31,12 @@ attributes_to_add = {
   'CustomIntField' => :int,
   'CustomDatetimeField' => :datetime
 }
-begin
-  Temporal.add_custom_search_attributes(attributes_to_add)
-  Temporal.logger.info('Registered search attributes', { namespace: namespace, attributes: attributes_to_add })
-rescue Temporal::SearchAttributeAlreadyExistsFailure
-  Temporal.logger.info('Default search attributes already exist for namespace', { namespace: namespace })
+
+attributes_to_add.each do |name, type|
+  begin
+    Temporal.add_custom_search_attributes({name: type})
+    Temporal.logger.info("Registered search attributes #{name} = #{type}", { namespace: namespace })
+  rescue Temporal::SearchAttributeAlreadyExistsFailure
+    Temporal.logger.info("Default search attribute #{name} already exist for namespace", { namespace: namespace })
+  end
 end

--- a/lib/temporal/client.rb
+++ b/lib/temporal/client.rb
@@ -410,18 +410,21 @@ module Temporal
     end
 
     # @param attributes [Hash[String, Symbol]] name to symbol for type, see INDEXED_VALUE_TYPE above
-    def add_custom_search_attributes(attributes)
-      connection.add_custom_search_attributes(attributes)
+    # @param namespace String, required for SQL enhanced visibility, ignored for elastic search
+    def add_custom_search_attributes(attributes, namespace: nil)
+      connection.add_custom_search_attributes(attributes, namespace || config.default_execution_options.namespace)
     end
 
+    # @param namespace String, required for SQL enhanced visibility, ignored for elastic search
     # @return Hash[String, Symbol] name to symbol for type, see INDEXED_VALUE_TYPE above
-    def list_custom_search_attributes
-      connection.list_custom_search_attributes
+    def list_custom_search_attributes(namespace: nil)
+      connection.list_custom_search_attributes(namespace || config.default_execution_options.namespace)
     end
 
     # @param attribute_names [Array[String]] Attributes to remove
-    def remove_custom_search_attributes(*attribute_names)
-      connection.remove_custom_search_attributes(attribute_names)
+    # @param namespace String, required for SQL enhanced visibility, ignored for elastic search
+    def remove_custom_search_attributes(*attribute_names, namespace: nil)
+      connection.remove_custom_search_attributes(attribute_names, namespace || config.default_execution_options.namespace)
     end
 
     def connection

--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -493,7 +493,7 @@ module Temporal
         client.count_workflow_executions(request)
       end
 
-      def add_custom_search_attributes(attributes)
+      def add_custom_search_attributes(attributes, namespace)
         attributes.each_value do |symbol_type|
           next if SYMBOL_TO_INDEXED_VALUE_TYPE.include?(symbol_type)
 
@@ -503,7 +503,8 @@ module Temporal
         end
 
         request = Temporalio::Api::OperatorService::V1::AddSearchAttributesRequest.new(
-          search_attributes: attributes.map { |name, type| [name, SYMBOL_TO_INDEXED_VALUE_TYPE[type]] }.to_h
+          search_attributes: attributes.map { |name, type| [name, SYMBOL_TO_INDEXED_VALUE_TYPE[type]] }.to_h,
+          namespace: namespace
         )
         begin
           operator_client.add_search_attributes(request)
@@ -517,15 +518,18 @@ module Temporal
         end
       end
 
-      def list_custom_search_attributes
-        request = Temporalio::Api::OperatorService::V1::ListSearchAttributesRequest.new
+      def list_custom_search_attributes(namespace)
+        request = Temporalio::Api::OperatorService::V1::ListSearchAttributesRequest.new(
+          namespace: namespace
+        )
         response = operator_client.list_search_attributes(request)
         response.custom_attributes.map { |name, type| [name, INDEXED_VALUE_TYPE_TO_SYMBOL[type]] }.to_h
       end
 
-      def remove_custom_search_attributes(attribute_names)
+      def remove_custom_search_attributes(attribute_names, namespace)
         request = Temporalio::Api::OperatorService::V1::RemoveSearchAttributesRequest.new(
-          search_attributes: attribute_names
+          search_attributes: attribute_names,
+          namespace: namespace
         )
         begin
           operator_client.remove_search_attributes(request)

--- a/spec/unit/lib/temporal/client_spec.rb
+++ b/spec/unit/lib/temporal/client_spec.rb
@@ -8,7 +8,7 @@ require 'temporal/connection/grpc'
 describe Temporal::Client do
   subject { described_class.new(config) }
 
-  let(:config) { Temporal::Configuration.new }
+  let(:config) { Temporal::Configuration.new.tap { |c| c.namespace = namespace } }
   let(:connection) { instance_double(Temporal::Connection::GRPC) }
   let(:namespace) { 'default-test-namespace' }
   let(:workflow_id) { SecureRandom.uuid }
@@ -826,7 +826,7 @@ describe Temporal::Client do
 
       expect(connection)
         .to have_received(:add_custom_search_attributes)
-        .with(attributes)
+        .with(attributes, namespace)
     end
   end
 
@@ -853,7 +853,7 @@ describe Temporal::Client do
 
       expect(connection)
         .to have_received(:remove_custom_search_attributes)
-        .with(%i[SomeTextField SomeIntField])
+        .with(%i[SomeTextField SomeIntField], namespace)
     end
   end
 

--- a/spec/unit/lib/temporal/grpc_spec.rb
+++ b/spec/unit/lib/temporal/grpc_spec.rb
@@ -246,10 +246,7 @@ describe Temporal::Connection::GRPC do
           timeout: timeout
         )
 
-        expect(grpc_stub).to have_received(:get_workflow_execution_history) do |request, deadline:|
-          expect(request.wait_new_event).to eq(true)
-          expect(deadline).to eq(now + timeout)
-        end
+        expect(grpc_stub).to have_received(:get_workflow_execution_history).with(anything, deadline: now + timeout)
       end
 
       it 'demands a timeout to be specified' do

--- a/spec/unit/lib/temporal/workflow/executor_spec.rb
+++ b/spec/unit/lib/temporal/workflow/executor_spec.rb
@@ -55,7 +55,7 @@ describe Temporal::Workflow::Executor do
     end
 
     it 'generates workflow metadata' do
-      allow(Temporal::Metadata::Workflow).to receive(:new).and_call_original
+      allow(Temporal::Metadata::Workflow).to receive(:new)
       payload = Temporalio::Api::Common::V1::Payload.new(
         metadata: { 'encoding' => 'json/plain' },
         data: '"bar"'.b
@@ -70,19 +70,19 @@ describe Temporal::Workflow::Executor do
       event_attributes = workflow_started_event.workflow_execution_started_event_attributes
       expect(Temporal::Metadata::Workflow)
         .to have_received(:new)
-              .with(
-                namespace: workflow_metadata.namespace,
-                id: workflow_metadata.workflow_id,
-                name: event_attributes.workflow_type.name,
-                run_id: event_attributes.original_execution_run_id,
-                parent_id: nil,
-                parent_run_id: nil,
-                attempt: event_attributes.attempt,
-                task_queue: event_attributes.task_queue.name,
-                run_started_at: workflow_started_event.event_time.to_time,
-                memo: {},
-                headers: {'Foo' => 'bar'}
-              )
+          .with(
+            namespace: workflow_metadata.namespace,
+            id: workflow_metadata.workflow_id,
+            name: event_attributes.workflow_type.name,
+            run_id: event_attributes.original_execution_run_id,
+            parent_id: nil,
+            parent_run_id: nil,
+            attempt: event_attributes.attempt,
+            task_queue: event_attributes.task_queue.name,
+            headers: {'Foo' => 'bar'},
+            run_started_at: workflow_started_event.event_time.to_time,
+            memo: {},
+          )
     end
   end
 


### PR DESCRIPTION
### Summary

This makes temporal-ruby compatible with SQL-based enhanced visibility by propagating namespace through the APIs. If no namespace value is specified, the default from the configuration will be used. In clusters with Elastic Search for enhanced visibility, this value will be ignored, but it is required for SQL-based enhanced visibility.

Other tangentially related improvements:
- Some specs failed when run on Windows with the latest versions of Ruby and dependencies. These fixes are minor to get the tests passing in this environment.
- The `examples/bin/register_namespace` script has been made more robust. This can now be run without any arguments to properly provision a newly started up Temporal server with the `ruby-samples` namespace and search attributes. This script also now works with Temporalite or other SQL-based enhanced visibility systems.

### Testing

Existing specs all run on both docker-compose based Temporal server and the SQL-lite based Temporal CLI dev server!

To run these on, install the new Temporal CLI, then:
```
# in one terminal, keep running
temporal server start-dev

# in another terminal
cd examples
bin\register_namespace
bundle exec specs # run example tests as usual according to README.md instructions
```