### PR TITLE
ProtoJSON safely encode JSON to ASCII-8BIT (String#b)

### DIFF
--- a/lib/temporal/connection/converter/payload/proto_json.rb
+++ b/lib/temporal/connection/converter/payload/proto_json.rb
@@ -25,7 +25,7 @@ module Temporal
                 'encoding' => ENCODING,
                 'messageType' => data.class.descriptor.name,
               },
-              data: data.to_json,
+              data: data.to_json.b,
             )
           end
         end

--- a/spec/unit/lib/temporal/connection/converter/payload/proto_json_spec.rb
+++ b/spec/unit/lib/temporal/connection/converter/payload/proto_json_spec.rb
@@ -15,6 +15,13 @@ describe Temporal::Connection::Converter::Payload::ProtoJSON do
 
       expect(subject.from_payload(subject.to_payload(input))).to eq(input)
     end
+
+    it 'encodes special characters' do
+      input = Temporalio::Api::Common::V1::Payload.new(
+        metadata: { 'it’ll work!' => 'bytebytebyte' },
+      )
+      expect(subject.from_payload(subject.to_payload(input))).to eq(input)
+    end
   end
 
   it 'skips if not proto message' do


### PR DESCRIPTION
ProtoJSON `data` bytes support w/ [`String#b`](https://apidock.com/ruby/String/b)

https://github.com/coinbase/temporal-ruby/issues/263

`JSON` payload converter does the same [here](https://github.com/coinbase/temporal-ruby/blob/80f00631a0254508e23defac0d50a98af62301ed/lib/temporal/connection/converter/payload/json.rb#L21).