### PR TITLE
Add option for gRPC client connection retries

### DIFF
--- a/lib/temporal/configuration.rb
+++ b/lib/temporal/configuration.rb
@@ -12,13 +12,13 @@ require 'temporal/connection/converter/codec/chain'
 
 module Temporal
   class Configuration
-    Connection = Struct.new(:type, :host, :port, :credentials, :identity, keyword_init: true)
+    Connection = Struct.new(:type, :host, :port, :credentials, :identity, :connection_options, keyword_init: true)
     Execution = Struct.new(:namespace, :task_queue, :timeouts, :headers, :search_attributes, keyword_init: true)
 
     attr_reader :timeouts, :error_handlers, :capabilities
     attr_accessor :connection_type, :converter, :use_error_serialization_v2, :host, :port, :credentials, :identity,
                   :logger, :metrics_adapter, :namespace, :task_queue, :headers, :search_attributes, :header_propagators,
-                  :payload_codec, :legacy_signals, :no_signals_in_first_task
+                  :payload_codec, :legacy_signals, :no_signals_in_first_task, :connection_options
 
     # See https://docs.temporal.io/blog/activity-timeouts/ for general docs.
     # We want an infinite execution timeout for cron schedules and other perpetual workflows.
@@ -84,6 +84,7 @@ module Temporal
       @search_attributes = {}
       @header_propagators = []
       @capabilities = Capabilities.new(self)
+      @connection_options = {}
 
       # Signals previously were incorrectly replayed in order within a workflow task window, rather
       # than at the beginning. Correcting this changes the determinism of any workflow with signals.
@@ -120,7 +121,8 @@ module Temporal
         host: host,
         port: port,
         credentials: credentials,
-        identity: identity || default_identity
+        identity: identity || default_identity,
+        connection_options: connection_options
       ).freeze
     end
 

--- a/lib/temporal/connection.rb
+++ b/lib/temporal/connection.rb
@@ -12,8 +12,9 @@ module Temporal
       port = configuration.port
       credentials = configuration.credentials
       identity = configuration.identity
+      options = configuration.connection_options
 
-      connection_class.new(host, port, identity, credentials)
+      connection_class.new(host, port, identity, credentials, options)
     end
   end
 end

--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -804,8 +804,16 @@ module Temporal
           channel_args["grpc.keepalive_time_ms"] = options[:keepalive_time_ms]
         end
 
-        if options[:retry_connection]
+        if options[:retry_connection] || options[:retry_policy]
           channel_args["grpc.enable_retries"] = 1
+
+          retry_policy = options[:retry_policy] || {
+            retryableStatusCodes: ["UNAVAILABLE"],
+            maxAttempts: 3,
+            initialBackoff: "0.1s",
+            backoffMultiplier: 2.0,
+            maxBackoff: "0.3s"
+          }
 
           channel_args["grpc.service_config"] = ::JSON.generate(
             methodConfig: [
@@ -815,13 +823,7 @@ module Temporal
                     service: "temporal.api.workflowservice.v1.WorkflowService",
                   }
                 ],
-                retryPolicy: {
-                  retryableStatusCodes: ["UNAVAILABLE"],
-                  maxAttempts: 3,
-                  initialBackoff: "0.1s",
-                  backoffMultiplier: 2.0,
-                  maxBackoff: "0.3s"
-                }
+                retryPolicy: retry_policy
               }
             ]
           )

--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -795,11 +795,21 @@ module Temporal
       attr_reader :url, :identity, :credentials, :options, :poll_mutex, :poll_request
 
       def client
-        @client ||= Temporalio::Api::WorkflowService::V1::WorkflowService::Stub.new(
+        return @client if @client
+
+        channel_args = {}
+
+        if options[:keepalive_time_ms]
+          channel_args["grpc.keepalive_time_ms"] = options[:keepalive_time_ms]
+        end
+
+        @client = Temporalio::Api::WorkflowService::V1::WorkflowService::Stub.new(
           url,
           credentials,
           timeout: CONNECTION_TIMEOUT_SECONDS,
-          interceptors: [ClientNameVersionInterceptor.new]
+          interceptors: [ClientNameVersionInterceptor.new],
+          channel_args: channel_args
+
         )
       end
 

--- a/spec/unit/lib/temporal/grpc_spec.rb
+++ b/spec/unit/lib/temporal/grpc_spec.rb
@@ -830,4 +830,27 @@ describe Temporal::Connection::GRPC do
       end
     end
   end
+
+  describe "passing in options" do
+    before do
+      allow(subject).to receive(:client).and_call_original
+    end
+
+    context "when keepalive_time_ms is passed" do
+      subject { Temporal::Connection::GRPC.new(nil, nil, identity, :this_channel_is_insecure, keepalive_time_ms: 30_000) }
+
+      it "passes the option to the channel args" do
+        expect(Temporalio::Api::WorkflowService::V1::WorkflowService::Stub).to receive(:new).with(
+          ":",
+          :this_channel_is_insecure,
+          timeout: 60,
+          interceptors: [instance_of(Temporal::Connection::ClientNameVersionInterceptor)],
+          channel_args: {
+            "grpc.keepalive_time_ms" => 30_000
+          }
+        )
+        subject.send(:client)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add a config option for a basic gRPC connection retry policy:

``` ruby
config.connection_options = {
  retry_connection: true
}
```

That uses a basic policy:

```ruby
{
  retryableStatusCodes: ["UNAVAILABLE"],
  maxAttempts: 3,
  initialBackoff: "0.1s",
  backoffMultiplier: 2.0,
  maxBackoff: "0.3s"
}
```

There’s also a `retry_policy` option to set a custom policy if you want more control:

``` ruby
config.connection_options = {
  retry_policy: {
    retryableStatusCodes: ["UNAVAILABLE", "INTERNAL"],
    maxAttempts: 5,
    initialBackoff: "0.1s",
    backoffMultiplier: 2.5,
    maxBackoff: "0.7s"
  }
}
```