### PR TITLE
Fix continue as new timeout propagation

### DIFF
--- a/lib/temporal/connection/serializer/continue_as_new.rb
+++ b/lib/temporal/connection/serializer/continue_as_new.rb
@@ -16,7 +16,7 @@ module Temporal
                 workflow_type: Temporalio::Api::Common::V1::WorkflowType.new(name: object.workflow_type),
                 task_queue: Temporalio::Api::TaskQueue::V1::TaskQueue.new(name: object.task_queue),
                 input: to_payloads(object.input),
-                workflow_run_timeout: object.timeouts[:execution],
+                workflow_run_timeout: object.timeouts[:run],
                 workflow_task_timeout: object.timeouts[:task],
                 retry_policy: Temporal::Connection::Serializer::RetryPolicy.new(object.retry_policy).to_proto,
                 header: serialize_headers(object.headers),

--- a/spec/unit/lib/temporal/connection/serializer/continue_as_new_spec.rb
+++ b/spec/unit/lib/temporal/connection/serializer/continue_as_new_spec.rb
@@ -4,11 +4,16 @@ require 'temporal/workflow/command'
 describe Temporal::Connection::Serializer::ContinueAsNew do
   describe 'to_proto' do
     it 'produces a protobuf' do
+      timeouts = {
+        execution: 1000,
+        run: 100,
+        task: 10
+      }
       command = Temporal::Workflow::Command::ContinueAsNew.new(
         workflow_type: 'my-workflow-type',
         task_queue: 'my-task-queue',
         input: ['one', 'two'],
-        timeouts: Temporal.configuration.timeouts,
+        timeouts: timeouts,
         headers: {'foo-header': 'bar'},
         memo: {'foo-memo': 'baz'},
         search_attributes: {'foo-search-attribute': 'qux'},
@@ -33,6 +38,9 @@ describe Temporal::Connection::Serializer::ContinueAsNew do
       expect(attribs.header.fields['foo-header'].data).to eq('"bar"')
       expect(attribs.memo.fields['foo-memo'].data).to eq('"baz"')
       expect(attribs.search_attributes.indexed_fields['foo-search-attribute'].data).to eq('"qux"')
+
+      expect(attribs.workflow_run_timeout.seconds).to eq(timeouts[:run])
+      expect(attribs.workflow_task_timeout.seconds).to eq(timeouts[:task])
     end
   end
 end


### PR DESCRIPTION
When continuing as new, the execution timeout is being set as the run timeout on the next run. This change corrects this small typo. The execution timeout cannot be changed on subsequent runs, and therefore doesn't need to be used here at all. The existing spec for continue as new has been updated to cover this case.