### PR TITLE
Remove cancelation commands when underlying futures are closed

### DIFF
--- a/examples/spec/integration/activity_cancellation_spec.rb
+++ b/examples/spec/integration/activity_cancellation_spec.rb
@@ -33,4 +33,19 @@ describe 'Activity cancellation', :integration do
     expect(result).to be_a(Temporal::ActivityCanceled)
     expect(result.message).to eq('ACTIVITY_ID_NOT_STARTED')
   end
+
+  it 'cancels a running activity around the time it completes' do
+    workflow_id, run_id = run_workflow(LongWorkflow, 1, 0.5)
+
+    sleep 0.4
+    Temporal.signal_workflow(LongWorkflow, :CANCEL, workflow_id, run_id)
+
+    result = Temporal.await_workflow_result(
+      LongWorkflow,
+      workflow_id: workflow_id,
+      run_id: run_id,
+    )
+
+    expect(result).to be_nil
+  end
 end

--- a/examples/spec/integration/activity_cancellation_spec.rb
+++ b/examples/spec/integration/activity_cancellation_spec.rb
@@ -33,19 +33,4 @@ describe 'Activity cancellation', :integration do
     expect(result).to be_a(Temporal::ActivityCanceled)
     expect(result.message).to eq('ACTIVITY_ID_NOT_STARTED')
   end
-
-  it 'cancels a running activity around the time it completes' do
-    workflow_id, run_id = run_workflow(LongWorkflow, 1, 0.5)
-
-    sleep 0.4
-    Temporal.signal_workflow(LongWorkflow, :CANCEL, workflow_id, run_id)
-
-    result = Temporal.await_workflow_result(
-      LongWorkflow,
-      workflow_id: workflow_id,
-      run_id: run_id,
-    )
-
-    expect(result).to be_nil
-  end
 end

--- a/lib/temporal/workflow/command_state_machine.rb
+++ b/lib/temporal/workflow/command_state_machine.rb
@@ -48,6 +48,14 @@ module Temporal
       def time_out
         @state = TIMED_OUT_STATE
       end
+
+      def closed?
+        @state == COMPLETED_STATE ||
+          @state == CANCELED_STATE ||
+          @state == FAILED_STATE ||
+          @state == TIMED_OUT_STATE ||
+          @state == TERMINATED_STATE
+      end
     end
   end
 end

--- a/lib/temporal/workflow/executor.rb
+++ b/lib/temporal/workflow/executor.rb
@@ -42,7 +42,7 @@ module Temporal
           state_manager.apply(window)
         end
 
-        RunResult.new(commands: state_manager.commands, new_sdk_flags_used: state_manager.new_sdk_flags_used)
+        RunResult.new(commands: state_manager.final_commands, new_sdk_flags_used: state_manager.new_sdk_flags_used)
       end
 
       # Process queries using the pre-registered query handlers

--- a/spec/unit/lib/temporal/workflow/state_manager_spec.rb
+++ b/spec/unit/lib/temporal/workflow/state_manager_spec.rb
@@ -489,8 +489,8 @@ describe Temporal::Workflow::StateManager do
       )
       state_manager.schedule(cancel_activity_command)
 
-      cancel_timer_command = Temporal::Workflow::Command::RequestActivityCancellation.new(
-        activity_id: start_timer_command.timer_id
+      cancel_timer_command = Temporal::Workflow::Command::CancelTimer.new(
+        timer_id: start_timer_command.timer_id
       )
       state_manager.schedule(cancel_timer_command)
 

--- a/spec/unit/lib/temporal/workflow/state_manager_spec.rb
+++ b/spec/unit/lib/temporal/workflow/state_manager_spec.rb
@@ -469,6 +469,89 @@ describe Temporal::Workflow::StateManager do
     end
   end
 
+  describe "#final_commands" do
+    let(:dispatcher) { Temporal::Workflow::Dispatcher.new }
+    let(:state_manager) do
+      Temporal::Workflow::StateManager.new(dispatcher, config)
+    end
+
+    let(:config) { Temporal::Configuration.new }
+
+    it "preserves canceled activity or timer commands when not completed" do
+      schedule_activity_command = Temporal::Workflow::Command::ScheduleActivity.new
+      state_manager.schedule(schedule_activity_command)
+
+      start_timer_command = Temporal::Workflow::Command::StartTimer.new
+      state_manager.schedule(start_timer_command)
+
+      cancel_activity_command = Temporal::Workflow::Command::RequestActivityCancellation.new(
+        activity_id: schedule_activity_command.activity_id
+      )
+      state_manager.schedule(cancel_activity_command)
+
+      cancel_timer_command = Temporal::Workflow::Command::RequestActivityCancellation.new(
+        activity_id: start_timer_command.timer_id
+      )
+      state_manager.schedule(cancel_timer_command)
+
+      expect(state_manager.final_commands).to(
+        eq(
+          [
+            [1, schedule_activity_command],
+            [2, start_timer_command],
+            [3, cancel_activity_command],
+            [4, cancel_timer_command]
+          ]
+        )
+      )
+    end
+
+    it "drop cancel activity command when completed" do
+      schedule_activity_command = Temporal::Workflow::Command::ScheduleActivity.new
+      state_manager.schedule(schedule_activity_command)
+
+      cancel_command = Temporal::Workflow::Command::RequestActivityCancellation.new(
+        activity_id: schedule_activity_command.activity_id
+      )
+      state_manager.schedule(cancel_command)
+
+      # Fake completing the activity
+      window = Temporal::Workflow::History::Window.new
+      # The fake assumes an activity event completed two events ago, so fix the event id to +2
+      window.add(
+        Temporal::Workflow::History::Event.new(
+          Fabricate(:api_activity_task_completed_event, event_id: schedule_activity_command.activity_id + 2)
+        )
+      )
+      state_manager.apply(window)
+
+      expect(state_manager.final_commands).to(eq([[1, schedule_activity_command]]))
+    end
+
+    it "drop cancel timer command when completed" do
+      start_timer_command = Temporal::Workflow::Command::StartTimer.new
+      state_manager.schedule(start_timer_command)
+
+      cancel_command = Temporal::Workflow::Command::CancelTimer.new(
+        timer_id: start_timer_command.timer_id
+      )
+      state_manager.schedule(cancel_command)
+
+      # Fake completing the timer
+      window = Temporal::Workflow::History::Window.new
+      # The fake assumes an activity event completed four events ago, so fix the event id to +4
+      window.add(
+        Temporal::Workflow::History::Event.new(
+          Fabricate(:api_timer_fired_event, event_id: start_timer_command.timer_id + 4)
+        )
+      )
+      state_manager.apply(window)
+
+      expect(state_manager.final_commands).to(eq([[1, start_timer_command]]))
+    end
+  end
+
+
   describe '#search_attributes' do
     let(:initial_search_attributes) do
       {


### PR DESCRIPTION
### Summary
This change filters out activity and timer cancellation commands before sending back the result of the workflow task to Temporal server. It does this when those commands are associated with activities or timers that have already been canceled.

### Motivation
Existing code in `future.rb` already ensures that cancellation is a no-op on activity and timer futures that have already completed at that point in workflow execution. However, this doesn't cover all cases where an activity or timer is being canceled in the same workflow task where it is completing or failing. Consider the following scenario:

In an earlier workflow task:
- An activity is scheduled by starting an activity in workflow code

In a later workflow task:
- A signal is received, which has a handler that cancels the activity. This will produce a `RequestCancelActivityTaskCommand` which is put in a list to be sent back to the Temporal server.
- The activity completes or fails

Because the future will still not be complete when the signal is received, it will be canceled and the command produced. However, later in the processing of the history window, we encounter a history event indicating that cancellation is not valid because the activity has already finished. When the `RequestCancelActivityTaskCommand` is sent to Temporal server, it will reject it as invalid and retry the workflow task. This will continue indefinitely, putting the workflow in a "stuck" state.

### Testing
- Adds a new integration spec that reproduces this race condition
- Adds some new unit specs for the state manager that precisely tests this filtering behavior