### PR TITLE
Require version in client name version interceptor

### DIFF
--- a/lib/temporal/connection/interceptors/client_name_version_interceptor.rb
+++ b/lib/temporal/connection/interceptors/client_name_version_interceptor.rb
@@ -1,4 +1,5 @@
 require 'grpc'
+require 'temporal/version'
 
 module Temporal
   module Connection


### PR DESCRIPTION
This fixes https://github.com/coinbase/temporal-ruby/issues/237 (an issue with package loading) introduced in #223.

fyi @mjameswh