### PR TITLE
Add Schedule api support

### DIFF
--- a/examples/spec/integration/create_schedule_spec.rb
+++ b/examples/spec/integration/create_schedule_spec.rb
@@ -1,0 +1,87 @@
+require "temporal/errors"
+require "temporal/schedule/backfill"
+require "temporal/schedule/calendar"
+require "temporal/schedule/interval"
+require "temporal/schedule/schedule"
+require "temporal/schedule/schedule_spec"
+require "temporal/schedule/schedule_policies"
+require "temporal/schedule/schedule_state"
+require "temporal/schedule/start_workflow_action"
+
+describe "Temporal.create_schedule", :integration do
+  let(:example_schedule) do
+    workflow_id = SecureRandom.uuid
+    Temporal::Schedule::Schedule.new(
+      spec: Temporal::Schedule::ScheduleSpec.new(
+        calendars: [Temporal::Schedule::Calendar.new(day_of_week: "*", hour: "18", minute: "30")],
+        intervals: [Temporal::Schedule::Interval.new(every: 6000, offset: 300)],
+        cron_expressions: ["@hourly"],
+        jitter: 30,
+        # Set an end time so that the test schedule doesn't run forever
+        end_time: Time.now + 600
+      ),
+      action: Temporal::Schedule::StartWorkflowAction.new(
+        "HelloWorldWorkflow",
+        "Test",
+        options: {
+          workflow_id: workflow_id,
+          task_queue: Temporal.configuration.task_queue
+        }
+      ),
+      policies: Temporal::Schedule::SchedulePolicies.new(
+        overlap_policy: :buffer_one
+      ),
+      state: Temporal::Schedule::ScheduleState.new(
+        notes: "Created by integration test"
+      )
+    )
+  end
+
+  it "can create schedules" do
+    namespace = integration_spec_namespace
+
+    schedule_id = SecureRandom.uuid
+
+    create_response = Temporal.create_schedule(
+      namespace,
+      schedule_id,
+      example_schedule,
+      memo: {"schedule_memo" => "schedule memo value"},
+      trigger_immediately: true,
+      backfill: Temporal::Schedule::Backfill.new(start_time: (Date.today - 90).to_time, end_time: Time.now)
+    )
+    expect(create_response).to(be_an_instance_of(Temporalio::Api::WorkflowService::V1::CreateScheduleResponse))
+
+    describe_response = Temporal.describe_schedule(namespace, schedule_id)
+
+    expect(describe_response.memo).to(eq({"schedule_memo" => "schedule memo value"}))
+    expect(describe_response.schedule.spec.jitter.seconds).to(eq(30))
+    expect(describe_response.schedule.policies.overlap_policy).to(eq(:SCHEDULE_OVERLAP_POLICY_BUFFER_ONE))
+    expect(describe_response.schedule.action.start_workflow.workflow_type.name).to(eq("HelloWorldWorkflow"))
+    expect(describe_response.schedule.state.notes).to(eq("Created by integration test"))
+  end
+
+  it "can create schedules with a minimal set of fields" do
+    namespace = integration_spec_namespace
+    schedule_id = SecureRandom.uuid
+
+    schedule = Temporal::Schedule::Schedule.new(
+      spec: Temporal::Schedule::ScheduleSpec.new(
+        cron_expressions: ["@hourly"],
+        # Set an end time so that the test schedule doesn't run forever
+        end_time: Time.now + 600
+      ),
+      action: Temporal::Schedule::StartWorkflowAction.new(
+        "HelloWorldWorkflow",
+        "Test",
+        options: {task_queue: Temporal.configuration.task_queue}
+      )
+    )
+
+    Temporal.create_schedule(namespace, schedule_id, schedule)
+
+    describe_response = Temporal.describe_schedule(namespace, schedule_id)
+    expect(describe_response.schedule.action.start_workflow.workflow_type.name).to(eq("HelloWorldWorkflow"))
+    expect(describe_response.schedule.policies.overlap_policy).to(eq(:SCHEDULE_OVERLAP_POLICY_SKIP))
+  end
+end

--- a/examples/spec/integration/delete_schedule_spec.rb
+++ b/examples/spec/integration/delete_schedule_spec.rb
@@ -1,0 +1,50 @@
+require "temporal/errors"
+require "temporal/schedule/schedule"
+require "temporal/schedule/schedule_spec"
+require "temporal/schedule/start_workflow_action"
+
+describe "Temporal.delete_schedule", :integration do
+  let(:example_schedule) do
+    Temporal::Schedule::Schedule.new(
+      spec: Temporal::Schedule::ScheduleSpec.new(
+        cron_expressions: ["@hourly"],
+        # Set an end time so that the test schedule doesn't run forever
+        end_time: Time.now + 600
+      ),
+      action: Temporal::Schedule::StartWorkflowAction.new(
+        "HelloWorldWorkflow",
+        "Test",
+        options: {
+          task_queue: Temporal.configuration.task_queue
+        }
+      )
+    )
+  end
+
+  it "can delete schedules" do
+    namespace = integration_spec_namespace
+
+    schedule_id = SecureRandom.uuid
+
+    Temporal.create_schedule(namespace, schedule_id, example_schedule)
+    describe_response = Temporal.describe_schedule(namespace, schedule_id)
+    expect(describe_response.schedule.action.start_workflow.workflow_type.name).to(eq("HelloWorldWorkflow"))
+
+    Temporal.delete_schedule(namespace, schedule_id)
+
+    # Now that the schedule is delted it should raise a not found error
+    expect do
+      Temporal.describe_schedule(namespace, schedule_id)
+    end
+      .to(raise_error(Temporal::NotFoundFailure))
+  end
+
+  it "raises a NotFoundFailure if a schedule doesn't exist" do
+    namespace = integration_spec_namespace
+
+    expect do
+      Temporal.delete_schedule(namespace, "some-invalid-schedule-id")
+    end
+      .to(raise_error(Temporal::NotFoundFailure))
+  end
+end

--- a/examples/spec/integration/list_schedules_spec.rb
+++ b/examples/spec/integration/list_schedules_spec.rb
@@ -1,0 +1,109 @@
+require "timeout"
+require "temporal/errors"
+require "temporal/schedule/backfill"
+require "temporal/schedule/calendar"
+require "temporal/schedule/interval"
+require "temporal/schedule/schedule"
+require "temporal/schedule/schedule_spec"
+require "temporal/schedule/schedule_policies"
+require "temporal/schedule/schedule_state"
+require "temporal/schedule/start_workflow_action"
+
+describe "Temporal.list_schedules", :integration do
+  let(:example_schedule) do
+    workflow_id = SecureRandom.uuid
+    Temporal::Schedule::Schedule.new(
+      spec: Temporal::Schedule::ScheduleSpec.new(
+        cron_expressions: ["@hourly"],
+        # Set an end time so that the test schedule doesn't run forever
+        end_time: Time.now + 600
+      ),
+      action: Temporal::Schedule::StartWorkflowAction.new(
+        "HelloWorldWorkflow",
+        "Test",
+        options: {
+          task_queue: Temporal.configuration.task_queue
+        }
+      )
+    )
+  end
+
+  def cleanup
+    namespace = integration_spec_namespace
+    loop do
+      resp = Temporal.list_schedules(namespace, maximum_page_size: 1000)
+      resp.schedules.each do |schedule|
+        begin
+          Temporal.delete_schedule(namespace, schedule.schedule_id)
+        rescue Temporal::NotFoundFailure
+          # This sometimes throws if a schedule has already been 'completed' (end time is reached)
+        end
+      end
+      break if resp.next_page_token == ""
+    end
+  end
+
+  before do
+    cleanup
+  end
+
+
+  it "can list schedules with pagination" do
+    namespace = integration_spec_namespace
+
+    10.times do
+      schedule_id = SecureRandom.uuid
+      Temporal.create_schedule(namespace, schedule_id, example_schedule)
+    end
+
+    # list_schedules is eventually consistent. Wait until at least 10 schedules are returned
+    Timeout.timeout(10) do
+      loop do
+        result = Temporal.list_schedules(namespace, maximum_page_size: 100)
+
+        break if result && result.schedules.count >= 10
+
+        sleep(0.5)
+      end
+    end
+
+    page_one = Temporal.list_schedules(namespace, maximum_page_size: 2)
+    expect(page_one.schedules.count).to(eq(2))
+    page_two = Temporal.list_schedules(namespace, next_page_token: page_one.next_page_token, maximum_page_size: 8)
+    expect(page_two.schedules.count).to(eq(8))
+
+    # ensure that we got dfifereent schedules in each page
+    page_two_schedule_ids = page_two.schedules.map(&:schedule_id)
+    page_one.schedules.each do |schedule|
+      expect(page_two_schedule_ids).not_to(include(schedule.schedule_id))
+    end
+  end
+
+  it "roundtrip encodes/decodes memo with payload" do
+    namespace = integration_spec_namespace
+    schedule_id = "schedule_with_encoded_memo_payload-#{SecureRandom.uuid}}"
+    Temporal.create_schedule(
+      namespace,
+      schedule_id,
+      example_schedule,
+      memo: {"schedule_memo" => "schedule memo value"}
+    )
+
+    resp = nil
+    matching_schedule = nil
+
+    # list_schedules is eventually consistent. Wait until our created schedule is returned
+    Timeout.timeout(10) do
+      loop do
+        resp = Temporal.list_schedules(namespace, maximum_page_size: 1000)
+
+        matching_schedule = resp.schedules.find { |s| s.schedule_id == schedule_id }
+        break unless matching_schedule.nil?
+
+        sleep(0.1)
+      end
+    end
+
+    expect(matching_schedule.memo).to(eq({"schedule_memo" => "schedule memo value"}))
+  end
+end

--- a/examples/spec/integration/pause_schedule_spec.rb
+++ b/examples/spec/integration/pause_schedule_spec.rb
@@ -1,0 +1,44 @@
+require "temporal/schedule/schedule"
+require "temporal/schedule/calendar"
+require "temporal/schedule/schedule_spec"
+require "temporal/schedule/schedule_policies"
+require "temporal/schedule/schedule_state"
+require "temporal/schedule/start_workflow_action"
+
+describe "Temporal.pause_schedule", :integration do
+  let(:example_schedule) do
+    Temporal::Schedule::Schedule.new(
+      spec: Temporal::Schedule::ScheduleSpec.new(
+        cron_expressions: ["@hourly"],
+        # Set an end time so that the test schedule doesn't run forever
+        end_time: Time.now + 600
+      ),
+      action: Temporal::Schedule::StartWorkflowAction.new(
+        "HelloWorldWorkflow",
+        "Test",
+        options: {
+          task_queue: Temporal.configuration.task_queue
+        }
+      )
+    )
+  end
+
+  it "can pause and unpause a schedule" do
+    namespace = integration_spec_namespace
+    schedule_id = SecureRandom.uuid
+
+    Temporal.create_schedule(namespace, schedule_id, example_schedule)
+    describe_response = Temporal.describe_schedule(namespace, schedule_id)
+    expect(describe_response.schedule.state.paused).to(eq(false))
+
+    Temporal.pause_schedule(namespace, schedule_id)
+
+    describe_response = Temporal.describe_schedule(namespace, schedule_id)
+    expect(describe_response.schedule.state.paused).to(eq(true))
+
+    Temporal.unpause_schedule(namespace, schedule_id)
+
+    describe_response = Temporal.describe_schedule(namespace, schedule_id)
+    expect(describe_response.schedule.state.paused).to(eq(false))
+  end
+end

--- a/examples/spec/integration/trigger_schedule_spec.rb
+++ b/examples/spec/integration/trigger_schedule_spec.rb
@@ -1,0 +1,49 @@
+require "timeout"
+require "temporal/schedule/schedule"
+require "temporal/schedule/calendar"
+require "temporal/schedule/schedule_spec"
+require "temporal/schedule/schedule_policies"
+require "temporal/schedule/schedule_state"
+require "temporal/schedule/start_workflow_action"
+
+describe "Temporal.trigger_schedule", :integration do
+  let(:example_schedule) do
+    Temporal::Schedule::Schedule.new(
+      spec: Temporal::Schedule::ScheduleSpec.new(
+        # Set this to a date in the future to avoid triggering the schedule immediately
+        calendars: [Temporal::Schedule::Calendar.new(year: "2055", month: "12", day_of_month: "25")]
+      ),
+      action: Temporal::Schedule::StartWorkflowAction.new(
+        "HelloWorldWorkflow",
+        "Test",
+        options: {
+          task_queue: Temporal.configuration.task_queue
+        }
+      )
+    )
+  end
+
+  it "can trigger a schedule to run immediately" do
+    namespace = integration_spec_namespace
+    schedule_id = SecureRandom.uuid
+
+    Temporal.create_schedule(namespace, schedule_id, example_schedule)
+    describe_response = Temporal.describe_schedule(namespace, schedule_id)
+    expect(describe_response.info.recent_actions.size).to(eq(0))
+
+    # Trigger the schedule and wait to see that it actually ran
+    Temporal.trigger_schedule(namespace, schedule_id, overlap_policy: :buffer_one)
+
+    Timeout.timeout(10) do
+      loop do
+        describe_response = Temporal.describe_schedule(namespace, schedule_id)
+
+        break if describe_response.info && describe_response.info.recent_actions.size >= 1
+
+        sleep(0.5)
+      end
+    end
+
+    expect(describe_response.info.recent_actions.size).to(eq(1))
+  end
+end

--- a/examples/spec/integration/update_schedule_spec.rb
+++ b/examples/spec/integration/update_schedule_spec.rb
@@ -1,0 +1,103 @@
+require "temporal/errors"
+require "temporal/schedule/schedule"
+require "temporal/schedule/schedule_spec"
+require "temporal/schedule/schedule_policies"
+require "temporal/schedule/schedule_state"
+require "temporal/schedule/start_workflow_action"
+
+describe "Temporal.update_schedule", :integration do
+  let(:example_schedule) do
+    Temporal::Schedule::Schedule.new(
+      spec: Temporal::Schedule::ScheduleSpec.new(
+        cron_expressions: ["@hourly"],
+        jitter: 30,
+        # Set an end time so that the test schedule doesn't run forever
+        end_time: Time.now + 600
+      ),
+      action: Temporal::Schedule::StartWorkflowAction.new(
+        "HelloWorldWorkflow",
+        "Test",
+        options: {
+          task_queue: Temporal.configuration.task_queue
+        }
+      ),
+      policies: Temporal::Schedule::SchedulePolicies.new(
+        overlap_policy: :buffer_one
+      ),
+      state: Temporal::Schedule::ScheduleState.new(
+        notes: "Created by integration test"
+      )
+    )
+  end
+
+  let(:updated_schedule) do
+    Temporal::Schedule::Schedule.new(
+      spec: Temporal::Schedule::ScheduleSpec.new(
+        cron_expressions: ["@hourly"],
+        jitter: 500,
+        # Set an end time so that the test schedule doesn't run forever
+        end_time: Time.now + 600
+      ),
+      action: Temporal::Schedule::StartWorkflowAction.new(
+        "HelloWorldWorkflow",
+        "UpdatedInput",
+        options: {
+          task_queue: Temporal.configuration.task_queue
+        }
+      ),
+      policies: Temporal::Schedule::SchedulePolicies.new(
+        overlap_policy: :buffer_all
+      ),
+      state: Temporal::Schedule::ScheduleState.new(
+        notes: "Updated by integration test"
+      )
+    )
+  end
+
+  it "can update schedules" do
+    namespace = integration_spec_namespace
+    schedule_id = SecureRandom.uuid
+
+    Temporal.create_schedule(namespace, schedule_id, example_schedule)
+
+    describe_response = Temporal.describe_schedule(namespace, schedule_id)
+    expect(describe_response.schedule.spec.jitter.seconds).to(eq(30))
+    expect(describe_response.schedule.policies.overlap_policy).to(eq(:SCHEDULE_OVERLAP_POLICY_BUFFER_ONE))
+    expect(describe_response.schedule.action.start_workflow.workflow_type.name).to(eq("HelloWorldWorkflow"))
+    expect(describe_response.schedule.state.notes).to(eq("Created by integration test"))
+
+    Temporal.update_schedule(namespace, schedule_id, updated_schedule)
+    updated_describe = Temporal.describe_schedule(namespace, schedule_id)
+    expect(updated_describe.schedule.spec.jitter.seconds).to(eq(500))
+    expect(updated_describe.schedule.policies.overlap_policy).to(eq(:SCHEDULE_OVERLAP_POLICY_BUFFER_ALL))
+    expect(updated_describe.schedule.state.notes).to(eq("Updated by integration test"))
+  end
+
+  it "does not update if conflict token doesnt match" do
+    namespace = integration_spec_namespace
+    schedule_id = SecureRandom.uuid
+
+    initial_response = Temporal.create_schedule(namespace, schedule_id, example_schedule)
+
+    # Update the schedule but pass the incorrect token
+    Temporal.update_schedule(namespace, schedule_id, updated_schedule, conflict_token: "invalid token")
+
+    # The schedule should not have been updated (we don't get an error message from the server in this case)
+    describe_response = Temporal.describe_schedule(namespace, schedule_id)
+    expect(describe_response.schedule.spec.jitter.seconds).to(eq(30))
+
+    # If we pass the right conflict token the update should be applied
+    Temporal.update_schedule(namespace, schedule_id, updated_schedule, conflict_token: initial_response.conflict_token)
+    updated_describe = Temporal.describe_schedule(namespace, schedule_id)
+    expect(updated_describe.schedule.spec.jitter.seconds).to(eq(500))
+  end
+
+  it "raises a NotFoundFailure if a schedule doesn't exist" do
+    namespace = integration_spec_namespace
+
+    expect do
+      Temporal.update_schedule(namespace, "some-invalid-schedule-id", updated_schedule)
+    end
+      .to(raise_error(Temporal::NotFoundFailure))
+  end
+end

--- a/lib/temporal.rb
+++ b/lib/temporal.rb
@@ -8,6 +8,7 @@ require 'temporal/client'
 require 'temporal/metrics'
 require 'temporal/json'
 require 'temporal/errors'
+require 'temporal/schedule'
 require 'temporal/workflow/errors'
 
 module Temporal
@@ -34,7 +35,15 @@ module Temporal
                  :add_custom_search_attributes,
                  :list_custom_search_attributes,
                  :remove_custom_search_attributes,
-                 :connection
+                 :connection,
+                 :list_schedules,
+                 :describe_schedule,
+                 :create_schedule,
+                 :delete_schedule,
+                 :update_schedule,
+                 :trigger_schedule,
+                 :pause_schedule,
+                 :unpause_schedule
 
   class << self
     def configure(&block)

--- a/lib/temporal/client.rb
+++ b/lib/temporal/client.rb
@@ -501,6 +501,24 @@ module Temporal
       )
     end
 
+    # Delete a schedule in a namespace
+    #
+    # @param namespace [String] namespace to list schedules in
+    # @param schedule_id [String] schedule id
+    def delete_schedule(namespace, schedule_id)
+      connection.delete_schedule(namespace: namespace, schedule_id: schedule_id)
+    end
+
+    # Update a schedule in a namespace
+    #
+    # @param namespace [String] namespace to list schedules in
+    # @param schedule_id [String] schedule id
+    # @param schedule [Temporal::Schedule::Schedule] schedule to update. All fields in the schedule will be replaced completely by this updated schedule.
+    # @param conflict_token [String] a token that was returned by a previous describe_schedule call. If provided and does not match the current schedule's token, the update will fail.
+    def update_schedule(namespace, schedule_id, schedule, conflict_token: nil)
+      connection.update_schedule(namespace: namespace, schedule_id: schedule_id, schedule: schedule, conflict_token: conflict_token)
+    end
+
     def connection
       @connection ||= Temporal::Connection.generate(config.for_connection)
     end

--- a/lib/temporal/client.rb
+++ b/lib/temporal/client.rb
@@ -519,6 +519,33 @@ module Temporal
       connection.update_schedule(namespace: namespace, schedule_id: schedule_id, schedule: schedule, conflict_token: conflict_token)
     end
 
+    # Trigger one action of a schedule to run immediately
+    #
+    # @param namespace [String] namespace
+    # @param schedule_id [String] schedule id
+    # @param overlap_policy [Symbol] Should be one of :skip, :buffer_one, :buffer_all, :cancel_other, :terminate_other, :allow_all
+    def trigger_schedule(namespace, schedule_id, overlap_policy: nil)
+      connection.trigger_schedule(namespace: namespace, schedule_id: schedule_id, overlap_policy: overlap_policy)
+    end
+
+    # Pause a schedule so actions will not run
+    #
+    # @param namespace [String] namespace
+    # @param schedule_id [String] schedule id
+    # @param note [String] an optional note to explain why the schedule was paused
+    def pause_schedule(namespace, schedule_id, note: nil)
+      connection.pause_schedule(namespace: namespace, schedule_id: schedule_id, should_pause: true, note: note)
+    end
+
+    # Unpause a schedule so actions will run
+    #
+    # @param namespace [String] namespace
+    # @param schedule_id [String] schedule id
+    # @param note [String] an optional note to explain why the schedule was unpaused
+    def unpause_schedule(namespace, schedule_id, note: nil)
+      connection.pause_schedule(namespace: namespace, schedule_id: schedule_id, should_pause: false, note: note)
+    end
+
     def connection
       @connection ||= Temporal::Connection.generate(config.for_connection)
     end

--- a/lib/temporal/client.rb
+++ b/lib/temporal/client.rb
@@ -454,6 +454,53 @@ module Temporal
       connection.remove_custom_search_attributes(attribute_names, namespace || config.default_execution_options.namespace)
     end
 
+    # List all schedules in a namespace
+    #
+    # @param namespace [String] namespace to list schedules in
+    # @param maximum_page_size [Integer] number of namespace results to return per page.
+    # @param next_page_token [String] a optional pagination token returned by a previous list_namespaces call
+    def list_schedules(namespace, maximum_page_size:, next_page_token: '')
+      connection.list_schedules(namespace: namespace, maximum_page_size: maximum_page_size, next_page_token: next_page_token)
+    end
+ 
+    # Describe a schedule in a namespace
+    #
+    # @param namespace [String] namespace to list schedules in
+    # @param schedule_id [String] schedule id
+    def describe_schedule(namespace, schedule_id)
+      connection.describe_schedule(namespace: namespace, schedule_id: schedule_id)
+    end
+
+    # Create a new schedule
+    #
+    #
+    # @param namespace [String] namespace to create schedule in
+    # @param schedule_id [String] schedule id
+    # @param schedule [Temporal::Schedule::Schedule] schedule to create
+    # @param trigger_immediately [Boolean] If set, trigger one action to run immediately
+    # @param backfill [Temporal::Schedule::Backfill] If set, run through the backfill schedule and trigger actions.
+    # @param memo [Hash] optional key-value memo map to attach to the schedule
+    # @param search attributes [Hash] optional key-value search attributes to attach to the schedule
+    def create_schedule(
+      namespace,
+      schedule_id,
+      schedule,
+      trigger_immediately: false,
+      backfill: nil,
+      memo: nil,
+      search_attributes: nil
+    )
+      connection.create_schedule(
+        namespace: namespace,
+        schedule_id: schedule_id,
+        schedule: schedule,
+        trigger_immediately: trigger_immediately,
+        backfill: backfill,
+        memo: memo,
+        search_attributes: search_attributes
+      )
+    end
+
     def connection
       @connection ||= Temporal::Connection.generate(config.for_connection)
     end

--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -714,6 +714,38 @@ module Temporal
         client.create_schedule(request)
       end
 
+      def delete_schedule(namespace:, schedule_id:)
+        request = Temporalio::Api::WorkflowService::V1::DeleteScheduleRequest.new(
+          namespace: namespace,
+          schedule_id: schedule_id,
+          identity: identity
+        )
+
+        begin
+          client.delete_schedule(request)
+        rescue ::GRPC::NotFound => e
+          raise Temporal::NotFoundFailure, e
+        end
+      end
+
+      def update_schedule(namespace:, schedule_id:, schedule:, conflict_token: nil)
+        request = Temporalio::Api::WorkflowService::V1::UpdateScheduleRequest.new(
+          namespace: namespace,
+          schedule_id: schedule_id,
+          schedule: Temporal::Connection::Serializer::Schedule.new(schedule).to_proto,
+          conflict_token: conflict_token,
+          identity: identity,
+          request_id: SecureRandom.uuid
+        )
+
+        begin
+          client.update_schedule(request)
+        rescue ::GRPC::NotFound => e
+          raise Temporal::NotFoundFailure, e
+        end
+      end
+
+
       private
 
       attr_reader :url, :identity, :credentials, :options, :poll_mutex, :poll_request

--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -11,6 +11,8 @@ require 'temporal/connection/errors'
 require 'temporal/connection/interceptors/client_name_version_interceptor'
 require 'temporal/connection/serializer'
 require 'temporal/connection/serializer/failure'
+require 'temporal/connection/serializer/backfill'
+require 'temporal/connection/serializer/schedule'
 require 'temporal/connection/serializer/workflow_id_reuse_policy'
 require 'temporal/concerns/payloads'
 
@@ -626,6 +628,90 @@ module Temporal
 
       def get_system_info
         client.get_system_info(Temporalio::Api::WorkflowService::V1::GetSystemInfoRequest.new)
+      end
+
+      def list_schedules(namespace:, maximum_page_size:, next_page_token:)
+        request = Temporalio::Api::WorkflowService::V1::ListSchedulesRequest.new(
+          namespace: namespace,
+          maximum_page_size: maximum_page_size,
+          next_page_token: next_page_token
+        )
+        resp = client.list_schedules(request)
+
+        Temporal::Schedule::ListSchedulesResponse.new(
+          schedules: resp.schedules.map do |schedule|
+            Temporal::Schedule::ScheduleListEntry.new(
+              schedule_id: schedule.schedule_id,
+              memo: from_payload_map(schedule.memo&.fields || {}),
+              search_attributes: from_payload_map_without_codec(schedule.search_attributes&.indexed_fields || {}),
+              info: schedule.info
+            )
+          end,
+          next_page_token: resp.next_page_token,
+        )
+      end
+
+      def describe_schedule(namespace:, schedule_id:)
+        request = Temporalio::Api::WorkflowService::V1::DescribeScheduleRequest.new(
+          namespace: namespace,
+          schedule_id: schedule_id
+        )
+
+        resp = nil
+        begin
+          resp = client.describe_schedule(request)
+        rescue ::GRPC::NotFound => e
+          raise Temporal::NotFoundFailure, e
+        end
+
+        Temporal::Schedule::DescribeScheduleResponse.new(
+          schedule: resp.schedule,
+          info: resp.info,
+          memo: from_payload_map(resp.memo&.fields || {}),
+          search_attributes: from_payload_map_without_codec(resp.search_attributes&.indexed_fields || {}),
+          conflict_token: resp.conflict_token
+        )
+      end
+
+      def create_schedule(
+        namespace:,
+        schedule_id:,
+        schedule:,
+        trigger_immediately: nil,
+        backfill: nil,
+        memo: nil,
+        search_attributes: nil
+      )
+        initial_patch = nil
+        if trigger_immediately || backfill
+          initial_patch = Temporalio::Api::Schedule::V1::SchedulePatch.new
+          if trigger_immediately
+            initial_patch.trigger_immediately = Temporalio::Api::Schedule::V1::TriggerImmediatelyRequest.new(
+              overlap_policy: Temporal::Connection::Serializer::ScheduleOverlapPolicy.new(
+                schedule.policies&.overlap_policy
+              ).to_proto
+            )
+          end
+
+          if backfill
+            initial_patch.backfill_request += [Temporal::Connection::Serializer::Backfill.new(backfill).to_proto]
+          end
+        end
+
+        request = Temporalio::Api::WorkflowService::V1::CreateScheduleRequest.new(
+          namespace: namespace,
+          schedule_id: schedule_id,
+          schedule: Temporal::Connection::Serializer::Schedule.new(schedule).to_proto,
+          identity: identity,
+          request_id: SecureRandom.uuid,
+          memo: Temporalio::Api::Common::V1::Memo.new(
+            fields: to_payload_map(memo || {})
+          ),
+          search_attributes: Temporalio::Api::Common::V1::SearchAttributes.new(
+            indexed_fields: to_payload_map_without_codec(search_attributes || {})
+          )
+        )
+        client.create_schedule(request)
       end
 
       private

--- a/lib/temporal/connection/serializer/backfill.rb
+++ b/lib/temporal/connection/serializer/backfill.rb
@@ -1,0 +1,26 @@
+require "temporal/connection/serializer/base"
+require "temporal/connection/serializer/schedule_overlap_policy"
+
+module Temporal
+  module Connection
+    module Serializer
+      class Backfill < Base
+        def to_proto
+          return unless object
+
+          Temporalio::Api::Schedule::V1::BackfillRequest.new(
+            start_time: serialize_time(object.start_time),
+            end_time: serialize_time(object.end_time),
+            overlap_policy: Temporal::Connection::Serializer::ScheduleOverlapPolicy.new(object.overlap_policy).to_proto
+          )
+        end
+
+        def serialize_time(input_time)
+          return unless input_time
+
+          Google::Protobuf::Timestamp.new.from_time(input_time)
+        end
+      end
+    end
+  end
+end

--- a/lib/temporal/connection/serializer/schedule.rb
+++ b/lib/temporal/connection/serializer/schedule.rb
@@ -1,0 +1,22 @@
+require "temporal/connection/serializer/base"
+require "temporal/connection/serializer/schedule_spec"
+require "temporal/connection/serializer/schedule_action"
+require "temporal/connection/serializer/schedule_policies"
+require "temporal/connection/serializer/schedule_state"
+
+module Temporal
+  module Connection
+    module Serializer
+      class Schedule < Base
+        def to_proto
+          Temporalio::Api::Schedule::V1::Schedule.new(
+            spec: Temporal::Connection::Serializer::ScheduleSpec.new(object.spec).to_proto,
+            action: Temporal::Connection::Serializer::ScheduleAction.new(object.action).to_proto,
+            policies: Temporal::Connection::Serializer::SchedulePolicies.new(object.policies).to_proto,
+            state: Temporal::Connection::Serializer::ScheduleState.new(object.state).to_proto
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/temporal/connection/serializer/schedule_action.rb
+++ b/lib/temporal/connection/serializer/schedule_action.rb
@@ -1,0 +1,43 @@
+require "temporal/connection/serializer/base"
+require "temporal/concerns/payloads"
+
+module Temporal
+  module Connection
+    module Serializer
+      class ScheduleAction < Base
+        include Concerns::Payloads
+
+        def to_proto
+          unless object.is_a?(Temporal::Schedule::StartWorkflowAction)
+            raise ArgumentError, "Unknown action type #{object.class}"
+          end
+
+          Temporalio::Api::Schedule::V1::ScheduleAction.new(
+            start_workflow: Temporalio::Api::Workflow::V1::NewWorkflowExecutionInfo.new(
+              workflow_id: object.workflow_id,
+              workflow_type: Temporalio::Api::Common::V1::WorkflowType.new(
+                name: object.name
+              ),
+              task_queue: Temporalio::Api::TaskQueue::V1::TaskQueue.new(
+                name: object.task_queue
+              ),
+              input: to_payloads(object.input),
+              workflow_execution_timeout: object.execution_timeout,
+              workflow_run_timeout: object.run_timeout,
+              workflow_task_timeout: object.task_timeout,
+              header: Temporalio::Api::Common::V1::Header.new(
+                fields: to_payload_map(object.headers || {})
+              ),
+              memo: Temporalio::Api::Common::V1::Memo.new(
+                fields: to_payload_map(object.memo || {})
+              ),
+              search_attributes: Temporalio::Api::Common::V1::SearchAttributes.new(
+                indexed_fields: to_payload_map_without_codec(object.search_attributes || {})
+              )
+            )
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/temporal/connection/serializer/schedule_overlap_policy.rb
+++ b/lib/temporal/connection/serializer/schedule_overlap_policy.rb
@@ -1,0 +1,26 @@
+require "temporal/connection/serializer/base"
+
+module Temporal
+  module Connection
+    module Serializer
+      class ScheduleOverlapPolicy < Base
+        SCHEDULE_OVERLAP_POLICY = {
+          skip: Temporalio::Api::Enums::V1::ScheduleOverlapPolicy::SCHEDULE_OVERLAP_POLICY_SKIP,
+          buffer_one: Temporalio::Api::Enums::V1::ScheduleOverlapPolicy::SCHEDULE_OVERLAP_POLICY_BUFFER_ONE,
+          buffer_all: Temporalio::Api::Enums::V1::ScheduleOverlapPolicy::SCHEDULE_OVERLAP_POLICY_BUFFER_ALL,
+          cancel_other: Temporalio::Api::Enums::V1::ScheduleOverlapPolicy::SCHEDULE_OVERLAP_POLICY_CANCEL_OTHER,
+          terminate_other: Temporalio::Api::Enums::V1::ScheduleOverlapPolicy::SCHEDULE_OVERLAP_POLICY_TERMINATE_OTHER,
+          allow_all: Temporalio::Api::Enums::V1::ScheduleOverlapPolicy::SCHEDULE_OVERLAP_POLICY_ALLOW_ALL
+        }.freeze
+
+        def to_proto
+          return unless object
+
+          SCHEDULE_OVERLAP_POLICY.fetch(object) do
+            raise ArgumentError, "Unknown schedule overlap policy specified: #{object}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/temporal/connection/serializer/schedule_policies.rb
+++ b/lib/temporal/connection/serializer/schedule_policies.rb
@@ -1,0 +1,20 @@
+require "temporal/connection/serializer/base"
+require "temporal/connection/serializer/schedule_overlap_policy"
+
+module Temporal
+  module Connection
+    module Serializer
+      class SchedulePolicies < Base
+        def to_proto
+          return unless object
+
+          Temporalio::Api::Schedule::V1::SchedulePolicies.new(
+            overlap_policy: Temporal::Connection::Serializer::ScheduleOverlapPolicy.new(object.overlap_policy).to_proto,
+            catchup_window: object.catchup_window,
+            pause_on_failure: object.pause_on_failure
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/temporal/connection/serializer/schedule_spec.rb
+++ b/lib/temporal/connection/serializer/schedule_spec.rb
@@ -1,0 +1,45 @@
+require "temporal/connection/serializer/base"
+
+module Temporal
+  module Connection
+    module Serializer
+      class ScheduleSpec < Base
+        def to_proto
+          return unless object
+
+          Temporalio::Api::Schedule::V1::ScheduleSpec.new(
+            cron_string: object.cron_expressions,
+            interval: object.intervals.map do |interval|
+              Temporalio::Api::Schedule::V1::IntervalSpec.new(
+                interval: interval.every,
+                phase: interval.offset
+              )
+            end,
+            calendar: object.calendars.map do |calendar|
+              Temporalio::Api::Schedule::V1::CalendarSpec.new(
+                second: calendar.second,
+                minute: calendar.minute,
+                hour: calendar.hour,
+                day_of_month: calendar.day_of_month,
+                month: calendar.month,
+                year: calendar.year,
+                day_of_week: calendar.day_of_week,
+                comment: calendar.comment
+              )
+            end,
+            jitter: object.jitter,
+            timezone_name: object.timezone_name,
+            start_time: serialize_time(object.start_time),
+            end_time: serialize_time(object.end_time)
+          )
+        end
+
+        def serialize_time(input_time)
+          return unless input_time
+
+          Google::Protobuf::Timestamp.new.from_time(input_time)
+        end
+      end
+    end
+  end
+end

--- a/lib/temporal/connection/serializer/schedule_state.rb
+++ b/lib/temporal/connection/serializer/schedule_state.rb
@@ -1,0 +1,20 @@
+require "temporal/connection/serializer/base"
+
+module Temporal
+  module Connection
+    module Serializer
+      class ScheduleState < Base
+        def to_proto
+          return unless object
+
+          Temporalio::Api::Schedule::V1::ScheduleState.new(
+            notes: object.notes,
+            paused: object.paused,
+            limited_actions: object.limited_actions,
+            remaining_actions: object.remaining_actions
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/temporal/schedule.rb
+++ b/lib/temporal/schedule.rb
@@ -1,0 +1,16 @@
+require "temporal/schedule/backfill"
+require "temporal/schedule/calendar"
+require "temporal/schedule/describe_schedule_response"
+require "temporal/schedule/interval"
+require "temporal/schedule/list_schedules_response"
+require "temporal/schedule/schedule"
+require "temporal/schedule/schedule_list_entry"
+require "temporal/schedule/schedule_policies"
+require "temporal/schedule/schedule_spec"
+require "temporal/schedule/schedule_state"
+require "temporal/schedule/start_workflow_action"
+
+module Temporal
+  module Schedule
+  end
+end

--- a/lib/temporal/schedule/backfill.rb
+++ b/lib/temporal/schedule/backfill.rb
@@ -1,0 +1,42 @@
+module Temporal
+  module Schedule
+    class Backfill
+      # Controls what happens when a workflow would be started
+      # by a schedule, and is already running.
+      #
+      # If provided, must be one of:
+      # - :skip (default): means don't start anything. When the  workflow
+      #      completes, the next scheduled event after that time will be considered.
+      # - :buffer_one: means start the workflow again soon as the
+      #      current one completes, but only buffer one start in this way. If
+      #      another start is supposed to happen when the workflow is running,
+      #      and one is already buffered, then only the first one will be
+      #      started after the running workflow finishes.
+      # - :buffer_all : means buffer up any number of starts to all happen
+      #      sequentially, immediately after the running workflow completes.
+      # - :cancel_other: means that if there is another workflow running, cancel
+      #      it, and start the new one after the old one completes cancellation.
+      # - :terminate_other: means that if there is another workflow running,
+      #      terminate it and start the new one immediately.
+      # - :allow_all: means start any number of concurrent workflows.
+      #      Note that with this policy, last completion result and last failure
+      #      will not be available since workflows are not sequential.
+      attr_reader :overlap_policy
+
+      # The time to start the backfill
+      attr_reader :start_time
+
+      # The time to end the backfill
+      attr_reader :end_time
+
+      # @param start_time [Time] The time to start the backfill
+      # @param end_time [Time] The time to end the backfill
+      # @param overlap_policy [Time] Should be one of :skip, :buffer_one, :buffer_all, :cancel_other, :terminate_other, :allow_all
+      def initialize(start_time: nil, end_time: nil, overlap_policy: nil)
+        @start_time = start_time
+        @end_time = end_time
+        @overlap_policy = overlap_policy
+      end
+    end
+  end
+end

--- a/lib/temporal/schedule/calendar.rb
+++ b/lib/temporal/schedule/calendar.rb
@@ -1,0 +1,48 @@
+module Temporal
+  module Schedule
+
+    # Calendar describes an event specification relative to the calendar,
+    # similar to a traditional cron specification, but with labeled fields. Each
+    # field can be one of:
+    #   *: matches always
+    #   x: matches when the field equals x
+    #   x/y : matches when the field equals x+n*y where n is an integer
+    #   x-z: matches when the field is between x and z inclusive
+    #   w,x,y,...: matches when the field is one of the listed values
+    #
+    # Each x, y, z, ... is either a decimal integer, or a month or day of week name
+    # or abbreviation (in the appropriate fields).
+    #
+    # A timestamp matches if all fields match.
+    #
+    # Note that fields have different default values, for convenience.
+    #
+    # Note that the special case that some cron implementations have for treating
+    # day_of_month and day_of_week as "or" instead of "and" when both are set is
+    # not implemented.
+    #
+    # day_of_week can accept 0 or 7 as Sunday
+    class Calendar
+      attr_reader :second, :minute, :hour, :day_of_month, :month, :year, :day_of_week, :comment
+
+      # @param second [String] Expression to match seconds. Default: 0
+      # @param minute [String] Expression to match minutes. Default: 0
+      # @param hour [String] Expression to match hours. Default: 0
+      # @param day_of_month [String] Expression to match days of the month. Default: *
+      # @param month [String] Expression to match months. Default: *
+      # @param year [String] Expression to match years. Default: *
+      # @param day_of_week [String] Expression to match days of the week. Default: *
+      # @param comment [String] Free form comment describing the intent of this calendar.
+      def initialize(second: nil, minute: nil, hour: nil, day_of_month: nil, month: nil, year: nil, day_of_week: nil, comment: nil)
+        @second = second
+        @minute = minute
+        @hour = hour
+        @day_of_month = day_of_month
+        @month = month
+        @day_of_week = day_of_week
+        @year = year
+        @comment = comment
+      end
+    end
+  end
+end

--- a/lib/temporal/schedule/describe_schedule_response.rb
+++ b/lib/temporal/schedule/describe_schedule_response.rb
@@ -1,0 +1,11 @@
+module Temporal
+  module Schedule
+    class DescribeScheduleResponse < Struct.new(:schedule, :info, :memo, :search_attributes, :conflict_token, keyword_init: true)
+      # Override the constructor to make these objects immutable 
+      def initialize(*args)
+        super(*args)
+        self.freeze
+      end
+    end
+  end
+end

--- a/lib/temporal/schedule/interval.rb
+++ b/lib/temporal/schedule/interval.rb
@@ -1,0 +1,24 @@
+module Temporal
+  module Schedule
+    #  Interval matches times that can be expressed as:
+    #  Epoch + (n * every) + offset
+    #  where n is all integers ≥ 0.
+
+    #  For example, an `every` of 1 hour with `offset` of zero would match
+    #  every hour, on the hour. The same `every` but an `offset`
+    #  of 19 minutes would match every `xx:19:00`. An `every` of 28 days with
+    #  `offset` zero would match `2022-02-17T00:00:00Z` (among other times).
+    #  The same `every` with `offset` of 3 days, 5 hours, and 23 minutes
+    # would match `2022-02-20T05:23:00Z` instead.
+    class Interval
+      attr_reader :every, :offset
+
+      # @param every [Integer] the number of seconds between each interval
+      # @param offset [Integer] the number of seconds to provide as offset
+      def initialize(every:, offset: nil)
+        @every = every
+        @offset = offset
+      end
+    end
+  end
+end

--- a/lib/temporal/schedule/list_schedules_response.rb
+++ b/lib/temporal/schedule/list_schedules_response.rb
@@ -1,0 +1,11 @@
+module Temporal
+  module Schedule
+    class ListSchedulesResponse < Struct.new(:schedules, :next_page_token, keyword_init: true)
+      # Override the constructor to make these objects immutable 
+      def initialize(*args)
+        super(*args)
+        self.freeze
+      end
+    end
+  end
+end

--- a/lib/temporal/schedule/schedule.rb
+++ b/lib/temporal/schedule/schedule.rb
@@ -1,0 +1,14 @@
+module Temporal
+  module Schedule
+    class Schedule
+      attr_reader :spec, :action, :policies, :state
+
+      def initialize(spec:, action:, policies: nil, state: nil)
+        @spec = spec
+        @action = action
+        @policies = policies
+        @state = state
+      end
+    end
+  end
+end

--- a/lib/temporal/schedule/schedule_list_entry.rb
+++ b/lib/temporal/schedule/schedule_list_entry.rb
@@ -1,0 +1,12 @@
+module Temporal
+  module Schedule
+    # ScheduleListEntry is returned by ListSchedules.
+    class ScheduleListEntry < Struct.new(:schedule_id, :memo, :search_attributes, :info, keyword_init: true)
+      # Override the constructor to make these objects immutable 
+      def initialize(*args)
+        super(*args)
+        self.freeze
+      end
+    end
+  end
+end

--- a/lib/temporal/schedule/schedule_policies.rb
+++ b/lib/temporal/schedule/schedule_policies.rb
@@ -1,0 +1,48 @@
+module Temporal
+  module Schedule
+    class SchedulePolicies
+      # Controls what happens when a workflow would be started
+      # by a schedule, and is already running.
+      #
+      # If provided, must be one of:
+      # - :skip (default): means don't start anything. When the  workflow
+      #      completes, the next scheduled event after that time will be considered.
+      # - :buffer_one: means start the workflow again soon as the
+      #      current one completes, but only buffer one start in this way. If
+      #      another start is supposed to happen when the workflow is running,
+      #      and one is already buffered, then only the first one will be
+      #      started after the running workflow finishes.
+      # - :buffer_all : means buffer up any number of starts to all happen
+      #      sequentially, immediately after the running workflow completes.
+      # - :cancel_other: means that if there is another workflow running, cancel
+      #      it, and start the new one after the old one completes cancellation.
+      # - :terminate_other: means that if there is another workflow running,
+      #      terminate it and start the new one immediately.
+      # - :allow_all: means start any number of concurrent workflows.
+      #      Note that with this policy, last completion result and last failure
+      #      will not be available since workflows are not sequential.
+      attr_reader :overlap_policy
+
+      # Policy for catchups:
+      # If the Temporal server misses an action due to one or more components
+      # being down, and comes back up, the action will be run if the scheduled
+      # time is within this window from the current time.
+      # This value defaults to 60 seconds, and can't be less than 10 seconds.
+      attr_reader :catchup_window
+
+      # If true, and a workflow run fails or times out, turn on "paused".
+      # This applies after retry policies: the full chain of retries must fail to
+      # trigger a pause here.
+      attr_reader :pause_on_failure
+
+      # @param overlap_policy [Symbol] Should be one of :skip, :buffer_one, :buffer_all, :cancel_other, :terminate_other, :allow_all
+      # @param catchup_window [Integer] The number of seconds to catchup if the Temporal server misses an action
+      # @param pause_on_failure [Boolean] Whether to pause the schedule if the action fails
+      def initialize(overlap_policy: nil, catchup_window: nil, pause_on_failure: nil)
+        @overlap_policy = overlap_policy
+        @catchup_window = catchup_window
+        @pause_on_failure = pause_on_failure
+      end
+    end
+  end
+end

--- a/lib/temporal/schedule/schedule_spec.rb
+++ b/lib/temporal/schedule/schedule_spec.rb
@@ -1,0 +1,93 @@
+module Temporal
+  module Schedule
+    # ScheduleSpec is a complete description of a set of absolute timestamps
+    # (possibly infinite) that an action should occur at. The meaning of a
+    # ScheduleSpec depends only on its contents and never changes, except that the
+    # definition of a time zone can change over time (most commonly, when daylight
+    # saving time policy changes for an area). To create a totally self-contained
+    # ScheduleSpec, use UTC or include timezone_data
+
+    # For input, you can provide zero or more of: calendars, intervals or
+    # cron_expressions and all of them will be used (the schedule will take
+    # action at the union of all of their times, minus the ones that match
+    # exclude_structured_calendar).
+    class ScheduleSpec
+      # Calendar-based specifications of times.
+      #
+      # @return [Array<Temporal::Schedule::Calendar>]
+      attr_reader :calendars
+
+      # Interval-based specifications of times.
+      #
+      # @return [Array<Temporal::Schedule::Interval>]
+      attr_reader :intervals
+
+      # [Cron expressions](https://crontab.guru/). This is provided for easy
+      # migration from legacy Cron Workflows. For new use cases, we recommend
+      # using calendars or intervals for readability and maintainability.
+      #
+      #
+      # The string can have 5, 6, or 7 fields, separated by spaces.
+      #
+      # - 5 fields:         minute, hour, day_of_month, month, day_of_week
+      # - 6 fields:         minute, hour, day_of_month, month, day_of_week, year
+      # - 7 fields: second, minute, hour, day_of_month, month, day_of_week, year
+      #
+      # Notes:
+      #
+      # - If year is not given, it defaults to *.
+      # - If second is not given, it defaults to 0.
+      # - Shorthands `@yearly`, `@monthly`, `@weekly`, `@daily`, and `@hourly` are also
+      # accepted instead of the 5-7 time fields.
+      # - `@every interval[/<phase>]` is accepted and gets compiled into an
+      # IntervalSpec instead. `<interval>` and `<phase>` should be a decimal integer
+      # with a unit suffix s, m, h, or d.
+      # - Optionally, the string can be preceded by `CRON_TZ=<timezone name>` or
+      # `TZ=<timezone name>`, which will get copied to {@link timezone}.
+      # (In which case the {@link timezone} field should be left empty.)
+      # - Optionally, "#" followed by a comment can appear at the end of the string.
+      # - Note that the special case that some cron implementations have for
+      # treating day_of_month and day_of_week as "or" instead of "and" when both
+      # are set is not implemented.
+      #
+      # @return [Array<String>]
+      attr_reader :cron_expressions
+
+      # If set, any timestamps before start_time will be skipped.
+      attr_reader :start_time
+
+      # If set, any timestamps after end_time will be skipped.
+      attr_reader :end_time
+
+      # If set, the schedule will be randomly offset by up to this many seconds.
+      attr_reader :jitter
+
+      # Time zone to interpret all calendar-based specs in.
+      #
+      # If unset, defaults to UTC. We recommend using UTC for your application if
+      # at all possible, to avoid various surprising properties of time zones.
+      #
+      # Time zones may be provided by name, corresponding to names in the IANA
+      # time zone database (see https://www.iana.org/time-zones). The definition
+      # will be loaded by the Temporal server from the environment it runs in.
+      attr_reader :timezone_name
+
+      # @param cron_expressions [Array<String>]
+      # @param intervals [Array<Temporal::Schedule::Interval>]
+      # @param calendars [Array<Temporal::Schedule::Calendar>]
+      # @param start_time [Time] If set, any timestamps before start_time will be skipped.
+      # @param end_time [Time] If set, any timestamps after end_time will be skipped.
+      # @param jitter [Integer] If set, the schedule will be randomly offset by up to this many seconds.
+      # @param timezone_name [String] If set, the schedule will be interpreted in this time zone.
+      def initialize(cron_expressions: nil, intervals: nil, calendars: nil, start_time: nil, end_time: nil, jitter: nil, timezone_name: nil)
+        @cron_expressions = cron_expressions || []
+        @intervals = intervals || []
+        @calendars = calendars || []
+        @start_time = start_time
+        @end_time = end_time
+        @jitter = jitter
+        @timezone_name = timezone_name
+      end
+    end
+  end
+end

--- a/lib/temporal/schedule/schedule_state.rb
+++ b/lib/temporal/schedule/schedule_state.rb
@@ -1,0 +1,18 @@
+module Temporal
+  module Schedule
+    class ScheduleState
+      attr_reader :notes, :paused, :limited_actions, :remaining_actions
+
+      # @param notes [String] Human-readable notes about the schedule.
+      # @param paused [Boolean] If true, do not take any actions based on the schedule spec.
+      # @param limited_actions [Boolean] If true, decrement remaining_actions when an action is taken.
+      # @param remaining_actions [Integer] The number of actions remaining to be taken.
+      def initialize(notes: nil, paused: nil, limited_actions: nil, remaining_actions: nil)
+        @notes = notes
+        @paused = paused
+        @limited_actions = limited_actions
+        @remaining_actions = remaining_actions
+      end
+    end
+  end
+end

--- a/lib/temporal/schedule/start_workflow_action.rb
+++ b/lib/temporal/schedule/start_workflow_action.rb
@@ -1,0 +1,58 @@
+require "forwardable"
+
+module Temporal
+  module Schedule
+    class StartWorkflowAction
+      extend Forwardable
+
+      #target
+      def_delegators(
+        :@execution_options,
+        :name,
+        :task_queue,
+        :headers,
+        :memo
+      )
+
+      attr_reader :workflow_id, :input
+
+      # @param workflow [Temporal::Workflow, String] workflow class or name. When a workflow class
+      #   is passed, its config (namespace, task_queue, timeouts, etc) will be used
+      # @param input [any] arguments to be passed to workflow's #execute method
+      # @param args [Hash] keyword arguments to be passed to workflow's #execute method
+      # @param options [Hash, nil] optional overrides
+      # @option options [String] :workflow_id
+      # @option options [String] :name workflow name
+      # @option options [String] :namespace
+      # @option options [String] :task_queue
+      # @option options [Hash] :retry_policy check Temporal::RetryPolicy for available options
+      # @option options [Hash] :timeouts check Temporal::Configuration::DEFAULT_TIMEOUTS
+      # @option options [Hash] :headers
+      # @option options [Hash] :search_attributes
+      #
+      # @return [String] workflow's run ID
+      def initialize(workflow, *input, options: {})
+        @workflow_id = options[:workflow_id] || SecureRandom.uuid
+        @input = input
+
+        @execution_options = ExecutionOptions.new(workflow, options)
+      end
+
+      def execution_timeout
+        @execution_options.timeouts[:execution]
+      end
+
+      def run_timeout
+        @execution_options.timeouts[:run] || @execution_options.timeouts[:execution]
+      end
+
+      def task_timeout
+        @execution_options.timeouts[:task]
+      end
+
+      def search_attributes
+        Workflow::Context::Helpers.process_search_attributes(@execution_options.search_attributes)
+      end
+    end
+  end
+end

--- a/spec/unit/lib/temporal/connection/converter/payload/proto_json_spec.rb
+++ b/spec/unit/lib/temporal/connection/converter/payload/proto_json_spec.rb
@@ -29,14 +29,4 @@ describe Temporal::Connection::Converter::Payload::ProtoJSON do
 
     expect(subject.to_payload(input)).to be nil
   end
-
-  # DO NOT MERGE THIS UPSTREAM TO COINBASE
-  it 'exemptions' do
-    data = '{"name":"foo"}'
-    Temporal::Connection::Converter::Payload::ProtoJSON::SPECIAL_STRIPE_WORKFLOW_PAYLOAD_TYPES.each do |message_type|
-      fake_payload = Struct.new(:metadata, :data).new({ 'messageType' => message_type }, data)
-      data_out = subject.from_payload(fake_payload)
-      expect(data_out).to eq({ 'name' => 'foo' })
-    end
-  end
 end

--- a/spec/unit/lib/temporal/connection/converter/payload/proto_json_spec.rb
+++ b/spec/unit/lib/temporal/connection/converter/payload/proto_json_spec.rb
@@ -29,4 +29,14 @@ describe Temporal::Connection::Converter::Payload::ProtoJSON do
 
     expect(subject.to_payload(input)).to be nil
   end
+
+  # DO NOT MERGE THIS UPSTREAM TO COINBASE
+  it 'exemptions' do
+    data = '{"name":"foo"}'
+    Temporal::Connection::Converter::Payload::ProtoJSON::SPECIAL_STRIPE_WORKFLOW_PAYLOAD_TYPES.each do |message_type|
+      fake_payload = Struct.new(:metadata, :data).new({ 'messageType' => message_type }, data)
+      data_out = subject.from_payload(fake_payload)
+      expect(data_out).to eq({ 'name' => 'foo' })
+    end
+  end
 end

--- a/spec/unit/lib/temporal/connection/serializer/backfill_spec.rb
+++ b/spec/unit/lib/temporal/connection/serializer/backfill_spec.rb
@@ -1,0 +1,32 @@
+require "temporal/connection/errors"
+require "temporal/schedule/backfill"
+require "temporal/connection/serializer/backfill"
+
+describe Temporal::Connection::Serializer::Backfill do
+  let(:example_backfill) do
+    Temporal::Schedule::Backfill.new(
+      start_time: Time.new(2000, 1, 1, 0, 0, 0),
+      end_time: Time.new(2031, 1, 1, 0, 0, 0),
+      overlap_policy: :buffer_all
+    )
+  end
+
+  describe "to_proto" do
+    it "raises an error if an invalid overlap_policy is specified" do
+      invalid = Temporal::Schedule::Backfill.new(overlap_policy: :foobar)
+      expect do
+        described_class.new(invalid).to_proto
+      end
+        .to(raise_error(Temporal::Connection::ArgumentError, "Unknown schedule overlap policy specified: foobar"))
+    end
+
+    it "produces well-formed protobuf" do
+      result = described_class.new(example_backfill).to_proto
+
+      expect(result).to(be_a(Temporalio::Api::Schedule::V1::BackfillRequest))
+      expect(result.overlap_policy).to(eq(:SCHEDULE_OVERLAP_POLICY_BUFFER_ALL))
+      expect(result.start_time.to_time).to(eq(example_backfill.start_time))
+      expect(result.end_time.to_time).to(eq(example_backfill.end_time))
+    end
+  end
+end

--- a/spec/unit/lib/temporal/connection/serializer/schedule_action_spec.rb
+++ b/spec/unit/lib/temporal/connection/serializer/schedule_action_spec.rb
@@ -1,0 +1,50 @@
+require "temporal/connection/errors"
+require "temporal/schedule/start_workflow_action"
+require "temporal/connection/serializer/schedule_action"
+
+describe Temporal::Connection::Serializer::ScheduleAction do
+  let(:timeouts) { {run: 100, task: 10} }
+
+  let(:example_action) do
+    Temporal::Schedule::StartWorkflowAction.new(
+      "HelloWorldWorkflow",
+      "one",
+      "two",
+      options: {
+        workflow_id: "foobar",
+        task_queue: "my-task-queue",
+        timeouts: timeouts,
+        memo: {:"foo-memo" => "baz"},
+        search_attributes: {:"foo-search-attribute" => "qux"},
+        headers: {:"foo-header" => "bar"}
+      }
+    )
+  end
+
+  describe "to_proto" do
+    it "raises an error if an invalid action is specified" do
+      expect do
+        described_class.new(123).to_proto
+      end
+        .to(raise_error(Temporal::Connection::ArgumentError)) do |e|
+          expect(e.message).to(eq("Unknown action type Integer"))
+        end
+    end
+
+    it "produces well-formed protobuf" do
+      result = described_class.new(example_action).to_proto
+
+      expect(result).to(be_a(Temporalio::Api::Schedule::V1::ScheduleAction))
+
+      action = result.start_workflow
+      expect(action).to(be_a(Temporalio::Api::Workflow::V1::NewWorkflowExecutionInfo))
+      expect(action.task_queue.name).to(eq("my-task-queue"))
+      expect(action.input.payloads.map(&:data)).to(eq(["\"one\"", "\"two\""]))
+      expect(action.header.fields["foo-header"].data).to(eq("\"bar\""))
+      expect(action.memo.fields["foo-memo"].data).to(eq("\"baz\""))
+      expect(action.search_attributes.indexed_fields["foo-search-attribute"].data).to(eq("\"qux\""))
+      expect(action.workflow_run_timeout.seconds).to(eq(timeouts[:run]))
+      expect(action.workflow_task_timeout.seconds).to(eq(timeouts[:task]))
+    end
+  end
+end

--- a/spec/unit/lib/temporal/connection/serializer/schedule_policies_spec.rb
+++ b/spec/unit/lib/temporal/connection/serializer/schedule_policies_spec.rb
@@ -1,0 +1,31 @@
+require "temporal/schedule/schedule_policies"
+require "temporal/connection/serializer/schedule_policies"
+
+describe Temporal::Connection::Serializer::SchedulePolicies do
+  let(:example_policies) do
+    Temporal::Schedule::SchedulePolicies.new(
+      overlap_policy: :buffer_one,
+      catchup_window: 600,
+      pause_on_failure: true
+    )
+  end
+
+  describe "to_proto" do
+    it "produces well-formed protobuf" do
+      result = described_class.new(example_policies).to_proto
+
+      expect(result).to(be_a(Temporalio::Api::Schedule::V1::SchedulePolicies))
+      expect(result.overlap_policy).to(eq(:SCHEDULE_OVERLAP_POLICY_BUFFER_ONE))
+      expect(result.catchup_window.seconds).to(eq(600))
+      expect(result.pause_on_failure).to(eq(true))
+    end
+
+    it "should raise if an unknown overlap policy is specified" do
+      invalid_policies = Temporal::Schedule::SchedulePolicies.new(overlap_policy: :foobar)
+      expect do
+        described_class.new(invalid_policies).to_proto
+      end
+        .to(raise_error(Temporal::Connection::ArgumentError, "Unknown schedule overlap policy specified: foobar"))
+    end
+  end
+end

--- a/spec/unit/lib/temporal/connection/serializer/schedule_spec_spec.rb
+++ b/spec/unit/lib/temporal/connection/serializer/schedule_spec_spec.rb
@@ -1,0 +1,57 @@
+require "temporal/schedule/schedule_spec"
+require "temporal/schedule/interval"
+require "temporal/schedule/calendar"
+require "temporal/connection/serializer/schedule_spec"
+
+describe Temporal::Connection::Serializer::ScheduleSpec do
+  let(:example_spec) do
+    Temporal::Schedule::ScheduleSpec.new(
+      cron_expressions: ["@hourly"],
+      intervals: [
+        Temporal::Schedule::Interval.new(every: 50, offset: 30),
+        Temporal::Schedule::Interval.new(every: 60)
+      ],
+      calendars: [
+        Temporal::Schedule::Calendar.new(
+          hour: "7",
+          minute: "0,3,15",
+          day_of_week: "MONDAY",
+          month: "1-6",
+          comment: "some comment explaining intent"
+        ),
+        Temporal::Schedule::Calendar.new(
+          minute: "8",
+          hour: "*"
+        )
+      ],
+      start_time: Time.new(2000, 1, 1, 0, 0, 0),
+      end_time: Time.new(2031, 1, 1, 0, 0, 0),
+      jitter: 500,
+      timezone_name: "America/New_York"
+    )
+  end
+
+  describe "to_proto" do
+    it "produces well-formed protobuf" do
+      result = described_class.new(example_spec).to_proto
+
+      expect(result).to(be_a(Temporalio::Api::Schedule::V1::ScheduleSpec))
+      expect(result.cron_string).to(eq(["@hourly"]))
+      expect(result.interval[0].interval.seconds).to(eq(50))
+      expect(result.interval[0].phase.seconds).to(eq(30))
+      expect(result.interval[1].interval.seconds).to(eq(60))
+      expect(result.interval[1].phase).to(be_nil)
+      expect(result.calendar[0].hour).to(eq("7"))
+      expect(result.calendar[0].minute).to(eq("0,3,15"))
+      expect(result.calendar[0].day_of_week).to(eq("MONDAY"))
+      expect(result.calendar[0].month).to(eq("1-6"))
+      expect(result.calendar[0].comment).to(eq("some comment explaining intent"))
+      expect(result.calendar[1].hour).to(eq("*"))
+      expect(result.calendar[1].minute).to(eq("8"))
+      expect(result.start_time.to_time).to(eq(example_spec.start_time))
+      expect(result.end_time.to_time).to(eq(example_spec.end_time))
+      expect(result.jitter.seconds).to(eq(500))
+      expect(result.timezone_name).to(eq("America/New_York"))
+    end
+  end
+end

--- a/spec/unit/lib/temporal/connection/serializer/schedule_state_spec.rb
+++ b/spec/unit/lib/temporal/connection/serializer/schedule_state_spec.rb
@@ -1,0 +1,25 @@
+require "temporal/schedule/schedule_state"
+require "temporal/connection/serializer/schedule_state"
+
+describe Temporal::Connection::Serializer::ScheduleState do
+  let(:example_state) do
+    Temporal::Schedule::ScheduleState.new(
+      notes: "some notes",
+      paused: true,
+      limited_actions: true,
+      remaining_actions: 500
+    )
+  end
+
+  describe "to_proto" do
+    it "produces well-formed protobuf" do
+      result = described_class.new(example_state).to_proto
+
+      expect(result).to(be_a(Temporalio::Api::Schedule::V1::ScheduleState))
+      expect(result.notes).to(eq("some notes"))
+      expect(result.paused).to(eq(true))
+      expect(result.limited_actions).to(eq(true))
+      expect(result.remaining_actions).to(eq(500))
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This PR adds support for interacting with the [Temporal Schedules Api](https://temporal.io/blog/how-we-build-it-building-scheduled-workflows-in-temporal). We're using this patch internally to synchronize schedules with Temporal when new code is deployed.

The approach I took was to define a set of `Temporal::Schedule` classes that roughly map to the proto models defined in the [temporal api](https://github.com/temporalio/api/blob/master/temporal/api/schedule/v1/message.proto).

This is a large PR given the surface area of the api, but I've tried to break it by commit to make it a bit easier to review.

## Test Plan

Ran `rspec spec` and `cd examples && rspec spec` without error