### PR TITLE
Require "temporal/version" so Temporal::VERSION can be referenced

### DIFF
--- a/lib/temporal.rb
+++ b/lib/temporal.rb
@@ -8,6 +8,7 @@ require 'temporal/client'
 require 'temporal/metrics'
 require 'temporal/json'
 require 'temporal/errors'
+require 'temporal/version'
 require 'temporal/workflow/errors'
 
 module Temporal


### PR DESCRIPTION
I ran across this after pulling the latest SHA.  This fixes #237 for me when I use this branch.