### PR TITLE
Fix and add spec for local activities

### DIFF
--- a/lib/temporal/workflow/context.rb
+++ b/lib/temporal/workflow/context.rb
@@ -1,5 +1,6 @@
 require 'securerandom'
 
+require 'temporal/activity/context'
 require 'temporal/execution_options'
 require 'temporal/errors'
 require 'temporal/thread_local_context'
@@ -113,7 +114,7 @@ module Temporal
 
         side_effect do
           # TODO: this probably requires a local context implementation
-          context = Activity::Context.new(nil, nil)
+          context = Activity::Context.new(nil, nil, nil, nil)
           activity_class.execute_in_context(context, input)
         end
       end


### PR DESCRIPTION
### Summary

#234 broke local activities because the `Activity::Context` constructor callsite they rely on was not updated. Local activities were also not covered by any specs, which made it easy to miss this. This change passes the correct number of parameters to the constructor and adds a basic spec for local activity invocation.

Fixes #245 

### Testing

New spec: `bundle exec rspec spec/unit/lib/temporal/workflow/context_spec.rb:100`
