### PR TITLE
Fix task queue type to match enum

### DIFF
--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -595,7 +595,7 @@ module Temporal
           task_queue: Temporalio::Api::TaskQueue::V1::TaskQueue.new(
             name: task_queue
           ),
-          task_queue_type: Temporalio::Api::Enums::V1::TaskQueueType::Workflow,
+          task_queue_type: Temporalio::Api::Enums::V1::TaskQueueType::TASK_QUEUE_TYPE_WORKFLOW,
           include_task_queue_status: true
         )
         client.describe_task_queue(request)


### PR DESCRIPTION
Fix task queue type to match enum defined constant

When using `describe_task_queue` api, we run into an error

```
`describe_task_queue': uninitialized constant Temporalio::Api::Enums::V1::TaskQueueType::Workflow (NameError)
```