### PR TITLE
Make worker.start and worker.stop threadsafe

### DIFF
--- a/lib/temporal/activity/poller.rb
+++ b/lib/temporal/activity/poller.rb
@@ -38,6 +38,10 @@ module Temporal
       end
 
       def wait
+        if !shutting_down?
+          raise "Activity poller waiting for shutdown completion without being in shutting_down state!"
+        end
+
         thread.join
         thread_pool.shutdown
       end

--- a/lib/temporal/worker.rb
+++ b/lib/temporal/worker.rb
@@ -45,6 +45,7 @@ module Temporal
         binary_checksum: binary_checksum,
         poll_retry_seconds: workflow_poll_retry_seconds
       }
+      @start_stop_mutex = Mutex.new
     end
 
     def register_workflow(workflow_class, options = {})
@@ -104,17 +105,22 @@ module Temporal
     end
 
     def start
-      workflows.each_pair do |(namespace, task_queue), lookup|
-        pollers << workflow_poller_for(namespace, task_queue, lookup)
+      @start_stop_mutex.synchronize do
+        return if shutting_down? # Handle the case where stop method grabbed the mutex first
+
+        trap_signals
+
+        workflows.each_pair do |(namespace, task_queue), lookup|
+          pollers << workflow_poller_for(namespace, task_queue, lookup)
+        end
+
+        activities.each_pair do |(namespace, task_queue), lookup|
+          pollers << activity_poller_for(namespace, task_queue, lookup)
+        end
+
+        pollers.each(&:start)
       end
-
-      activities.each_pair do |(namespace, task_queue), lookup|
-        pollers << activity_poller_for(namespace, task_queue, lookup)
-      end
-
-      trap_signals
-
-      pollers.each(&:start)
+      on_started_test_hook
 
       # keep the main thread alive
       sleep 1 while !shutting_down?
@@ -124,12 +130,16 @@ module Temporal
       @shutting_down = true
 
       Thread.new do
-        pollers.each(&:stop_polling)
-        # allow workers to drain in-transit tasks.
-        # https://github.com/temporalio/temporal/issues/1058
-        sleep 1
-        pollers.each(&:cancel_pending_requests)
-        pollers.each(&:wait)
+        @start_stop_mutex.synchronize do
+          pollers.each(&:stop_polling)
+          while_stopping_test_hook
+          # allow workers to drain in-transit tasks.
+          # https://github.com/temporalio/temporal/issues/1058
+          sleep 1
+          pollers.each(&:cancel_pending_requests)
+          pollers.each(&:wait)
+        end
+        on_stopped_test_hook
       end.join
     end
 
@@ -142,6 +152,10 @@ module Temporal
     def shutting_down?
       @shutting_down
     end
+
+    def on_started_test_hook; end
+    def while_stopping_test_hook; end
+    def on_stopped_test_hook; end
 
     def workflow_poller_for(namespace, task_queue, lookup)
       Workflow::Poller.new(namespace, task_queue, lookup.freeze, config, workflow_task_middleware, workflow_middleware, workflow_poller_options)

--- a/lib/temporal/worker.rb
+++ b/lib/temporal/worker.rb
@@ -120,7 +120,7 @@ module Temporal
 
         pollers.each(&:start)
       end
-      on_started_test_hook
+      on_started_hook
 
       # keep the main thread alive
       sleep 1 while !shutting_down?
@@ -132,14 +132,14 @@ module Temporal
       Thread.new do
         @start_stop_mutex.synchronize do
           pollers.each(&:stop_polling)
-          while_stopping_test_hook
+          while_stopping_hook
           # allow workers to drain in-transit tasks.
           # https://github.com/temporalio/temporal/issues/1058
           sleep 1
           pollers.each(&:cancel_pending_requests)
           pollers.each(&:wait)
         end
-        on_stopped_test_hook
+        on_stopped_hook
       end.join
     end
 
@@ -153,9 +153,9 @@ module Temporal
       @shutting_down
     end
 
-    def on_started_test_hook; end
-    def while_stopping_test_hook; end
-    def on_stopped_test_hook; end
+    def on_started_hook; end
+    def while_stopping_hook; end
+    def on_stopped_hook; end
 
     def workflow_poller_for(namespace, task_queue, lookup)
       Workflow::Poller.new(namespace, task_queue, lookup.freeze, config, workflow_task_middleware, workflow_middleware, workflow_poller_options)

--- a/lib/temporal/workflow/poller.rb
+++ b/lib/temporal/workflow/poller.rb
@@ -41,6 +41,10 @@ module Temporal
       end
 
       def wait
+        if !shutting_down?
+          raise "Workflow poller waiting for shutdown completion without being in shutting_down state!"
+        end
+
         thread.join
         thread_pool.shutdown
       end

--- a/spec/unit/lib/temporal/activity/poller_spec.rb
+++ b/spec/unit/lib/temporal/activity/poller_spec.rb
@@ -28,9 +28,9 @@ describe Temporal::Activity::Poller do
 
   # poller will receive task times times, and nil thereafter.
   # poller will be shut down after that
-  def poll(poller, client, task, times: 1)
+  def poll(task, times: 1)
     polled_times = 0
-    allow(client).to receive(:poll_activity_task_queue) do
+    allow(connection).to receive(:poll_activity_task_queue) do
       polled_times += 1
       if polled_times <= times
         task
@@ -39,25 +39,25 @@ describe Temporal::Activity::Poller do
       end
     end
 
-    poller.start
+    subject.start
 
     while polled_times < times
       sleep(busy_wait_delay)
     end
     # stop poller before inspecting
-    poller.stop_polling; poller.wait
+    subject.stop_polling; subject.wait
     polled_times
   end
 
   describe '#start' do
     it 'measures time between polls' do
       # if it doesn't poll, this test will loop forever
-      times = poll(subject, connection, nil, times: 2)
+      times = poll(nil, times: 2)
       expect(times).to be >= 2
     end
 
     it 'reports time since last poll' do
-      poll(subject, connection, nil, times: 2)
+      poll(nil, times: 2)
 
       expect(Temporal.metrics)
         .to have_received(:timing)
@@ -71,7 +71,7 @@ describe Temporal::Activity::Poller do
     end
 
     it 'reports polling completed with received_task false' do
-      poll(subject, connection, nil, times: 2)
+      poll(nil, times: 2)
 
       expect(Temporal.metrics)
         .to have_received(:increment)
@@ -96,13 +96,13 @@ describe Temporal::Activity::Poller do
       end
 
       it 'schedules task processing using a ThreadPool' do
-        poll(subject, connection, task)
+        poll(task)
 
         expect(thread_pool).to have_received(:schedule)
       end
 
       it 'uses TaskProcessor to process tasks' do
-        poll(subject, connection, task)
+        poll(task)
 
         expect(Temporal::Activity::TaskProcessor)
           .to have_received(:new)
@@ -111,7 +111,7 @@ describe Temporal::Activity::Poller do
       end
 
       it 'reports polling completed with received_task true' do
-        poll(subject, connection, task)
+        poll(task)
 
         expect(Temporal.metrics)
           .to have_received(:increment)
@@ -136,7 +136,7 @@ describe Temporal::Activity::Poller do
         let(:entry_2) { Temporal::Middleware::Entry.new(TestPollerMiddleware, '2') }
 
         it 'initializes middleware chain and passes it down to TaskProcessor' do
-          poll(subject, connection, task)
+          poll(task)
 
           expect(Temporal::Middleware::Chain).to have_received(:new).with(middleware)
           expect(Temporal::Activity::TaskProcessor)

--- a/spec/unit/lib/temporal/activity/poller_spec.rb
+++ b/spec/unit/lib/temporal/activity/poller_spec.rb
@@ -89,8 +89,6 @@ describe Temporal::Activity::Poller do
       let(:task) { Fabricate(:api_activity_task) }
 
       before do
-        allow(subject).to receive(:shutting_down?).and_return(false, true)
-        allow(connection).to receive(:poll_activity_task_queue).and_return(task)
         allow(Temporal::Activity::TaskProcessor).to receive(:new).and_return(task_processor)
         allow(thread_pool).to receive(:schedule).and_yield
       end

--- a/spec/unit/lib/temporal/worker_spec.rb
+++ b/spec/unit/lib/temporal/worker_spec.rb
@@ -203,11 +203,11 @@ describe Temporal::Worker do
   end
 
   def start_and_stop(worker)
-    allow(worker).to receive(:on_started_test_hook) {
+    allow(worker).to receive(:on_started_hook) {
       worker.stop
     }
     stopped = false
-    allow(worker).to receive(:on_stopped_test_hook) {
+    allow(worker).to receive(:on_stopped_hook) {
       stopped = true
     }
 
@@ -338,7 +338,7 @@ describe Temporal::Worker do
       subject.register_workflow(TestWorkerWorkflow)
       subject.register_activity(TestWorkerActivity)
 
-      allow(subject).to receive(:while_stopping_test_hook) do
+      allow(subject).to receive(:while_stopping_hook) do
         # This callback is within a mutex, so this new thread shouldn't
         # do anything until Worker.stop is complete.
         Thread.new {subject.start}

--- a/spec/unit/lib/temporal/worker_spec.rb
+++ b/spec/unit/lib/temporal/worker_spec.rb
@@ -202,15 +202,41 @@ describe Temporal::Worker do
     end
   end
 
+  def start_and_stop(worker)
+    allow(worker).to receive(:on_started_test_hook) {
+      worker.stop
+    }
+    stopped = false
+    allow(worker).to receive(:on_stopped_test_hook) {
+      stopped = true
+    }
+
+    thread = Thread.new {worker.start}
+    while !stopped
+      sleep(THREAD_SYNC_DELAY)
+    end
+    thread
+  end
+
+  describe 'start and stop' do
+    it 'can stop before starting' do
+      expect(Temporal::Workflow::Poller)
+        .to_not receive(:new)
+      expect(Temporal::Activity::Poller)
+        .to_not receive(:new)
+      t = Thread.new {subject.stop}
+      subject.start
+      t.join
+    end
+  end
+
   describe '#start' do
-    let(:workflow_poller_1) { instance_double(Temporal::Workflow::Poller, start: nil) }
-    let(:workflow_poller_2) { instance_double(Temporal::Workflow::Poller, start: nil) }
-    let(:activity_poller_1) { instance_double(Temporal::Activity::Poller, start: nil) }
-    let(:activity_poller_2) { instance_double(Temporal::Activity::Poller, start: nil) }
+    let(:workflow_poller_1) { instance_double(Temporal::Workflow::Poller, start: nil, stop_polling: nil, cancel_pending_requests: nil, wait: nil) }
+    let(:workflow_poller_2) { instance_double(Temporal::Workflow::Poller, start: nil, stop_polling: nil, cancel_pending_requests: nil, wait: nil) }
+    let(:activity_poller_1) { instance_double(Temporal::Activity::Poller, start: nil, stop_polling: nil, cancel_pending_requests: nil, wait: nil) }
+    let(:activity_poller_2) { instance_double(Temporal::Activity::Poller, start: nil, stop_polling: nil, cancel_pending_requests: nil, wait: nil) }
 
     it 'starts a poller for each namespace/task list combination' do
-      allow(subject).to receive(:shutting_down?).and_return(true)
-
       allow(Temporal::Workflow::Poller)
         .to receive(:new)
         .with(
@@ -272,7 +298,7 @@ describe Temporal::Worker do
       subject.register_activity(TestWorkerActivity)
       subject.register_activity(TestWorkerActivity, task_queue: 'other-task-queue')
 
-      subject.start
+      start_and_stop(subject)
 
       expect(workflow_poller_1).to have_received(:start)
       expect(workflow_poller_2).to have_received(:start)
@@ -281,7 +307,7 @@ describe Temporal::Worker do
     end
 
     it 'can have an activity poller with a different thread pool size' do
-      activity_poller = instance_double(Temporal::Activity::Poller, start: nil)
+      activity_poller = instance_double(Temporal::Activity::Poller, start: nil, stop_polling: nil, cancel_pending_requests: nil, wait: nil)
       expect(Temporal::Activity::Poller)
         .to receive(:new)
         .with(
@@ -294,28 +320,40 @@ describe Temporal::Worker do
         )
         .and_return(activity_poller)
 
-      workflow_poller = instance_double(Temporal::Workflow::Poller, start: nil)
+      workflow_poller = instance_double(Temporal::Workflow::Poller, start: nil, stop_polling: nil, cancel_pending_requests: nil, wait: nil)
       expect(Temporal::Workflow::Poller)
         .to receive(:new)
               .and_return(workflow_poller)
 
       worker = Temporal::Worker.new(activity_thread_pool_size: 10)
-      allow(worker).to receive(:shutting_down?).and_return(true)
       worker.register_workflow(TestWorkerWorkflow)
       worker.register_activity(TestWorkerActivity)
 
-      worker.start
+      start_and_stop(worker)
 
       expect(activity_poller).to have_received(:start)
     end
 
+    it 'is mutually exclusive with stop' do
+      subject.register_workflow(TestWorkerWorkflow)
+      subject.register_activity(TestWorkerActivity)
+
+      allow(subject).to receive(:while_stopping_test_hook) do
+        # This callback is within a mutex, so this new thread shouldn't
+        # do anything until Worker.stop is complete.
+        Thread.new {subject.start}
+        sleep(THREAD_SYNC_DELAY) # give it a little time to do damage if it's going to
+      end
+      subject.stop
+    end
+
     it 'can have a worklow poller with a binary checksum' do
-      activity_poller = instance_double(Temporal::Activity::Poller, start: nil)
+      activity_poller = instance_double(Temporal::Activity::Poller, start: nil, stop_polling: nil, cancel_pending_requests: nil, wait: nil)
       expect(Temporal::Activity::Poller)
         .to receive(:new)
               .and_return(activity_poller)
 
-      workflow_poller = instance_double(Temporal::Workflow::Poller, start: nil)
+      workflow_poller = instance_double(Temporal::Workflow::Poller, start: nil, stop_polling: nil, cancel_pending_requests: nil, wait: nil)
       binary_checksum = 'abc123'
       expect(Temporal::Workflow::Poller)
         .to receive(:new)
@@ -333,17 +371,16 @@ describe Temporal::Worker do
         .and_return(workflow_poller)
 
       worker = Temporal::Worker.new(binary_checksum: binary_checksum)
-      allow(worker).to receive(:shutting_down?).and_return(true)
       worker.register_workflow(TestWorkerWorkflow)
       worker.register_activity(TestWorkerActivity)
 
-      worker.start
+      start_and_stop(worker)
 
       expect(workflow_poller).to have_received(:start)
     end
 
     it 'can have an activity poller that sleeps after unsuccessful poll' do
-      activity_poller = instance_double(Temporal::Activity::Poller, start: nil)
+      activity_poller = instance_double(Temporal::Activity::Poller, start: nil, stop_polling: nil, cancel_pending_requests: nil, wait: nil)
       expect(Temporal::Activity::Poller)
         .to receive(:new)
         .with(
@@ -357,17 +394,16 @@ describe Temporal::Worker do
         .and_return(activity_poller)
 
       worker = Temporal::Worker.new(activity_poll_retry_seconds: 10)
-      allow(worker).to receive(:shutting_down?).and_return(true)
       worker.register_workflow(TestWorkerWorkflow)
       worker.register_activity(TestWorkerActivity)
 
-      worker.start
+      start_and_stop(worker)
 
       expect(activity_poller).to have_received(:start)
     end
 
     it 'can have a workflow poller sleeping after unsuccessful poll' do
-      workflow_poller = instance_double(Temporal::Workflow::Poller, start: nil)
+      workflow_poller = instance_double(Temporal::Workflow::Poller, start: nil, stop_polling: nil, cancel_pending_requests: nil, wait: nil)
       expect(Temporal::Workflow::Poller)
         .to receive(:new)
         .with(
@@ -382,11 +418,10 @@ describe Temporal::Worker do
         .and_return(workflow_poller)
 
       worker = Temporal::Worker.new(workflow_poll_retry_seconds: 10)
-      allow(worker).to receive(:shutting_down?).and_return(true)
       worker.register_workflow(TestWorkerWorkflow)
       worker.register_activity(TestWorkerActivity)
 
-      worker.start
+      start_and_stop(worker)
 
       expect(workflow_poller).to have_received(:start)
     end
@@ -418,8 +453,6 @@ describe Temporal::Worker do
       end
 
       it 'starts pollers with correct middleware' do
-        allow(subject).to receive(:shutting_down?).and_return(true)
-
         allow(Temporal::Workflow::Poller)
           .to receive(:new)
           .with(
@@ -451,7 +484,7 @@ describe Temporal::Worker do
         subject.register_workflow(TestWorkerWorkflow)
         subject.register_activity(TestWorkerActivity)
 
-        subject.start
+        start_and_stop(subject)
 
         expect(workflow_poller_1).to have_received(:start)
         expect(activity_poller_1).to have_received(:start)
@@ -459,12 +492,11 @@ describe Temporal::Worker do
     end
 
     it 'sleeps while waiting for the shutdown' do
-      allow(subject).to receive(:shutting_down?).and_return(false, false, false, true)
       allow(subject).to receive(:sleep).and_return(nil)
 
-      subject.start
+      start_and_stop(subject)
 
-      expect(subject).to have_received(:sleep).with(1).exactly(3).times
+      expect(subject).to have_received(:sleep).with(1).once
     end
 
     describe 'signal handling' do
@@ -530,17 +562,12 @@ describe Temporal::Worker do
 
       subject.register_workflow(TestWorkerWorkflow)
       subject.register_activity(TestWorkerActivity)
-
-      @thread = Thread.new { subject.start }
-      sleep THREAD_SYNC_DELAY # allow worker to start
     end
 
     it 'stops the pollers and cancels pending requests' do
-      subject.stop
+      thread = start_and_stop(subject)
 
-      sleep THREAD_SYNC_DELAY # wait for the worker to stop
-
-      expect(@thread).not_to be_alive
+      expect(thread).not_to be_alive
       expect(workflow_poller).to have_received(:stop_polling)
       expect(workflow_poller).to have_received(:cancel_pending_requests)
       expect(activity_poller).to have_received(:stop_polling)
@@ -548,11 +575,9 @@ describe Temporal::Worker do
     end
 
     it 'waits for the pollers to stop' do
-      subject.stop
+      thread = start_and_stop(subject)
 
-      sleep THREAD_SYNC_DELAY # wait for worker to stop
-
-      expect(@thread).not_to be_alive
+      expect(thread).not_to be_alive
       expect(workflow_poller).to have_received(:wait)
       expect(activity_poller).to have_received(:wait)
     end

--- a/spec/unit/lib/temporal/workflow/poller_spec.rb
+++ b/spec/unit/lib/temporal/workflow/poller_spec.rb
@@ -228,8 +228,6 @@ describe Temporal::Workflow::Poller do
       end
 
       before do
-        allow(subject).to receive(:shutting_down?).and_return(false, true)
-        allow(connection).to receive(:poll_workflow_task_queue).and_raise(StandardError)
         allow(subject).to receive(:sleep).and_return(nil)
       end
 

--- a/spec/unit/lib/temporal/workflow/poller_spec.rb
+++ b/spec/unit/lib/temporal/workflow/poller_spec.rb
@@ -15,6 +15,7 @@ describe Temporal::Workflow::Poller do
   let(:workflow_middleware) { [] }
   let(:empty_middleware_chain) { instance_double(Temporal::Middleware::Chain) }
   let(:binary_checksum) { 'v1.0.0' }
+  let(:busy_wait_delay) {0.01}
 
   subject do
     described_class.new(
@@ -30,6 +31,29 @@ describe Temporal::Workflow::Poller do
     )
   end
 
+  # poller will receive task times times, and nil thereafter.
+  # poller will be shut down after that
+  def poll(poller, client, task, times: 1)
+    polled_times = 0
+    allow(client).to receive(:poll_workflow_task_queue) do
+      polled_times += 1
+      if polled_times <= times
+        task
+      else
+        nil
+      end
+    end
+
+    poller.start
+
+    while polled_times < times
+      sleep(busy_wait_delay)
+    end
+    # stop poller before inspecting
+    poller.stop_polling; poller.wait
+    polled_times
+  end
+
   before do
     allow(Temporal::Connection).to receive(:generate).and_return(connection)
     allow(Temporal::Middleware::Chain).to receive(:new).with(workflow_middleware).and_return(workflow_middleware_chain)
@@ -40,29 +64,14 @@ describe Temporal::Workflow::Poller do
   end
 
   describe '#start' do
-    it 'polls for decision tasks' do
-      allow(subject).to receive(:shutting_down?).and_return(false, false, true)
-      allow(connection).to receive(:poll_workflow_task_queue).and_return(nil)
-
+    it 'polls for workflow tasks' do
       subject.start
-
-      # stop poller before inspecting
-      subject.stop_polling; subject.wait
-
-      expect(connection)
-        .to have_received(:poll_workflow_task_queue)
-        .with(namespace: namespace, task_queue: task_queue, binary_checksum: binary_checksum)
-        .twice
+      times = poll(subject, connection, nil, times: 2)
+      expect(times).to be >=(2)
     end
 
     it 'reports time since last poll' do
-      allow(subject).to receive(:shutting_down?).and_return(false, false, true)
-      allow(connection).to receive(:poll_workflow_task_queue).and_return(nil)
-
-      subject.start
-
-      # stop poller before inspecting
-      subject.stop_polling; subject.wait
+      poll(subject, connection, nil)
 
       expect(Temporal.metrics)
         .to have_received(:timing)
@@ -72,17 +81,11 @@ describe Temporal::Workflow::Poller do
           namespace: namespace,
           task_queue: task_queue
         )
-        .twice
+        .at_least(2).times
     end
 
     it 'reports polling completed with received_task false' do
-      allow(subject).to receive(:shutting_down?).and_return(false, false, true)
-      allow(connection).to receive(:poll_workflow_task_queue).and_return(nil)
-
-      subject.start
-
-      # stop poller before inspecting
-      subject.stop_polling; subject.wait
+      poll(subject, connection, nil)
 
       expect(Temporal.metrics)
         .to have_received(:increment)
@@ -92,7 +95,7 @@ describe Temporal::Workflow::Poller do
           namespace: namespace,
           task_queue: task_queue
         )
-        .twice
+        .at_least(2).times
     end
 
     context 'when a workflow task is received' do
@@ -102,16 +105,11 @@ describe Temporal::Workflow::Poller do
       let(:task) { Fabricate(:api_workflow_task) }
 
       before do
-        allow(subject).to receive(:shutting_down?).and_return(false, true)
-        allow(connection).to receive(:poll_workflow_task_queue).and_return(task)
         allow(Temporal::Workflow::TaskProcessor).to receive(:new).and_return(task_processor)
       end
 
       it 'uses TaskProcessor to process tasks' do
-        subject.start
-
-        # stop poller before inspecting
-        subject.stop_polling; subject.wait
+        poll(subject, connection, task)
 
         expect(Temporal::Workflow::TaskProcessor)
           .to have_received(:new)
@@ -120,10 +118,7 @@ describe Temporal::Workflow::Poller do
       end
 
       it 'reports polling completed with received_task true' do
-        subject.start
-
-        # stop poller before inspecting
-        subject.stop_polling; subject.wait
+        poll(subject, connection, task)
 
         expect(Temporal.metrics)
           .to have_received(:increment)
@@ -150,10 +145,7 @@ describe Temporal::Workflow::Poller do
 
 
         it 'initializes middleware chain and passes it down to TaskProcessor' do
-          subject.start
-
-          # stop poller before inspecting
-          subject.stop_polling; subject.wait
+          poll(subject, connection, task)
 
           expect(Temporal::Middleware::Chain).to have_received(:new).with(middleware)
           expect(Temporal::Middleware::Chain).to have_received(:new).with(workflow_middleware)
@@ -166,15 +158,24 @@ describe Temporal::Workflow::Poller do
 
     context 'when connection is unable to poll' do
       before do
-        allow(subject).to receive(:shutting_down?).and_return(false, true)
-        allow(connection).to receive(:poll_workflow_task_queue).and_raise(StandardError)
         allow(subject).to receive(:sleep).and_return(nil)
       end
 
       it 'logs' do
         allow(Temporal.logger).to receive(:error)
 
+        polled = false
+        allow(connection).to receive(:poll_workflow_task_queue) do
+          if !polled
+            polled = true
+            raise StandardError
+          end
+        end
+
         subject.start
+        while !polled
+          sleep(busy_wait_delay)
+        end
 
         # stop poller before inspecting
         subject.stop_polling; subject.wait
@@ -190,7 +191,18 @@ describe Temporal::Workflow::Poller do
       end
 
       it 'does not sleep' do
+        polled = false
+        allow(connection).to receive(:poll_workflow_task_queue) do
+          if !polled
+            polled = true
+            raise StandardError
+          end
+        end
+
         subject.start
+        while !polled
+          sleep(busy_wait_delay)
+        end
 
         # stop poller before inspecting
         subject.stop_polling; subject.wait
@@ -222,7 +234,18 @@ describe Temporal::Workflow::Poller do
       end
 
       it 'sleeps' do
+        polled = false
+        allow(connection).to receive(:poll_workflow_task_queue) do
+          if !polled
+            polled = true
+            raise StandardError
+          end
+        end
+
         subject.start
+        while !polled
+          sleep(busy_wait_delay)
+        end
 
         # stop poller before inspecting
         subject.stop_polling; subject.wait


### PR DESCRIPTION
Upstreamed on behalf of @drewhoskins-stripe. Merge conflicts with #216 resolved.

# Description
In tests, we need to stop the worker threads from the main thread when we tear down the test case.
This was racing with start if we called it too soon, as was common, for example, if we threw an exception when trying to create a workflow.
Most commonly this resulted in a deadlock:
* stop method begins, shuts down 0 pollers, and sleeps
* start method completes, adding more pollers as part of normal initialization.
* stop method now calls `:wait` on each poller, but since they were added after the shutdown, they had not previously been shut down.

There are other potentially subtle issues, so I'm just throwing start and stop under a mutex.
I also added an assertion to the pollers to catch when this deadlock would happen in the future.

# Test Plan
I needed to refactor a bunch of  fragile unit tests that depended on the exact sequence of calls to `:shutting_down?`.

```
bundle exec rspec -f d ./spec/unit//lib/temporal/worker_spec.rb
bundle exec rspec -f d ./spec/unit//lib/temporal/workflow/poller_spec.rb
bundle exec rspec -f d ./spec/unit//lib/temporal/activity/poller_spec.rb
```
plus integration tests
```
cd examples
./bin/worker&
rspec ./spec/integration
```
