### PR TITLE
Support passing activity task rate limit on worker options

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ Temporal::Worker.new(
   workflow_thread_pool_size: 10, # how many threads poll for workflows
   binary_checksum: nil, # identifies the version of workflow worker code
   activity_poll_retry_seconds: 0, # how many seconds to wait after unsuccessful poll for activities
-  workflow_poll_retry_seconds: 0  # how many seconds to wait after unsuccessful poll for workflows
+  workflow_poll_retry_seconds: 0,  # how many seconds to wait after unsuccessful poll for workflows
+  activity_max_tasks_per_second: 0 # rate-limit for starting activity tasks (new activities + retries) on the task queue
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Temporal::Worker.new(
   workflow_thread_pool_size: 10, # how many threads poll for workflows
   binary_checksum: nil, # identifies the version of workflow worker code
   activity_poll_retry_seconds: 0, # how many seconds to wait after unsuccessful poll for activities
-  workflow_poll_retry_seconds: 0,  # how many seconds to wait after unsuccessful poll for workflows
+  workflow_poll_retry_seconds: 0, # how many seconds to wait after unsuccessful poll for workflows
   activity_max_tasks_per_second: 0 # rate-limit for starting activity tasks (new activities + retries) on the task queue
 )
 ```

--- a/lib/temporal/activity/poller.rb
+++ b/lib/temporal/activity/poller.rb
@@ -11,7 +11,8 @@ module Temporal
     class Poller
       DEFAULT_OPTIONS = {
         thread_pool_size: 20,
-        poll_retry_seconds: 0
+        poll_retry_seconds: 0,
+        max_tasks_per_second: 0 # unlimited
       }.freeze
 
       def initialize(namespace, task_queue, activity_lookup, config, middleware = [], options = {})
@@ -91,7 +92,8 @@ module Temporal
       end
 
       def poll_for_task
-        connection.poll_activity_task_queue(namespace: namespace, task_queue: task_queue)
+        connection.poll_activity_task_queue(namespace: namespace, task_queue: task_queue,
+                                            max_tasks_per_second: max_tasks_per_second)
       rescue ::GRPC::Cancelled
         # We're shutting down and we've already reported that in the logs
         nil
@@ -113,6 +115,10 @@ module Temporal
 
       def poll_retry_seconds
         @options[:poll_retry_seconds]
+      end
+
+      def max_tasks_per_second
+        @options[:max_tasks_per_second]
       end
 
       def thread_pool

--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -256,7 +256,7 @@ module Temporal
         client.respond_workflow_task_failed(request)
       end
 
-      def poll_activity_task_queue(namespace:, task_queue:)
+      def poll_activity_task_queue(namespace:, task_queue:, max_tasks_per_second: 0)
         request = Temporalio::Api::WorkflowService::V1::PollActivityTaskQueueRequest.new(
           identity: identity,
           namespace: namespace,
@@ -264,6 +264,12 @@ module Temporal
             name: task_queue
           )
         )
+
+        if max_tasks_per_second > 0
+          request.task_queue_metadata = Temporalio::Api::TaskQueue::V1::TaskQueueMetadata.new(
+            max_tasks_per_second: Google::Protobuf::DoubleValue.new(value: max_tasks_per_second)
+          )
+        end
 
         poll_mutex.synchronize do
           return unless can_poll?

--- a/spec/unit/lib/temporal/activity/poller_spec.rb
+++ b/spec/unit/lib/temporal/activity/poller_spec.rb
@@ -199,6 +199,36 @@ describe Temporal::Activity::Poller do
     end
   end
 
+  context 'when max_tasks_per_second is set' do
+    subject do
+      described_class.new(
+        namespace,
+        task_queue,
+        lookup,
+        config,
+        middleware,
+        {
+          max_tasks_per_second: 32
+        }
+      )
+    end
+
+    it 'sends PollActivityTaskQueue requests with the configured task rate-limit' do
+      times = poll(nil, times: 2)
+      expect(times).to be >= 2
+
+      expect(connection).to have_received(:poll_activity_task_queue)
+        .with(
+          namespace: namespace,
+          task_queue: task_queue,
+          max_tasks_per_second: 32
+        )
+        .at_least(2)
+        .times
+    end
+  end
+
+
   context 'when connection is unable to poll and poll_retry_seconds is set' do
     subject do
       described_class.new(


### PR DESCRIPTION
### Summary

This PR exposes the `activity_max_tasks_per_second` option when constructing a new `Temporal::Worker` instance. This setting sets the `max_tasks_per_second` option when making `PollActivityTaskQueue` RPCs to the server, which has the effect of limiting how fast the server will give out activity tasks (both new activities and retries of already-running activities).

This same option is exposed in other SDKs; for example in Java it's available on the `WorkerOptions` struct as [the `setMaxTaskQueueActivitiesPerSecond` option](<https://javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/worker/WorkerOptions.Builder.html#setMaxTaskQueueActivitiesPerSecond(double)>). The doc comment added in this PR was based off of the doc comment in the Java SDK. The semantics of the values `activity_max_tasks_per_second` can be (non-negative decimal number) and when it sets set on the wire (if it's > 0) was copied directly from [the Java SDK's implementation, here](https://git.corp.stripe.com/stripe-private-oss-forks/temporal-sdk-java/blob/7e3902e3e7b59ee2c85415524eafcbdeccdc4f7d/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityPollTask.java#L73-L78) (although it diverges slightly from the [Go SDK](https://github.com/temporalio/sdk-go/blob/9c40461e456e36dc4e23215d73f410ef6e9b85dd/internal/internal_task_pollers.go#L943)).

### Motivation

Allow Ruby workers to control the rate of processing activities, to control impact on downstream systems.

### Test plan

#### Unit tests

Existing unit tests/example unit tests pass, and the new tests I added validate that, at each step, the option is making its way to the underlying gRPC connection:

```sh
bundle exec rspec spec/
cd examples && bundle exec rspec spec/
```

#### Manual tests

I also manually validated that the activity task rate limit works as expected. To do so, I modified the `examples/bin/worker` script to include a rate-limit on the `Worker.new` call:

```rb
worker = Temporal::Worker.new(binary_checksum: `git show HEAD -s --format=%H`.strip, activity_max_tasks_per_second: 0.5)
```

Then, I ran the `AsyncHelloWorldWorkflow` workflow with 10 activities, and validated that it took around 20-30 seconds (10 activities \* 0.5 activities/second + a bit of overhead/inaccuracy) for the workflow to complete:

```sh
cd examples
docker-compose up
bin/worker # with special code patch
bin/trigger AsyncHelloWorldWorkflow 10
```

![image](https://github.com/user-attachments/assets/6d5c6085-52fe-4b3f-b1a0-aa9fb3b39465)

Repeating the test _without_ the change to `examples/bin/worker` (i.e. an unlimited activity task queue) shows that the rate-limit makes a meaningful difference:

![image](https://github.com/user-attachments/assets/cbc0cd34-d40d-4ceb-852c-252fe0fb051b)
