### PR TITLE
[Fix] Fix integration specs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Start dependencies
         run: |
-          docker-compose \
+          docker compose \
             -f examples/docker-compose.yml \
             up -d
 


### PR DESCRIPTION
Looks like GitHub actions docker finally got updated and now uses `docker compose` instead of `docker-compose`