### PR TITLE
Add missing arguments to Temporal.reset_workflow and add integration tests for Resets

### DIFF
--- a/examples/spec/integration/initial_search_attributes_spec.rb
+++ b/examples/spec/integration/initial_search_attributes_spec.rb
@@ -58,6 +58,8 @@ describe 'starting workflow with initial search attributes', :integration do
       workflow_id,
       nil
     )
-    expect(execution_info.search_attributes).to eq(expected_attributes)
+    # Temporal might add new built-in search attributes, so just assert that
+    # the expected attributes are a subset of the actual attributes:
+    expect(execution_info.search_attributes).to be >= expected_attributes
   end
 end

--- a/examples/spec/integration/reset_workflow_spec.rb
+++ b/examples/spec/integration/reset_workflow_spec.rb
@@ -1,0 +1,163 @@
+require 'workflows/hello_world_workflow'
+require 'workflows/query_workflow'
+require 'temporal/reset_reapply_type'
+
+describe 'Temporal.reset_workflow' do
+  it 'can reset a closed workflow to the beginning' do
+    workflow_id = SecureRandom.uuid
+    original_run_id = Temporal.start_workflow(
+      HelloWorldWorkflow,
+      'Test',
+      options: { workflow_id: workflow_id }
+    )
+
+    original_result = Temporal.await_workflow_result(
+      HelloWorldWorkflow,
+      workflow_id: workflow_id,
+      run_id: original_run_id
+    )
+    expect(original_result).to eq('Hello World, Test')
+
+    new_run_id = Temporal.reset_workflow(
+      Temporal.configuration.namespace,
+      workflow_id,
+      original_run_id,
+      strategy: Temporal::ResetStrategy::FIRST_WORKFLOW_TASK
+    )
+
+    new_result = Temporal.await_workflow_result(
+      HelloWorldWorkflow,
+      workflow_id: workflow_id,
+      run_id: new_run_id,
+    )
+    expect(new_result).to eq('Hello World, Test')
+  end
+
+  def reset_hello_world_workflow_10_times(workflow_id, original_run_id, request_id:)
+    10.times.map do
+      new_run_id = Temporal.reset_workflow(
+        Temporal.configuration.namespace,
+        workflow_id,
+        original_run_id,
+        strategy: Temporal::ResetStrategy::FIRST_WORKFLOW_TASK,
+        request_id: request_id
+      )
+
+      new_result = Temporal.await_workflow_result(
+        HelloWorldWorkflow,
+        workflow_id: workflow_id,
+        run_id: new_run_id,
+      )
+      expect(new_result).to eq('Hello World, Test')
+
+      new_run_id
+    end
+  end
+
+  it 'can repeatedly reset the same closed workflow to the beginning' do
+    workflow_id = SecureRandom.uuid
+    original_run_id = Temporal.start_workflow(
+      HelloWorldWorkflow,
+      'Test',
+      options: { workflow_id: workflow_id }
+    )
+
+    original_result = Temporal.await_workflow_result(
+      HelloWorldWorkflow,
+      workflow_id: workflow_id,
+      run_id: original_run_id,
+    )
+    expect(original_result).to eq('Hello World, Test')
+
+    new_run_ids = reset_hello_world_workflow_10_times(
+      workflow_id,
+      original_run_id,
+      # This causes the request_id to be generated with a random value:
+      request_id: nil
+    )
+
+    # Each Reset request should have resulted in a unique workflow execution
+    expect(new_run_ids.uniq.size).to eq(new_run_ids.size)
+  end
+
+  it 'can deduplicate reset requests' do
+    workflow_id = SecureRandom.uuid
+    original_run_id = Temporal.start_workflow(
+      HelloWorldWorkflow,
+      'Test',
+      options: { workflow_id: workflow_id }
+    )
+
+    original_result = Temporal.await_workflow_result(
+      HelloWorldWorkflow,
+      workflow_id: workflow_id,
+      run_id: original_run_id,
+    )
+    expect(original_result).to eq('Hello World, Test')
+
+    reset_request_id = SecureRandom.uuid
+    new_run_ids = reset_hello_world_workflow_10_times(
+      workflow_id,
+      original_run_id,
+      request_id: reset_request_id
+    )
+
+    # Each Reset request except the first should have been deduplicated
+    expect(new_run_ids.uniq.size).to eq(1)
+  end
+
+  def start_query_workflow_and_signal_three_times
+    workflow_id = SecureRandom.uuid
+    run_id = Temporal.start_workflow(
+      QueryWorkflow,
+      options: { workflow_id: workflow_id }
+    )
+
+    expect(Temporal.query_workflow(QueryWorkflow, 'signal_count', workflow_id, run_id))
+      .to eq 0
+
+    Temporal.signal_workflow(QueryWorkflow, 'make_progress', workflow_id, run_id)
+    Temporal.signal_workflow(QueryWorkflow, 'make_progress', workflow_id, run_id)
+    Temporal.signal_workflow(QueryWorkflow, 'make_progress', workflow_id, run_id)
+
+    expect(Temporal.query_workflow(QueryWorkflow, 'signal_count', workflow_id, run_id))
+      .to eq 3
+
+    { workflow_id: workflow_id, run_id: run_id }
+  end
+
+  it 'can reapply signals when resetting a workflow' do
+    workflow_id, original_run_id = start_query_workflow_and_signal_three_times.values_at(:workflow_id, :run_id)
+
+    new_run_id = Temporal.reset_workflow(
+      Temporal.configuration.namespace,
+      workflow_id,
+      original_run_id,
+      strategy: Temporal::ResetStrategy::FIRST_WORKFLOW_TASK,
+      reset_reapply_type: Temporal::ResetReapplyType::SIGNAL
+    )
+
+    expect(Temporal.query_workflow(QueryWorkflow, 'signal_count', workflow_id, new_run_id))
+      .to eq 3
+
+    Temporal.terminate_workflow(workflow_id, run_id: new_run_id)
+  end
+
+  it 'can skip reapplying signals when resetting a workflow' do
+    workflow_id, original_run_id = start_query_workflow_and_signal_three_times.values_at(:workflow_id, :run_id)
+
+    new_run_id = Temporal.reset_workflow(
+      Temporal.configuration.namespace,
+      workflow_id,
+      original_run_id,
+      strategy: Temporal::ResetStrategy::FIRST_WORKFLOW_TASK,
+      reset_reapply_type: Temporal::ResetReapplyType::NONE
+    )
+
+    expect(Temporal.query_workflow(QueryWorkflow, 'signal_count', workflow_id, new_run_id))
+      .to eq 0
+
+    Temporal.terminate_workflow(workflow_id, run_id: new_run_id)
+  end
+end
+  

--- a/examples/spec/integration/reset_workflow_spec.rb
+++ b/examples/spec/integration/reset_workflow_spec.rb
@@ -33,8 +33,8 @@ describe 'Temporal.reset_workflow' do
     expect(new_result).to eq('Hello World, Test')
   end
 
-  def reset_hello_world_workflow_10_times(workflow_id, original_run_id, request_id:)
-    10.times.map do
+  def reset_hello_world_workflow_twice(workflow_id, original_run_id, request_id:)
+    2.times.map do
       new_run_id = Temporal.reset_workflow(
         Temporal.configuration.namespace,
         workflow_id,
@@ -69,7 +69,7 @@ describe 'Temporal.reset_workflow' do
     )
     expect(original_result).to eq('Hello World, Test')
 
-    new_run_ids = reset_hello_world_workflow_10_times(
+    new_run_ids = reset_hello_world_workflow_twice(
       workflow_id,
       original_run_id,
       # This causes the request_id to be generated with a random value:
@@ -96,7 +96,7 @@ describe 'Temporal.reset_workflow' do
     expect(original_result).to eq('Hello World, Test')
 
     reset_request_id = SecureRandom.uuid
-    new_run_ids = reset_hello_world_workflow_10_times(
+    new_run_ids = reset_hello_world_workflow_twice(
       workflow_id,
       original_run_id,
       request_id: reset_request_id

--- a/examples/spec/integration/upsert_search_attributes_spec.rb
+++ b/examples/spec/integration/upsert_search_attributes_spec.rb
@@ -44,6 +44,8 @@ describe 'Temporal::Workflow::Context.upsert_search_attributes', :integration do
       workflow_id,
       nil
     )
-    expect(execution_info.search_attributes).to eq(expected_attributes)
+    # Temporal might add new built-in search attributes, so just assert that
+    # the expected attributes are a subset of the actual attributes:
+    expect(execution_info.search_attributes).to be >= expected_attributes
   end
 end

--- a/lib/temporal/client.rb
+++ b/lib/temporal/client.rb
@@ -283,11 +283,11 @@ module Temporal
     # @param reason [String] a reset reason to be recorded in workflow's history for reference
     # @param request_id [String, nil] an idempotency key for the Reset request or `nil` to use
     #   an auto-generated, unique value
-    # @param reset_reapply_type [Symbol, nil] one of the Temporal::ResetReapplyType values or `nil`
-    #   to use the server default
+    # @param reset_reapply_type [Symbol] one of the Temporal::ResetReapplyType values. Defaults
+    #   to SIGNAL.
     #
     # @return [String] run_id of the new workflow execution
-    def reset_workflow(namespace, workflow_id, run_id, strategy: nil, workflow_task_id: nil, reason: 'manual reset', request_id: nil, reset_reapply_type: nil)
+    def reset_workflow(namespace, workflow_id, run_id, strategy: nil, workflow_task_id: nil, reason: 'manual reset', request_id: nil, reset_reapply_type: Temporal::ResetReapplyType::SIGNAL)
       # Pick default strategy for backwards-compatibility
       strategy ||= :last_workflow_task unless workflow_task_id
 

--- a/lib/temporal/client.rb
+++ b/lib/temporal/client.rb
@@ -298,6 +298,14 @@ module Temporal
       workflow_task_id ||= find_workflow_task(namespace, workflow_id, run_id, strategy)&.id
       raise Error, 'Could not find an event to reset to' unless workflow_task_id
 
+      if request_id.nil?
+        # Generate a request ID if one is not provided.
+        # This is consistent with the Go SDK:
+        # https://github.com/temporalio/sdk-go/blob/e1d76b7c798828302980d483f0981128c97a20c2/internal/internal_workflow_client.go#L952-L972
+
+        request_id = SecureRandom.uuid
+      end
+
       response = connection.reset_workflow_execution(
         namespace: namespace,
         workflow_id: workflow_id,

--- a/lib/temporal/client.rb
+++ b/lib/temporal/client.rb
@@ -271,7 +271,7 @@ module Temporal
     # Reset a workflow
     #
     # @note More on resetting a workflow here —
-    #   https://docs.temporal.io/docs/system-tools/tctl/#restart-reset-workflow
+    #   https://docs.temporal.io/tctl-v1/workflow#reset
     #
     # @param namespace [String]
     # @param workflow_id [String]
@@ -281,9 +281,13 @@ module Temporal
     # @param workflow_task_id [Integer, nil] A specific event ID to reset to. The event has to
     #   be of a type WorkflowTaskCompleted, WorkflowTaskFailed or WorkflowTaskTimedOut
     # @param reason [String] a reset reason to be recorded in workflow's history for reference
+    # @param request_id [String, nil] an idempotency key for the Reset request or `nil` to use
+    #   an auto-generated, unique value
+    # @param reset_reapply_type [Symbol, nil] one of the Temporal::ResetReapplyType values or `nil`
+    #   to use the server default
     #
     # @return [String] run_id of the new workflow execution
-    def reset_workflow(namespace, workflow_id, run_id, strategy: nil, workflow_task_id: nil, reason: 'manual reset')
+    def reset_workflow(namespace, workflow_id, run_id, strategy: nil, workflow_task_id: nil, reason: 'manual reset', request_id: nil, reset_reapply_type: nil)
       # Pick default strategy for backwards-compatibility
       strategy ||= :last_workflow_task unless workflow_task_id
 
@@ -299,7 +303,9 @@ module Temporal
         workflow_id: workflow_id,
         run_id: run_id,
         reason: reason,
-        workflow_task_event_id: workflow_task_id
+        workflow_task_event_id: workflow_task_id,
+        request_id: request_id,
+        reset_reapply_type: reset_reapply_type
       )
 
       response.run_id

--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -414,15 +414,7 @@ module Temporal
         client.signal_with_start_workflow_execution(request)
       end
 
-      def reset_workflow_execution(namespace:, workflow_id:, run_id:, reason:, workflow_task_event_id:, request_id: nil, reset_reapply_type: nil)
-        if request_id.nil?
-          # Generate a request ID if one is not provided.
-          # This is consistent with the Go SDK:
-          # https://github.com/temporalio/sdk-go/blob/e1d76b7c798828302980d483f0981128c97a20c2/internal/internal_workflow_client.go#L952-L972
-
-          request_id = SecureRandom.uuid
-        end
-
+      def reset_workflow_execution(namespace:, workflow_id:, run_id:, reason:, workflow_task_event_id:, request_id:, reset_reapply_type: nil)
         request = Temporalio::Api::WorkflowService::V1::ResetWorkflowExecutionRequest.new(
           namespace: namespace,
           workflow_execution: Temporalio::Api::Common::V1::WorkflowExecution.new(

--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -44,6 +44,11 @@ module Temporal
         [Temporalio::Api::Enums::V1::IndexedValueType.lookup(int_value), symbol]
       end.to_h.freeze
 
+      SYMBOL_TO_RESET_REAPPLY_TYPE = {
+        signal: Temporalio::Api::Enums::V1::ResetReapplyType::RESET_REAPPLY_TYPE_SIGNAL,
+        none: Temporalio::Api::Enums::V1::ResetReapplyType::RESET_REAPPLY_TYPE_NONE,
+      }
+
       DEFAULT_OPTIONS = {
         max_page_size: 100
       }.freeze
@@ -409,7 +414,15 @@ module Temporal
         client.signal_with_start_workflow_execution(request)
       end
 
-      def reset_workflow_execution(namespace:, workflow_id:, run_id:, reason:, workflow_task_event_id:)
+      def reset_workflow_execution(namespace:, workflow_id:, run_id:, reason:, workflow_task_event_id:, request_id: nil, reset_reapply_type: nil)
+        if request_id.nil?
+          # Generate a request ID if one is not provided.
+          # This is consistent with the Go SDK:
+          # https://github.com/temporalio/sdk-go/blob/e1d76b7c798828302980d483f0981128c97a20c2/internal/internal_workflow_client.go#L952-L972
+
+          request_id = SecureRandom.uuid
+        end
+
         request = Temporalio::Api::WorkflowService::V1::ResetWorkflowExecutionRequest.new(
           namespace: namespace,
           workflow_execution: Temporalio::Api::Common::V1::WorkflowExecution.new(
@@ -417,8 +430,17 @@ module Temporal
             run_id: run_id,
           ),
           reason: reason,
-          workflow_task_finish_event_id: workflow_task_event_id
+          workflow_task_finish_event_id: workflow_task_event_id,
+          request_id: request_id
         )
+
+        if reset_reapply_type
+          reapply_type = SYMBOL_TO_RESET_REAPPLY_TYPE[reset_reapply_type]
+          raise Client::ArgumentError, 'Unknown reset_reapply_type specified' unless reapply_type
+
+          request.reset_reapply_type = reapply_type
+        end
+
         client.reset_workflow_execution(request)
       end
 

--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -414,7 +414,7 @@ module Temporal
         client.signal_with_start_workflow_execution(request)
       end
 
-      def reset_workflow_execution(namespace:, workflow_id:, run_id:, reason:, workflow_task_event_id:, request_id:, reset_reapply_type: nil)
+      def reset_workflow_execution(namespace:, workflow_id:, run_id:, reason:, workflow_task_event_id:, request_id:, reset_reapply_type: Temporal::ResetReapplyType::SIGNAL)
         request = Temporalio::Api::WorkflowService::V1::ResetWorkflowExecutionRequest.new(
           namespace: namespace,
           workflow_execution: Temporalio::Api::Common::V1::WorkflowExecution.new(

--- a/lib/temporal/reset_reapply_type.rb
+++ b/lib/temporal/reset_reapply_type.rb
@@ -1,0 +1,6 @@
+module Temporal
+  module ResetReapplyType
+    SIGNAL = :signal
+    NONE = :none
+  end
+end

--- a/spec/unit/lib/temporal/client_spec.rb
+++ b/spec/unit/lib/temporal/client_spec.rb
@@ -612,8 +612,9 @@ describe Temporal::Client do
           run_id: '1234',
           reason: 'Test reset',
           workflow_task_event_id: workflow_task_id,
-          request_id: nil,
-          reset_reapply_type: nil
+          # The request ID will be a random UUID:
+          request_id: anything,
+          reset_reapply_type: :signal
         )
       end
 
@@ -661,8 +662,9 @@ describe Temporal::Client do
           run_id: run_id,
           reason: 'manual reset',
           workflow_task_event_id: 16,
-          request_id: nil,
-          reset_reapply_type: nil
+          # The request ID will be a random UUID:
+          request_id: instance_of(String),
+          reset_reapply_type: :signal
         )
       end
     end
@@ -692,8 +694,9 @@ describe Temporal::Client do
             run_id: run_id,
             reason: 'manual reset',
             workflow_task_event_id: 16,
-            request_id: nil,
-            reset_reapply_type: nil
+            # The request ID will be a random UUID:
+            request_id: instance_of(String),
+            reset_reapply_type: :signal
           )
         end
       end
@@ -708,8 +711,9 @@ describe Temporal::Client do
             run_id: run_id,
             reason: 'manual reset',
             workflow_task_event_id: 4,
-            request_id: nil,
-            reset_reapply_type: nil
+            # The request ID will be a random UUID:
+            request_id: instance_of(String),
+            reset_reapply_type: :signal
           )
         end
       end
@@ -725,8 +729,9 @@ describe Temporal::Client do
             run_id: run_id,
             reason: 'manual reset',
             workflow_task_event_id: 10,
-            request_id: nil,
-            reset_reapply_type: nil
+            # The request ID will be a random UUID:
+            request_id: instance_of(String),
+            reset_reapply_type: :signal
           )
         end
       end

--- a/spec/unit/lib/temporal/client_spec.rb
+++ b/spec/unit/lib/temporal/client_spec.rb
@@ -4,6 +4,7 @@ require 'temporal/configuration'
 require 'temporal/workflow'
 require 'temporal/workflow/history'
 require 'temporal/connection/grpc'
+require 'temporal/reset_reapply_type'
 
 describe Temporal::Client do
   subject { described_class.new(config) }
@@ -610,7 +611,31 @@ describe Temporal::Client do
           workflow_id: '123',
           run_id: '1234',
           reason: 'Test reset',
-          workflow_task_event_id: workflow_task_id
+          workflow_task_event_id: workflow_task_id,
+          request_id: nil,
+          reset_reapply_type: nil
+        )
+      end
+
+      it 'passes through request_id and reset_reapply_type' do
+        subject.reset_workflow(
+          'default-test-namespace',
+          '123',
+          '1234',
+          workflow_task_id: workflow_task_id,
+          reason: 'Test reset',
+          request_id: 'foo',
+          reset_reapply_type: Temporal::ResetReapplyType::SIGNAL
+        )
+
+        expect(connection).to have_received(:reset_workflow_execution).with(
+          namespace: 'default-test-namespace',
+          workflow_id: '123',
+          run_id: '1234',
+          reason: 'Test reset',
+          workflow_task_event_id: workflow_task_id,
+          request_id: 'foo',
+          reset_reapply_type: :signal
         )
       end
 
@@ -635,7 +660,9 @@ describe Temporal::Client do
           workflow_id: workflow_id,
           run_id: run_id,
           reason: 'manual reset',
-          workflow_task_event_id: 16
+          workflow_task_event_id: 16,
+          request_id: nil,
+          reset_reapply_type: nil
         )
       end
     end
@@ -664,7 +691,9 @@ describe Temporal::Client do
             workflow_id: workflow_id,
             run_id: run_id,
             reason: 'manual reset',
-            workflow_task_event_id: 16
+            workflow_task_event_id: 16,
+            request_id: nil,
+            reset_reapply_type: nil
           )
         end
       end
@@ -678,7 +707,9 @@ describe Temporal::Client do
             workflow_id: workflow_id,
             run_id: run_id,
             reason: 'manual reset',
-            workflow_task_event_id: 4
+            workflow_task_event_id: 4,
+            request_id: nil,
+            reset_reapply_type: nil
           )
         end
       end
@@ -693,7 +724,9 @@ describe Temporal::Client do
             workflow_id: workflow_id,
             run_id: run_id,
             reason: 'manual reset',
-            workflow_task_event_id: 10
+            workflow_task_event_id: 10,
+            request_id: nil,
+            reset_reapply_type: nil
           )
         end
       end


### PR DESCRIPTION
This PR adds two arguments present on the [`ResetWorkflowExecutionRequest` Protobuf message](https://api-docs.temporal.io/#temporal.api.workflowservice.v1.ResetWorkflowExecutionRequest) to the `Temporal.reset_workflow` API:
- `request_id` (an idempotency key)
- `reset_reapply_type` (used to optionally replay signals when resetting workflows)

This PR also adds integration tests for workflow resets, including tests for each of the above added arguments.

### Note: backwards compatibility

I attempted to make the API changes backwards compatible. However, I'm not sure if the `Temporal.reset_workflow` is used much in production, anyways, because I believe it has been broken ever since [Temporal Server v1.14.0](https://github.com/temporalio/temporal/releases/tag/v1.14.0) made the change that the `request_id` field must not be empty (in https://github.com/temporalio/temporal/pull/2141). Before my PR, temporal-ruby wasn't setting this field on the Protobuf object, causing it to use the zero value (empty string). This caused the Temporal Server to always respond with a gRPC "invalid argument" error.

I fixed this in this PR by falling back to a random UUID if the `request_id` is not specified. This is consistent with what the Go SDK does ([source](https://github.com/temporalio/sdk-go/blob/e1d76b7c798828302980d483f0981128c97a20c2/internal/internal_workflow_client.go#L952-L972)).

#### Reproduction of broken behavior

This can be reproduced by:

1. Checking out any tag on https://github.com/temporalio/docker-compose **after v1.14.0 (inclusive)**, and running `docker-compose up`
2. Creating the example namespace (`(cd examples && ./bin/register_namespace ruby-samples)`)
3. Running the example worker (`(cd examples && ./bin/worker)`
4. Running `(cd examples && ./bin/trigger QueryWorkflow)`. Note the workflow_id for the workflow this starts:
    ```sh
    $ (cd examples && ./bin/trigger QueryWorkflow)                                                                                                                                                                                                    
    I, [2023-07-11T16:22:25.593108 #603]  INFO -- temporal_client: Started workflow {"workflow_id":"bd442477-7348-428e-b40f-89793471a071","run_id":"14b8f6f5-6e6b-4f8d-ba96-d6c449fdbb34"}
    
    # Store the workflow_id:
    $ workflow_id="bd442477-7348-428e-b40f-89793471a071"
    ```

5. Running `(cd examples && ./bin/reset ruby-samples "$workflow_id")`:
    ```
    $ (cd examples && ./bin/reset ruby-samples "$workflow_id")
    Traceback (most recent call last):
    	...
    .../gems/grpc-1.56.0/src/ruby/lib/grpc/generic/active_call.rb:29:in `check_status': 3:RequestId is not set on request.. debug_error_string:{UNKNOWN:Error received from peer  {grpc_message:"RequestId is not set on request.", grpc_status:3, created_time:"2023-07-11T16:20:36.345632-07:00"}} (GRPC::InvalidArgument)
    ```