### PR TITLE
Propagate :use_error_serialization_v2 option to GRPC client

### DIFF
--- a/lib/temporal/configuration.rb
+++ b/lib/temporal/configuration.rb
@@ -122,7 +122,7 @@ module Temporal
         port: port,
         credentials: credentials,
         identity: identity || default_identity,
-        connection_options: connection_options
+        connection_options: connection_options.merge(use_error_serialization_v2: @use_error_serialization_v2)
       ).freeze
     end
 

--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -311,7 +311,7 @@ module Temporal
       end
 
       def respond_activity_task_failed(namespace:, task_token:, exception:)
-        serialize_whole_error = Temporal.configuration.use_error_serialization_v2
+        serialize_whole_error = options.fetch(:use_error_serialization_v2, Temporal.configuration.use_error_serialization_v2)
         request = Temporalio::Api::WorkflowService::V1::RespondActivityTaskFailedRequest.new(
           namespace: namespace,
           identity: identity,


### PR DESCRIPTION
Attempt to address https://github.com/coinbase/temporal-ruby/issues/295. 

Alter `Temporal::Connection::GRPC` to respect a `:use_error_serialization_v2` option, falling back to the global singleton value if not found, and update `Temporal::Configuration#for_connection` to pass its setting through when creating connections.

It looks like options can already be plumbed through by editing a Temporal::Configuration instance's `connection_options`, but this case seems slightly different because `use_error_serialization_v2` is an explicit setting on the configuration.