### PR TITLE
[WIP] Allow inheritance of retry and timeout options

### DIFF
--- a/lib/temporal/concerns/executable.rb
+++ b/lib/temporal/concerns/executable.rb
@@ -16,13 +16,13 @@ module Temporal
       end
 
       def retry_policy(*args)
-        return @retry_policy if args.empty?
-        @retry_policy = args.first
+        return @@retry_policy if args.empty?
+        @@retry_policy = args.first
       end
 
       def timeouts(*args)
-        return @timeouts if args.empty?
-        @timeouts = args.first
+        return @@timeouts if args.empty?
+        @@timeouts = args.first
       end
 
       def headers(*args)

--- a/spec/unit/lib/temporal/execution_options_spec.rb
+++ b/spec/unit/lib/temporal/execution_options_spec.rb
@@ -179,6 +179,21 @@ describe Temporal::ExecutionOptions do
             'HeaderB' => 'ValueB' # overriden by options
           )
         end
+
+        context 'when there is options on the parent class' do
+          class TestSubWorkflow < TestWorkflow
+          end
+
+          let(:object) { TestSubWorkflow }
+
+          it 'uses the options for retry_policy and timeouts from the parent class' do
+            expect(subject.retry_policy).to be_an_instance_of(Temporal::RetryPolicy)
+            expect(subject.retry_policy.interval).to eq(2)
+            expect(subject.retry_policy.backoff).to eq(2)
+            expect(subject.retry_policy.max_attempts).to eq(10)
+            expect(subject.timeouts).to eq(schedule_to_close: 20, start_to_close: 10)
+          end
+        end
       end
 
       context 'with defaults given' do


### PR DESCRIPTION
Presently you only have the option of using the default options or per-class configuration of timeout and retry. This PR changes it so subclassed executables inherit these settings from their parent Ruby class.