### PR TITLE
Allow setting credentials as lambda

### DIFF
--- a/lib/temporal/configuration.rb
+++ b/lib/temporal/configuration.rb
@@ -15,7 +15,8 @@ module Temporal
     Execution = Struct.new(:namespace, :task_queue, :timeouts, :headers, :search_attributes, keyword_init: true)
 
     attr_reader :timeouts, :error_handlers
-    attr_accessor :connection_type, :converter, :use_error_serialization_v2, :host, :port, :credentials, :identity,
+    attr_writer :credentials
+    attr_accessor :connection_type, :converter, :use_error_serialization_v2, :host, :port, :identity,
                   :logger, :metrics_adapter, :namespace, :task_queue, :headers, :search_attributes, :header_propagators,
                   :payload_codec
 
@@ -98,6 +99,12 @@ module Temporal
 
     def timeouts=(new_timeouts)
       @timeouts = DEFAULT_TIMEOUTS.merge(new_timeouts)
+    end
+
+    def credentials
+      return @credentials.call if @credentials.is_a?(Proc)
+
+      @credentials
     end
 
     def for_connection

--- a/spec/unit/lib/temporal/configuration_spec.rb
+++ b/spec/unit/lib/temporal/configuration_spec.rb
@@ -61,5 +61,19 @@ describe Temporal::Configuration do
       subject.identity = new_identity
       expect(subject.for_connection).to have_attributes(identity: new_identity)
     end
+
+    it 'default credentials' do
+      expect(subject.for_connection).to have_attributes(credentials: :this_channel_is_insecure)
+    end
+
+    it 'override credentials' do
+      subject.credentials = :test_credentials
+      expect(subject.for_connection).to have_attributes(credentials: :test_credentials)
+    end
+
+    it 'override credentials with lambda' do
+      subject.credentials = -> { :test_credentials }
+      expect(subject.for_connection).to have_attributes(credentials: :test_credentials)
+    end
   end
 end


### PR DESCRIPTION
We had a problem with multiple Puma workers and preload, because Temporal initializer which configures connection credentials ran before fork. Therefore after fork it we got an error:

```
grpc cannot be used before and after forking
```

Reconfiguring credentials after forking does not work because of the guard in grpc gem:
https://github.com/grpc/grpc/blob/e20e7a1198b2ff276a2f4f8514201b8ac1456830/src/ruby/ext/grpc/rb_grpc.c#L264

Therefore the most elegant solution was to configure credentials on demand, when connection is being built (after fork). 
I have added a lambda support to solve this issue. It works for us.

@egletam