### PR TITLE
Allow access to `Temporal. get_workflow_history` directly

### DIFF
--- a/lib/temporal.rb
+++ b/lib/temporal.rb
@@ -28,6 +28,7 @@ module Temporal
                  :fetch_workflow_execution_info,
                  :complete_activity,
                  :fail_activity,
+                 :get_workflow_history,
                  :list_open_workflow_executions,
                  :list_closed_workflow_executions,
                  :query_workflow_executions,

--- a/spec/unit/lib/temporal_spec.rb
+++ b/spec/unit/lib/temporal_spec.rb
@@ -61,6 +61,9 @@ describe Temporal do
       it_behaves_like 'a forwarded method', :complete_activity, 'test-token', StandardError.new
     end
 
+    describe '.get_workflow_history' do
+      it_behaves_like 'a forwarded method', :get_workflow_history, 'test-namespace', 'x', 'y'
+    end
   end
 
   describe '.configure' do


### PR DESCRIPTION
As per https://github.com/coinbase/temporal-ruby/issues/301

Add this so I can access get_workflow_history as a forwarded method