### PR TITLE
Improve thread pool error handling

### DIFF
--- a/lib/temporal/activity/poller.rb
+++ b/lib/temporal/activity/poller.rb
@@ -115,6 +115,7 @@ module Temporal
       def thread_pool
         @thread_pool ||= ThreadPool.new(
           options[:thread_pool_size],
+          @config,
           {
             pool_name: 'activity_task_poller',
             namespace: namespace,
@@ -126,6 +127,7 @@ module Temporal
       def heartbeat_thread_pool
         @heartbeat_thread_pool ||= ScheduledThreadPool.new(
           options[:thread_pool_size],
+          @config,
           {
             pool_name: 'heartbeat',
             namespace: namespace,

--- a/lib/temporal/activity/poller.rb
+++ b/lib/temporal/activity/poller.rb
@@ -61,6 +61,9 @@ module Temporal
       end
 
       def poll_loop
+        # Prevent the poller thread from silently dying
+        Thread.current.abort_on_exception = true
+
         last_poll_time = Time.now
         metrics_tags = { namespace: namespace, task_queue: task_queue }.freeze
 

--- a/lib/temporal/activity/task_processor.rb
+++ b/lib/temporal/activity/task_processor.rb
@@ -47,7 +47,7 @@ module Temporal
 
         respond_failed(error)
       ensure
-        unless context.heartbeat_check_scheduled.nil?
+        unless context&.heartbeat_check_scheduled.nil?
           heartbeat_thread_pool.cancel(context.heartbeat_check_scheduled)
         end
 

--- a/lib/temporal/scheduled_thread_pool.rb
+++ b/lib/temporal/scheduled_thread_pool.rb
@@ -9,11 +9,12 @@ module Temporal
 
     ScheduledItem = Struct.new(:id, :job, :fire_at, :canceled, keyword_init: true)
 
-    def initialize(size, metrics_tags)
+    def initialize(size, config, metrics_tags)
       @size = size
       @metrics_tags = metrics_tags
       @queue = Queue.new
       @mutex = Mutex.new
+      @config = config
       @available_threads = size
       @occupied_threads = {}
       @pool = Array.new(size) do |_i|
@@ -92,7 +93,16 @@ module Temporal
           # reliably be stopped once running. It's still in the begin/rescue block
           # so that it won't be executed if the thread gets canceled.
           if !item.canceled
-            item.job.call
+            begin
+              item.job.call
+            rescue StandardError => e
+              Temporal.logger.error('Error reached top of thread pool thread', { error: e.inspect })
+              Temporal::ErrorHandler.handle(e, @config)
+            rescue Exception => ex
+              Temporal.logger.error('Exception reached top of thread pool thread', { error: ex.inspect })
+              Temporal::ErrorHandler.handle(ex, @config)
+              raise
+            end
           end
         rescue CancelError
         end

--- a/lib/temporal/scheduled_thread_pool.rb
+++ b/lib/temporal/scheduled_thread_pool.rb
@@ -66,6 +66,8 @@ module Temporal
     EXIT_SYMBOL = :exit
 
     def poll
+      Thread.current.abort_on_exception = true
+
       loop do
         item = @queue.pop
         if item == EXIT_SYMBOL

--- a/lib/temporal/thread_pool.rb
+++ b/lib/temporal/thread_pool.rb
@@ -55,6 +55,8 @@ module Temporal
     EXIT_SYMBOL = :exit
 
     def poll
+      Thread.current.abort_on_exception = true
+
       catch(EXIT_SYMBOL) do
         loop do
           job = @queue.pop

--- a/lib/temporal/thread_pool.rb
+++ b/lib/temporal/thread_pool.rb
@@ -11,11 +11,12 @@ module Temporal
   class ThreadPool
     attr_reader :size
 
-    def initialize(size, metrics_tags)
+    def initialize(size, config, metrics_tags)
       @size = size
       @metrics_tags = metrics_tags
       @queue = Queue.new
       @mutex = Mutex.new
+      @config = config
       @availability = ConditionVariable.new
       @available_threads = size
       @pool = Array.new(size) do |_i|
@@ -60,7 +61,16 @@ module Temporal
       catch(EXIT_SYMBOL) do
         loop do
           job = @queue.pop
-          job.call
+          begin
+            job.call
+          rescue StandardError => e
+            Temporal.logger.error('Error reached top of thread pool thread', { error: e.inspect })
+            Temporal::ErrorHandler.handle(e, @config)
+          rescue Exception => ex
+            Temporal.logger.error('Exception reached top of thread pool thread', { error: ex.inspect })
+            Temporal::ErrorHandler.handle(ex, @config)
+            raise
+          end
           @mutex.synchronize do
             @available_threads += 1
             @availability.signal

--- a/lib/temporal/workflow/poller.rb
+++ b/lib/temporal/workflow/poller.rb
@@ -117,6 +117,7 @@ module Temporal
       def thread_pool
         @thread_pool ||= ThreadPool.new(
           options[:thread_pool_size],
+          @config,
           {
             pool_name: 'workflow_task_poller',
             namespace: namespace,

--- a/lib/temporal/workflow/poller.rb
+++ b/lib/temporal/workflow/poller.rb
@@ -63,6 +63,9 @@ module Temporal
       end
 
       def poll_loop
+        # Prevent the poller thread from silently dying
+        Thread.current.abort_on_exception = true
+
         last_poll_time = Time.now
         metrics_tags = { namespace: namespace, task_queue: task_queue }.freeze
 

--- a/spec/unit/lib/temporal/activity/context_spec.rb
+++ b/spec/unit/lib/temporal/activity/context_spec.rb
@@ -3,7 +3,7 @@ require 'temporal/metadata/activity'
 require 'temporal/scheduled_thread_pool'
 
 describe Temporal::Activity::Context do
-  let(:client) { instance_double('Temporal::Client::GRPCClient') }
+  let(:connection) { instance_double('Temporal::Connection::GRPC') }
   let(:metadata_hash) { Fabricate(:activity_metadata).to_h }
   let(:metadata) { Temporal::Metadata::Activity.new(**metadata_hash) }
   let(:config) { Temporal::Configuration.new }
@@ -11,15 +11,15 @@ describe Temporal::Activity::Context do
   let(:heartbeat_thread_pool) { Temporal::ScheduledThreadPool.new(1, config, {}) }
   let(:heartbeat_response) { Fabricate(:api_record_activity_heartbeat_response) }
 
-  subject { described_class.new(client, metadata, config, heartbeat_thread_pool) }
+  subject { described_class.new(connection, metadata, config, heartbeat_thread_pool) }
 
   describe '#heartbeat' do
-    before { allow(client).to receive(:record_activity_task_heartbeat).and_return(heartbeat_response) }
+    before { allow(connection).to receive(:record_activity_task_heartbeat).and_return(heartbeat_response) }
 
     it 'records heartbeat' do
       subject.heartbeat
 
-      expect(client)
+      expect(connection)
         .to have_received(:record_activity_task_heartbeat)
         .with(namespace: metadata.namespace, task_token: metadata.task_token, details: nil)
     end
@@ -27,7 +27,7 @@ describe Temporal::Activity::Context do
     it 'records heartbeat with details' do
       subject.heartbeat(foo: :bar)
 
-      expect(client)
+      expect(connection)
         .to have_received(:record_activity_task_heartbeat)
         .with(namespace: metadata.namespace, task_token: metadata.task_token, details: { foo: :bar })
     end
@@ -48,7 +48,7 @@ describe Temporal::Activity::Context do
             subject.heartbeat(iteration: i)
           end
 
-          expect(client)
+          expect(connection)
             .to have_received(:record_activity_task_heartbeat)
             .with(namespace: metadata.namespace, task_token: metadata.task_token, details: { iteration: 0 })
             .once
@@ -67,7 +67,7 @@ describe Temporal::Activity::Context do
           # Shutdown to drain remaining threads
           heartbeat_thread_pool.shutdown
 
-          expect(client)
+          expect(connection)
             .to have_received(:record_activity_task_heartbeat)
             .ordered
             .with(namespace: metadata.namespace, task_token: metadata.task_token, details: { iteration: 1 })
@@ -80,7 +80,7 @@ describe Temporal::Activity::Context do
         config.timeouts = { max_heartbeat_throttle_interval: 0 }
         subject.heartbeat
 
-        expect(client)
+        expect(connection)
           .to have_received(:record_activity_task_heartbeat)
           .with(namespace: metadata.namespace, task_token: metadata.task_token, details: nil)
 
@@ -90,17 +90,18 @@ describe Temporal::Activity::Context do
   end
 
   describe '#last_heartbeat_throttled' do
-    before { allow(client).to receive(:record_activity_task_heartbeat).and_return(heartbeat_response) }
+    before { allow(connection).to receive(:record_activity_task_heartbeat).and_return(heartbeat_response) }
 
-    let(:metadata_hash) { Fabricate(:activity_metadata, heartbeat_timeout: 10).to_h }
+    let(:metadata_hash) { Fabricate(:activity_metadata, heartbeat_timeout: 3).to_h }
 
     it 'true when throttled, false when not' do
       subject.heartbeat(iteration: 1)
       expect(subject.last_heartbeat_throttled).to be(false)
       subject.heartbeat(iteration: 2)
       expect(subject.last_heartbeat_throttled).to be(true)
-      subject.heartbeat(iteration: 3)
-      expect(subject.last_heartbeat_throttled).to be(true)
+
+      # Shutdown to drain remaining threads
+      heartbeat_thread_pool.shutdown
     end
   end
 
@@ -120,7 +121,7 @@ describe Temporal::Activity::Context do
 
   describe '#async?' do
     subject { context.async? }
-    let(:context) { described_class.new(client, metadata, nil, nil) }
+    let(:context) { described_class.new(connection, metadata, nil, nil) }
 
     context 'when context is sync' do
       it { is_expected.to eq(false) }

--- a/spec/unit/lib/temporal/activity/context_spec.rb
+++ b/spec/unit/lib/temporal/activity/context_spec.rb
@@ -8,7 +8,7 @@ describe Temporal::Activity::Context do
   let(:metadata) { Temporal::Metadata::Activity.new(**metadata_hash) }
   let(:config) { Temporal::Configuration.new }
   let(:task_token) { SecureRandom.uuid }
-  let(:heartbeat_thread_pool) { Temporal::ScheduledThreadPool.new(1, {}) }
+  let(:heartbeat_thread_pool) { Temporal::ScheduledThreadPool.new(1, config, {}) }
   let(:heartbeat_response) { Fabricate(:api_record_activity_heartbeat_response) }
 
   subject { described_class.new(client, metadata, config, heartbeat_thread_pool) }

--- a/spec/unit/lib/temporal/scheduled_thread_pool_spec.rb
+++ b/spec/unit/lib/temporal/scheduled_thread_pool_spec.rb
@@ -5,9 +5,10 @@ describe Temporal::ScheduledThreadPool do
     allow(Temporal.metrics).to receive(:gauge)
   end
 
+  let(:config) { Temporal::Configuration.new }
   let(:size) { 2 }
   let(:tags) { { foo: 'bar', bat: 'baz' } }
-  let(:thread_pool) { described_class.new(size, tags) }
+  let(:thread_pool) { described_class.new(size, config, tags) }
 
   describe '#schedule' do
     it 'executes one task with zero delay on a thread and exits' do

--- a/spec/unit/lib/temporal/scheduled_thread_pool_spec.rb
+++ b/spec/unit/lib/temporal/scheduled_thread_pool_spec.rb
@@ -40,6 +40,38 @@ describe Temporal::ScheduledThreadPool do
       expect(answers.pop).to eq(:first)
       expect(answers.pop).to eq(:second)
     end
+
+    it 'error does not exit' do
+      times = 0
+
+      thread_pool.schedule(:foo, 0) do
+        times += 1
+        raise 'foo'
+      end
+
+      thread_pool.shutdown
+
+      expect(times).to eq(1)
+    end
+
+    it 'exception does exit' do
+      Thread.report_on_exception = false
+      times = 0
+
+      thread_pool.schedule(:foo, 0) do
+        times += 1
+        raise Exception, 'crash'
+      end
+
+      begin
+        thread_pool.shutdown
+        raise 'should not be reached'
+      rescue Exception => e
+        'ok'
+      end
+
+      expect(times).to eq(1)
+    end
   end
 
   describe '#cancel' do

--- a/spec/unit/lib/temporal/thread_pool_spec.rb
+++ b/spec/unit/lib/temporal/thread_pool_spec.rb
@@ -23,6 +23,37 @@ describe Temporal::ThreadPool do
       expect(times).to eq(1)
     end
 
+    it 'handles error without exiting' do
+      times = 0
+
+      thread_pool.schedule do
+        times += 1
+        raise 'failure'
+      end
+
+      thread_pool.shutdown
+
+      expect(times).to eq(1)
+    end
+
+    it 'handles exception with exiting' do
+      Thread.report_on_exception = false
+      times = 0
+
+      thread_pool.schedule do
+        times += 1
+        raise Exception, 'crash'
+      end
+
+      begin
+        thread_pool.shutdown
+      rescue Exception => e
+        'ok'
+      end
+
+      expect(times).to eq(1)
+    end
+
     it 'reports thread available metrics' do
       thread_pool.schedule do
       end

--- a/spec/unit/lib/temporal/thread_pool_spec.rb
+++ b/spec/unit/lib/temporal/thread_pool_spec.rb
@@ -5,9 +5,10 @@ describe Temporal::ThreadPool do
     allow(Temporal.metrics).to receive(:gauge)
   end
 
+  let(:config) { Temporal::Configuration.new }
   let(:size) { 2 }
   let(:tags) { { foo: 'bar', bat: 'baz' } }
-  let(:thread_pool) { described_class.new(size, tags) }
+  let(:thread_pool) { described_class.new(size, config, tags) }
 
   describe '#new' do
     it 'executes one task on a thread and exits' do


### PR DESCRIPTION
### Summary

All errors and exceptions coming out of a thread pool job are now logged and sent to the error handler

If any error does reach the top of the stack on a thread pool thread, it will now crash the process rather than silently kill the thread. Because `StandardError` is rescued in the `TaskProcessor`, this impacts only severe errors like `NoMemoryError` or `SecurityError` raised by activity or workflow code, or ordinary error raised due to bugs in temporal-ruby itself.

It's perhaps somewhat controversial to crash the worker process, but `Exception` raised out of user code or unexpected errors in the pollers, task processors, or thread pools, leave the worker in an unknown state, where it's unclear that it can continue to safely process work.

### Motivation

Before this change, when an activity or workflow task raises an error that is not a subclass of `StandardError`, it silently kills the thread pool thread it is running on. Additionally, _any_ errors in the ensure/rescue blocks in the pollers, task processors or the thread pool will cause this same behavior. Eventually, workers can run out of thread pool threads and become "zombie" workers that will stop polling for tasks, all while logging no errors.

For example, I've seen this occur when an error raised by an activity contains a circular reference. When Oj tries to serialize it, it will run out of memory and raise `NoMemoryError`. This is a subclass of `Exception` not `StandardError`, and therefore is not caught by an ordinary `rescue => e` clause. Eventually this reaches the top of the activity task thread pool thread and causes it to silently exit before it can increment the `available_threads` and signal the `availability` condition variable to free up resources. Memory frees up at this point, so the worker continues to run, but other failures may have occurred on other threads in the process during this period of memory exhaustion, leaving the worker in an unknown state. The activity will then be retried after it times out, which in turn kills another thread on one of the workers. If this happens enough times between worker service restarts, the entire worker fleet will not be able to process any activities.

### Testing

There are new specs for these thread pool cases in both regular and scheduled thread pools. Some other specs also had to be updated because they had errors throwing on a background thread that started surfacing hidden failures.