### PR TITLE
Relax version specifier for 'google-protobuf' to fix build errors on Apple Silicon machines

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'google-protobuf', '~> 3.19.6'
+gem 'google-protobuf', '~> 3'
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'google-protobuf', '~> 3'
+gem 'google-protobuf', '~> 3.19'
 
 gemspec

--- a/examples/Gemfile
+++ b/examples/Gemfile
@@ -4,6 +4,6 @@ gem 'temporal-ruby', path: '../'
 
 gem 'dry-types', '>= 1.7.2'
 gem 'dry-struct', '~> 1.6.0'
-gem 'google-protobuf', '~> 3'
+gem 'google-protobuf', '~> 3.19'
 
 gem 'rspec', group: :test

--- a/examples/Gemfile
+++ b/examples/Gemfile
@@ -4,6 +4,6 @@ gem 'temporal-ruby', path: '../'
 
 gem 'dry-types', '>= 1.7.2'
 gem 'dry-struct', '~> 1.6.0'
-gem 'google-protobuf', '~> 3.19.6'
+gem 'google-protobuf', '~> 3'
 
 gem 'rspec', group: :test


### PR DESCRIPTION
### Summary

This PR is a follow-up to https://github.com/coinbase/temporal-ruby/pull/308 that relaxes the gem version constraint from a `~> major.minor.patch` to a `~> major.minor` constraint. This means that any `3.x` version of `google-protobuf` is allowed, as long as the minor version is _at least_ `3.19`.

Doing so makes `bundle` resolve a much newer version of the `grpc` gem (on my machine, it makes it resolve `1.65.1` (released in July 2024) instead of `1.42.0` (released in Dec 2021)).

### Motivation

The older `grpc` gem version `1.42.0` has a known issue that causes build failures on Apple Silicon macOS systems: https://github.com/grpc/grpc/issues/35148. This is fixed in recent versions of the `grpc` gem.

By using a newer version of the `grpc` gem, fresh bundle installs on Apple Silicon computers work without any workarounds/special `bundle`/clang flags needed :tada:

### Test plan

I ran a couple example `bundle` installs before/after the changes in this PR on my system. In between each run, I deleted the `Gemfile.lock`'s, and then ran `bundle clean --force` with everything in the `Gemfile` temporarily commented-out (based on [this approach](https://stackoverflow.com/a/62320946)). I also had to manually-reinstall `rake` and `yard` after doing so using `gem install rake` and `gem install yard`.

#### System specifications

```
Apple M1 Max
macOS Sonoma 14.5
Ruby 3.1.4p223 (2023-03-30 revision 957bb7cb81) [arm64-darwin22]
Bundler version 2.5.16
```

#### Without change in this PR

On a fresh run of `bundle` (with no lockfile) on my machine without this PR, I get the following resolutions followed by a clang build failure of the `grpc` gem's native components:

```
Fetching gem metadata from https://rubygems.org/.
Fetching bundler 2.5.4
Installing bundler 2.5.4
Fetching gem metadata from https://rubygems.org/.......
Fetching base64 0.2.0
Fetching coderay 1.1.3
Fetching google-protobuf 3.19.6
Fetching grpc-tools 1.65.1
Fetching method_source 1.1.0
Fetching bigdecimal 3.1.8
Fetching diff-lcs 1.5.1
Fetching fabrication 2.31.0
Installing base64 0.2.0
Installing coderay 1.1.3
Fetching rspec-support 3.10.3
Installing google-protobuf 3.19.6 with native extensions
Fetching yard 0.9.36
Installing bigdecimal 3.1.8 with native extensions
Installing method_source 1.1.0
Installing diff-lcs 1.5.1
Installing fabrication 2.31.0
Installing rspec-support 3.10.3
Fetching pry 0.14.2
Installing pry 0.14.2
Installing yard 0.9.36
Fetching rspec-core 3.10.2
Installing rspec-core 3.10.2
Fetching rspec-mocks 3.10.3
Fetching rspec-expectations 3.10.2
Installing rspec-mocks 3.10.3
Installing rspec-expectations 3.10.2
Fetching rspec 3.10.0
Installing rspec 3.10.0
Installing grpc-tools 1.65.1
Fetching googleapis-common-protos-types 1.15.0
Installing googleapis-common-protos-types 1.15.0
Fetching grpc 1.48.0
Installing grpc 1.48.0 with native extensions
Fetching oj 3.16.4
Installing oj 3.16.4 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

make failed, exit code 2

... a bunch of clang output and a single error ...

An error occurred while installing grpc (1.48.0), and Bundler cannot continue.

In Gemfile:
  temporal-ruby was resolved to 0.1.1, which depends on
    grpc
```

Note `google-protobuf` resolving to `3.19.6` and `grpc` resolving to `1.48.0`.

Similarly, running `bundle` in the `examples` directory has a similar gem resolution/error.

#### With change in this PR

A fresh `bundle` run produces the following resolutions:

```
Fetching base64 0.2.0
Fetching bigdecimal 3.1.8
Fetching coderay 1.1.3
Fetching diff-lcs 1.5.1
Fetching fabrication 2.31.0
Fetching google-protobuf 3.25.4
Fetching grpc-tools 1.65.1
Fetching method_source 1.1.0
Installing base64 0.2.0
Installing diff-lcs 1.5.1
Installing bigdecimal 3.1.8 with native extensions
Installing coderay 1.1.3
Fetching rspec-support 3.10.3
Installing google-protobuf 3.25.4 with native extensions
Installing method_source 1.1.0
Installing fabrication 2.31.0
Installing rspec-support 3.10.3
Fetching pry 0.14.2
Installing pry 0.14.2
Fetching rspec-expectations 3.10.2
Fetching rspec-mocks 3.10.3
Fetching rspec-core 3.10.2
Installing rspec-expectations 3.10.2
Installing rspec-mocks 3.10.3
Installing rspec-core 3.10.2
Fetching rspec 3.10.0
Installing rspec 3.10.0
Installing grpc-tools 1.65.1
Fetching googleapis-common-protos-types 1.15.0
Installing googleapis-common-protos-types 1.15.0
Fetching grpc 1.65.1
Installing grpc 1.65.1 with native extensions
Fetching oj 3.16.4
Installing oj 3.16.4 with native extensions
Bundle complete! 7 Gemfile dependencies, 20 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
```

Note `google-protobuf` resolving to `3.25.4` and `grpc` resolving to `1.65.1`.

Similarly, running `bundle` in the `examples` directory now succeeds.
