### PR TITLE
Make `Activity::Context#metadata` public

### DIFF
--- a/lib/temporal/activity/context.rb
+++ b/lib/temporal/activity/context.rb
@@ -20,7 +20,7 @@ module Temporal
         @last_heartbeat_throttled = false
       end
 
-      attr_reader :heartbeat_check_scheduled, :cancel_requested, :last_heartbeat_throttled
+      attr_reader :metadata, :heartbeat_check_scheduled, :cancel_requested, :last_heartbeat_throttled
 
       def async
         @async = true
@@ -113,7 +113,7 @@ module Temporal
 
       private
 
-      attr_reader :connection, :metadata, :heartbeat_thread_pool, :config, :heartbeat_mutex, :last_heartbeat_details
+      attr_reader :connection, :heartbeat_thread_pool, :config, :heartbeat_mutex, :last_heartbeat_details
 
       def task_token
         metadata.task_token

--- a/spec/unit/lib/temporal/activity/context_spec.rb
+++ b/spec/unit/lib/temporal/activity/context_spec.rb
@@ -189,4 +189,10 @@ describe Temporal::Activity::Context do
       expect(subject.name).to eq('TestActivity')
     end
   end
+
+  describe '#metadata' do
+    it 'returns metadata' do
+      expect(subject.metadata).to eq(metadata)
+    end
+  end
 end


### PR DESCRIPTION
We want to access metadata from an activity context. This is useful for attaching metadata context, like the workflow name or id, to logs or exception metadata. `Workflow::Context#metadata` is already public, so this matches that behavior and makes `Activity::Context#metadata` public as well.