### PR TITLE
Move off `Dry::Struct::Value` before its removed from `dry-struct`

### DIFF
--- a/examples/Gemfile
+++ b/examples/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'temporal-ruby', path: '../'
 
-gem 'dry-types', '>= 1.2.0'
-gem 'dry-struct', '~> 1.1.1'
+gem 'dry-types', '>= 1.7.2'
+gem 'dry-struct', '~> 1.6.0'
 
 gem 'rspec', group: :test

--- a/lib/temporal/concerns/typed.rb
+++ b/lib/temporal/concerns/typed.rb
@@ -32,7 +32,7 @@ module Temporal
         private
 
         def generate_struct
-          Class.new(Dry::Struct::Value) { transform_keys(&:to_sym) }
+          Class.new(Dry::Struct) { transform_keys(&:to_sym) }
         end
       end
     end


### PR DESCRIPTION
Resolve the following warning before it becomes a bigger issue.

```
[dry-struct] Dry::Struct::Value is deprecated and will be removed in the next major version
/Users/sal/Development/temporal-ruby/lib/temporal/concerns/typed.rb:35:in `generate_struct'
```

Closes https://github.com/coinbase/temporal-ruby/issues/292