### PR TITLE
fix: add a loop to await_workflow_result so it will keep retrying until the workflow is completed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,10 @@ PROTO_OUT := lib/gen
 proto:
 	$(foreach PROTO_DIR,$(PROTO_DIRS),bundle exec grpc_tools_ruby_protoc -Iproto --ruby_out=$(PROTO_OUT) --grpc_out=$(PROTO_OUT) $(PROTO_DIR)*.proto;)
 
+	# Need to only load imports if not disabled
+	sed -i "/require 'temporal/ s|\(.*\)|\1 unless ENV['COINBASE_TEMPORAL_RUBY_DISABLE_PROTO_LOAD'] == '1'|" \
+		lib/gen/temporal/api/operatorservice/v1/service_services_pb.rb
+	sed -i "/require 'temporal/ s|\(.*\)|\1 unless ENV['COINBASE_TEMPORAL_RUBY_DISABLE_PROTO_LOAD'] == '1'|" \
+		lib/gen/temporal/api/workflowservice/v1/service_services_pb.rb
+
 .PHONY: proto

--- a/lib/gen/temporal/api/operatorservice/v1/service_services_pb.rb
+++ b/lib/gen/temporal/api/operatorservice/v1/service_services_pb.rb
@@ -25,7 +25,7 @@
 #
 
 require 'grpc'
-require 'temporal/api/operatorservice/v1/service_pb'
+require 'temporal/api/operatorservice/v1/service_pb' unless ENV['COINBASE_TEMPORAL_RUBY_DISABLE_PROTO_LOAD'] == '1'
 
 module Temporalio
   module Api

--- a/lib/gen/temporal/api/workflowservice/v1/service_services_pb.rb
+++ b/lib/gen/temporal/api/workflowservice/v1/service_services_pb.rb
@@ -25,7 +25,7 @@
 #
 
 require 'grpc'
-require 'temporal/api/workflowservice/v1/service_pb'
+require 'temporal/api/workflowservice/v1/service_pb' unless ENV['COINBASE_TEMPORAL_RUBY_DISABLE_PROTO_LOAD'] == '1'
 
 module Temporalio
   module Api

--- a/lib/temporal.rb
+++ b/lib/temporal.rb
@@ -1,5 +1,7 @@
-# Protoc wants all of its generated files on the LOAD_PATH
-$LOAD_PATH << File.expand_path('./gen', __dir__)
+# Protoc wants all of its generated files on the LOAD_PATH. Only require protos if not disabled.
+unless ENV['COINBASE_TEMPORAL_RUBY_DISABLE_PROTO_LOAD'] == '1'
+  $LOAD_PATH << File.expand_path('./gen', __dir__)
+end
 
 require 'securerandom'
 require 'forwardable'

--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -3,8 +3,6 @@ require 'time'
 require 'google/protobuf/well_known_types'
 require 'securerandom'
 require 'json'
-require 'gen/temporal/api/workflowservice/v1/service_services_pb'
-require 'gen/temporal/api/operatorservice/v1/service_services_pb'
 require 'temporal/connection/errors'
 require 'temporal/connection/interceptors/client_name_version_interceptor'
 require 'temporal/connection/serializer'
@@ -13,12 +11,16 @@ require 'temporal/connection/serializer/backfill'
 require 'temporal/connection/serializer/schedule'
 require 'temporal/connection/serializer/workflow_id_reuse_policy'
 
-# Only require protos if not disabled
+# Only require protos if not disabled. This env var is commonly set to work alongside the temporalio/sdk-ruby project.
 unless ENV['COINBASE_TEMPORAL_RUBY_DISABLE_PROTO_LOAD'] == '1'
   require 'gen/temporal/api/filter/v1/message_pb'
   require 'gen/temporal/api/enums/v1/workflow_pb'
   require 'gen/temporal/api/enums/v1/common_pb'
 end
+
+# These are gRPC stubs, not protos, and therefore are not disabled when protos are
+require 'gen/temporal/api/workflowservice/v1/service_services_pb'
+require 'gen/temporal/api/operatorservice/v1/service_services_pb'
 
 module Temporal
   module Connection

--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -3,11 +3,8 @@ require 'time'
 require 'google/protobuf/well_known_types'
 require 'securerandom'
 require 'json'
-require 'gen/temporal/api/filter/v1/message_pb'
 require 'gen/temporal/api/workflowservice/v1/service_services_pb'
 require 'gen/temporal/api/operatorservice/v1/service_services_pb'
-require 'gen/temporal/api/enums/v1/workflow_pb'
-require 'gen/temporal/api/enums/v1/common_pb'
 require 'temporal/connection/errors'
 require 'temporal/connection/interceptors/client_name_version_interceptor'
 require 'temporal/connection/serializer'
@@ -15,6 +12,13 @@ require 'temporal/connection/serializer/failure'
 require 'temporal/connection/serializer/backfill'
 require 'temporal/connection/serializer/schedule'
 require 'temporal/connection/serializer/workflow_id_reuse_policy'
+
+# Only require protos if not disabled
+unless ENV['COINBASE_TEMPORAL_RUBY_DISABLE_PROTO_LOAD'] == '1'
+  require 'gen/temporal/api/filter/v1/message_pb'
+  require 'gen/temporal/api/enums/v1/workflow_pb'
+  require 'gen/temporal/api/enums/v1/common_pb'
+end
 
 module Temporal
   module Connection

--- a/lib/temporal/connection/serializer/base.rb
+++ b/lib/temporal/connection/serializer/base.rb
@@ -1,6 +1,10 @@
 require 'oj'
-require 'gen/temporal/api/common/v1/message_pb'
-require 'gen/temporal/api/command/v1/message_pb'
+
+# Only require protos if not disabled
+unless ENV['COINBASE_TEMPORAL_RUBY_DISABLE_PROTO_LOAD'] == '1'
+  require 'gen/temporal/api/common/v1/message_pb'
+  require 'gen/temporal/api/command/v1/message_pb'
+end
 
 module Temporal
   module Connection

--- a/lib/temporal/connection/serializer/schedule_overlap_policy.rb
+++ b/lib/temporal/connection/serializer/schedule_overlap_policy.rb
@@ -1,4 +1,5 @@
 require "temporal/connection/serializer/base"
+require "gen/temporal/api/enums/v1/schedule_pb"
 
 module Temporal
   module Connection

--- a/lib/temporal/connection/serializer/schedule_overlap_policy.rb
+++ b/lib/temporal/connection/serializer/schedule_overlap_policy.rb
@@ -1,5 +1,9 @@
 require "temporal/connection/serializer/base"
-require "gen/temporal/api/enums/v1/schedule_pb"
+
+# Only require protos if not disabled
+unless ENV['COINBASE_TEMPORAL_RUBY_DISABLE_PROTO_LOAD'] == '1'
+  require "gen/temporal/api/enums/v1/schedule_pb"
+end
 
 module Temporal
   module Connection

--- a/lib/temporal/testing/replay_tester.rb
+++ b/lib/temporal/testing/replay_tester.rb
@@ -1,10 +1,14 @@
-require "gen/temporal/api/history/v1/message_pb"
 require "json"
 require "temporal/errors"
 require "temporal/metadata/workflow_task"
 require "temporal/middleware/chain"
 require "temporal/workflow/executor"
 require "temporal/workflow/stack_trace_tracker"
+
+# Only require protos if not disabled
+unless ENV['COINBASE_TEMPORAL_RUBY_DISABLE_PROTO_LOAD'] == '1'
+  require "gen/temporal/api/history/v1/message_pb"
+end
 
 module Temporal
   module Testing

--- a/spec/unit/lib/temporal/client_spec.rb
+++ b/spec/unit/lib/temporal/client_spec.rb
@@ -449,6 +449,31 @@ describe Temporal::Client do
       )
     end
 
+    it 'retries if there is till there is no closed event' do
+      completed_event = Fabricate(:workflow_completed_event, result: nil)
+      response_with_no_closed_event = Fabricate(:workflow_execution_history, events: [])
+      response_with_closed_event = Fabricate(:workflow_execution_history, events: [completed_event])
+
+      expect(connection)
+        .to receive(:get_workflow_execution_history)
+        .with(
+          namespace: 'some-namespace',
+          workflow_id: workflow_id,
+          run_id: run_id,
+          wait_for_new_event: true,
+          event_type: :close,
+          timeout: 30,
+        )
+        .and_return(response_with_no_closed_event, response_with_closed_event)
+
+
+        subject.await_workflow_result(
+        NamespacedWorkflow,
+        workflow_id: workflow_id,
+        run_id: run_id,
+      )
+    end
+
     it 'can override the namespace' do
       completed_event = Fabricate(:workflow_completed_event, result: nil)
       response = Fabricate(:workflow_execution_history, events: [completed_event])


### PR DESCRIPTION
this is based on this PR: https://github.com/coinbase/temporal-ruby/pull/305/files