### PR TITLE
fix(client): Missing require import for reset_reapply_type module

### DIFF
--- a/lib/temporal/client.rb
+++ b/lib/temporal/client.rb
@@ -11,6 +11,7 @@ require 'temporal/workflow/execution_info'
 require 'temporal/workflow/executions'
 require 'temporal/workflow/status'
 require 'temporal/reset_strategy'
+require 'temporal/reset_reapply_type'
 
 module Temporal
   class Client


### PR DESCRIPTION
I've noticed that when I try to use `reset_workflow` I get `NameError: uninitialized constant Temporal::ResetReapplyType` unless I provide `reset_reapply_type: :none` to the parameter list