### PR TITLE
Mark continue_as_new as not implemented in testing context

### DIFF
--- a/lib/temporal/testing/local_workflow_context.rb
+++ b/lib/temporal/testing/local_workflow_context.rb
@@ -180,6 +180,10 @@ module Temporal
         raise exception
       end
 
+      def continue_as_new(*input, **args)
+        raise NotImplementedError, 'not yet available for testing'
+      end
+
       def wait_for_all(*futures)
         futures.each(&:wait)
 


### PR DESCRIPTION
`continue_as_new` was never implemented in the testing context, so let's raise `NotImplementedError` instead of `NoMethodError` for clarify.