### PR TITLE
Set system.forceSearchAttributesCacheRefreshOnRead to true for examples

### DIFF
--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -7,6 +7,9 @@ services:
      - "7233:7233"
     environment:
       - "CASSANDRA_SEEDS=cassandra"
+      - "DYNAMIC_CONFIG_FILE_PATH=/etc/temporal/config/dynamicconfig/temporal-ruby.yaml"
+    volumes:
+      - ./dynamic-config.yml:/etc/temporal/config/dynamicconfig/temporal-ruby.yaml
     depends_on:
       - cassandra
 

--- a/examples/dynamic-config.yml
+++ b/examples/dynamic-config.yml
@@ -1,0 +1,2 @@
+system.forceSearchAttributesCacheRefreshOnRead:
+  - value: true


### PR DESCRIPTION
We have tests in CI that sometimes fails because the search attributes cache wasn't updated with the newly registered attributes. The setting added in this PR will force a cache refresh when reading search attributes.

See https://github.com/coinbase/temporal-ruby/pull/241 for more context.