### PR TITLE
Add filter to query_workflow_executions method arguments

### DIFF
--- a/lib/temporal/client.rb
+++ b/lib/temporal/client.rb
@@ -405,7 +405,9 @@ module Temporal
       Temporal::Workflow::Executions.new(connection: connection, status: :closed, request_options: { namespace: namespace, from: from, to: to, next_page_token: next_page_token, max_page_size: max_page_size}.merge(filter))
     end
 
-    def query_workflow_executions(namespace, query, next_page_token: nil, max_page_size: nil)
+    def query_workflow_executions(namespace, query, filter: {}, next_page_token: nil, max_page_size: nil)
+      validate_filter(filter, :status, :workflow, :workflow_id)
+      
       Temporal::Workflow::Executions.new(connection: connection, status: :all, request_options: { namespace: namespace, query: query, next_page_token: next_page_token, max_page_size: max_page_size }.merge(filter))
     end
 


### PR DESCRIPTION
In the [Temporal client code](https://github.com/coinbase/temporal-ruby/blob/41a8e923e52f62a6727e3ce6ffa2d68090b29439/lib/temporal/client.rb#LL408C5-L410C8), the query_workflow_executions method uses a local variable named filter within the method body but does not accept it as a parameter, causing a NameError to be raised.

The full error message is the following:

"error":"#<NameError: undefined local variable or method `filter' for #<Temporal::Client:0x000000010bca6f00>>"
This method was introduced in https://github.com/coinbase/temporal-ruby/pull/177.