### PR TITLE
Fix warnings

### DIFF
--- a/spec/unit/lib/temporal/activity_spec.rb
+++ b/spec/unit/lib/temporal/activity_spec.rb
@@ -64,7 +64,7 @@ describe Temporal::Activity do
       it 'does not raise an ArgumentError' do
         expect {
           described_class.execute_in_context(context, input)
-        }.not_to raise_error(ArgumentError, 'wrong number of arguments (given 2, expected 1; required keywords: b, c)')
+        }.not_to raise_error
       end
 
       it 'returns #execute result' do

--- a/spec/unit/lib/temporal/workflow_spec.rb
+++ b/spec/unit/lib/temporal/workflow_spec.rb
@@ -65,7 +65,7 @@ describe Temporal::Workflow do
       it 'does not raise an ArgumentError' do
         expect {
           described_class.execute_in_context(ctx, input)
-        }.not_to raise_error(ArgumentError, 'wrong number of arguments (given 2, expected 1; required keywords: b, c)')
+        }.not_to raise_error
       end
     end
   end

--- a/temporal.gemspec
+++ b/temporal.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.files         = Dir["{lib,rbi}/**/*.*"] + %w(temporal.gemspec Gemfile LICENSE README.md)
 
+  spec.add_dependency 'base64'
   spec.add_dependency 'grpc'
   spec.add_dependency 'oj'
 


### PR DESCRIPTION
Fixes a couple of warnings
- Adds the base64 gem to the gemspec. Starting in Ruby 3.4.0, this will be required since it's moving out of the standard library. For 3.3.0, this is showing up as a warning. See https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/ for more information
- Assertions that specs do not raise a specific error have been made more general to assert that a test raises no error at all. This removes a warning and should make these tests slightly more robust