### PR TITLE
Improve error handling in external signals

### DIFF
--- a/examples/spec/integration/wait_for_external_signal_workflow_spec.rb
+++ b/examples/spec/integration/wait_for_external_signal_workflow_spec.rb
@@ -76,7 +76,7 @@ describe WaitForExternalSignalWorkflow do
         run_id: run_id,
       )
 
-      expect(result).to eq(:workflow_execution_not_found)
+      expect(result).to match("Failed to send external signal because execution with workflow ID '#{receiver_workflow_id}' could not be found or has already completed")
     end
   end
 end

--- a/examples/spec/integration/wait_for_external_signal_workflow_spec.rb
+++ b/examples/spec/integration/wait_for_external_signal_workflow_spec.rb
@@ -11,7 +11,7 @@ describe WaitForExternalSignalWorkflow do
       run_id = Temporal.start_workflow(
         WaitForExternalSignalWorkflow,
         signal_name,
-        options: {workflow_id: receiver_workflow_id}
+        options: {workflow_id: receiver_workflow_id, timeouts: { execution: 30 }}
       )
 
       Temporal.start_workflow(
@@ -42,14 +42,14 @@ describe WaitForExternalSignalWorkflow do
       Temporal.start_workflow(
         WaitForExternalSignalWorkflow,
         signal_name,
-        options: {workflow_id: receiver_workflow_id}
+        options: {workflow_id: receiver_workflow_id, timeouts: { execution: 30 }}
       )
 
       run_id = Temporal.start_workflow(
         SendSignalToExternalWorkflow,
         signal_name,
         receiver_workflow_id,
-        options: {workflow_id: sender_workflow_id}
+        options: {workflow_id: sender_workflow_id, timeouts: { execution: 30 }}
       )
 
       result = Temporal.await_workflow_result(
@@ -68,7 +68,7 @@ describe WaitForExternalSignalWorkflow do
         SendSignalToExternalWorkflow,
         signal_name,
         receiver_workflow_id,
-        options: {workflow_id: sender_workflow_id})
+        options: {workflow_id: sender_workflow_id, timeouts: { execution: 30 } })
 
       result = Temporal.await_workflow_result(
         SendSignalToExternalWorkflow,
@@ -76,7 +76,7 @@ describe WaitForExternalSignalWorkflow do
         run_id: run_id,
       )
 
-      expect(result).to eq(:failed)
+      expect(result).to eq(:workflow_execution_not_found)
     end
   end
 end

--- a/examples/workflows/send_signal_to_external_workflow.rb
+++ b/examples/workflows/send_signal_to_external_workflow.rb
@@ -2,7 +2,7 @@
 # This is different than using the Client#send_signal method which is
 # for signaling a workflow *from outside* any workflow.
 #
-# Returns :success or :failed
+# Returns :success on success, or a specific error message on failure
 #
 class SendSignalToExternalWorkflow < Temporal::Workflow
   def execute(signal_name, target_workflow)
@@ -11,7 +11,7 @@ class SendSignalToExternalWorkflow < Temporal::Workflow
 
     status = nil
     future.done { status = :success }
-    future.failed { |error| status = error }
+    future.failed { |error| status = error.to_s }
     future.get
     status
   end

--- a/examples/workflows/send_signal_to_external_workflow.rb
+++ b/examples/workflows/send_signal_to_external_workflow.rb
@@ -8,10 +8,11 @@ class SendSignalToExternalWorkflow < Temporal::Workflow
   def execute(signal_name, target_workflow)
     logger.info("Send a signal to an external workflow")
     future = workflow.signal_external_workflow(WaitForExternalSignalWorkflow, signal_name, target_workflow, nil, ["arg1", "arg2"])
-    @status = nil
-    future.done { @status = :success }
-    future.failed { @status = :failed }
+
+    status = nil
+    future.done { status = :success }
+    future.failed { |error| status = error }
     future.get
-    @status
+    status
   end
 end

--- a/lib/temporal/errors.rb
+++ b/lib/temporal/errors.rb
@@ -24,6 +24,20 @@ module Temporal
   # Represents when a child workflow is terminated
   class ChildWorkflowTerminatedError < Error; end
 
+  # Base class for the set of errors that can result from sending an external
+  # signal in a workflow to another workflow
+  class ExternalSignalError < Error; end
+
+  # Occurs when the target workflow execution does not exist or has already been completed
+  class ExternalSignalExecutionNotFoundError < ExternalSignalError; end
+
+  # Occurs when the namespace of the target workflow does not exist
+  class ExternalSignalNamespaceNotFoundError < ExternalSignalError; end
+
+  # Occurs when the maximum signals per second per workflow execution is exceeded. For self
+  # hosted Temporal server, this is configured via history.maximumSignalsPerExecution.
+  class ExternalSignalLimitExceededError < ExternalSignalError; end
+
   # A superclass for activity exceptions raised explicitly
   # with the intent to propagate to a workflow
   # With v2 serialization (set with Temporal::Configuration#use_error_serialization_v2=true) you can

--- a/lib/temporal/workflow/context.rb
+++ b/lib/temporal/workflow/context.rb
@@ -439,22 +439,9 @@ module Temporal
           future.success_callbacks.each { |callback| call_in_fiber(callback, result) }
         end
 
-        dispatcher.register_handler(target, 'failed') do |cause|
-          reason =
-            case cause
-            when :SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_UNSPECIFIED
-              :unspecified
-            when :SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_EXTERNAL_WORKFLOW_EXECUTION_NOT_FOUND
-              :workflow_execution_not_found
-            when :SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_NAMESPACE_NOT_FOUND
-              :namespace_not_found
-            when :SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_SIGNAL_COUNT_LIMIT_EXCEEDED
-              :signal_count_limit_exceeded
-            else
-              :unknown
-            end
-          future.fail(reason)
-          future.failure_callbacks.each { |callback| call_in_fiber(callback, reason) }
+        dispatcher.register_handler(target, 'failed') do |error|
+          future.fail(error)
+          future.failure_callbacks.each { |callback| call_in_fiber(callback, error) }
         end
 
         future

--- a/lib/temporal/workflow/errors.rb
+++ b/lib/temporal/workflow/errors.rb
@@ -78,6 +78,25 @@ module Temporal
         end
       end
 
+      def self.generate_error_for_external_signal(cause:, namespace:, workflow_id:)
+        case cause
+        when :SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_EXTERNAL_WORKFLOW_EXECUTION_NOT_FOUND
+          Temporal::ExternalSignalExecutionNotFoundError.new(
+            "Failed to send external signal because execution with workflow ID '#{workflow_id}' could not be found or has already completed"
+          )
+        when :SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_NAMESPACE_NOT_FOUND
+          Temporal::ExternalSignalNamespaceNotFoundError.new(
+            "Failed to send external signal because namespace #{namespace} could not be found"
+          )
+        when :SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_SIGNAL_COUNT_LIMIT_EXCEEDED
+          Temporal::ExternalSignalLimitExceededError.new(
+            "Failed to send external signal because per workflow limit was exceeded"
+          )
+        else
+          Temporal::ExternalSignalError.new("Failed to send external workflow signal with unknown cause: #{cause}")
+        end
+      end
+
       private_class_method def self.safe_constantize(const)
         Object.const_get(const) if Object.const_defined?(const)
       rescue NameError

--- a/lib/temporal/workflow/state_manager.rb
+++ b/lib/temporal/workflow/state_manager.rb
@@ -416,7 +416,7 @@ module Temporal
           # Temporal Server cannot Signal the targeted Workflow
           # Usually because the Workflow could not be found
           state_machine.fail
-          dispatch(history_target, 'failed', 'StandardError', event.attributes.cause)
+          dispatch(history_target, 'failed', event.attributes.cause)
 
         when 'EXTERNAL_WORKFLOW_EXECUTION_SIGNALED'
           # Temporal Server has successfully Signaled the targeted Workflow

--- a/lib/temporal/workflow/state_manager.rb
+++ b/lib/temporal/workflow/state_manager.rb
@@ -416,7 +416,12 @@ module Temporal
           # Temporal Server cannot Signal the targeted Workflow
           # Usually because the Workflow could not be found
           state_machine.fail
-          dispatch(history_target, 'failed', event.attributes.cause)
+          error = Temporal::Workflow::Errors.generate_error_for_external_signal(
+            cause: event.attributes.cause,
+            namespace: event.attributes.namespace,
+            workflow_id: event.attributes.workflow_execution.workflow_id
+          )
+          dispatch(history_target, 'failed', error)
 
         when 'EXTERNAL_WORKFLOW_EXECUTION_SIGNALED'
           # Temporal Server has successfully Signaled the targeted Workflow

--- a/spec/fabricators/grpc/history_event_fabricator.rb
+++ b/spec/fabricators/grpc/history_event_fabricator.rb
@@ -221,3 +221,40 @@ Fabricator(:api_workflow_execution_signaled_event, from: :api_history_event) do
     )
   end
 end
+
+Fabricator(:api_signal_external_workflow_execution_initiated, from: :api_history_event) do
+  transient :workflow_id, :run_id
+  event_type { Temporalio::Api::Enums::V1::EventType::EVENT_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED }
+  signal_external_workflow_execution_initiated_event_attributes do |attrs|
+    Temporalio::Api::History::V1::SignalExternalWorkflowExecutionInitiatedEventAttributes.new(
+      signal_name: 'a_signal',
+      input: nil,
+      workflow_task_completed_event_id: attrs[:event_id] - 1,
+      workflow_execution: Temporalio::Api::Common::V1::WorkflowExecution.new(workflow_id: attrs[:workflow_id], run_id: attrs[:run_id])
+    )
+  end
+end
+
+Fabricator(:api_external_workflow_execution_signaled, from: :api_history_event) do
+  transient :workflow_id, :run_id
+  event_type { Temporalio::Api::Enums::V1::EventType::EVENT_TYPE_EXTERNAL_WORKFLOW_EXECUTION_SIGNALED }
+  external_workflow_execution_signaled_event_attributes do |attrs|
+    Temporalio::Api::History::V1::ExternalWorkflowExecutionSignaledEventAttributes.new(
+      initiated_event_id: attrs[:event_id] - 1,
+      workflow_execution: Temporalio::Api::Common::V1::WorkflowExecution.new(workflow_id: attrs[:workflow_id], run_id: attrs[:run_id])
+    )
+  end
+end
+
+Fabricator(:api_signal_external_workflow_execution_failed, from: :api_history_event) do
+  transient :workflow_id, :run_id
+  event_type { Temporalio::Api::Enums::V1::EventType::EVENT_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED }
+  signal_external_workflow_execution_failed_event_attributes do |attrs|
+    Temporalio::Api::History::V1::SignalExternalWorkflowExecutionFailedEventAttributes.new(
+      initiated_event_id: attrs[:event_id] - 1,
+      workflow_task_completed_event_id: attrs[:event_id] - 2,
+      workflow_execution: Temporalio::Api::Common::V1::WorkflowExecution.new(workflow_id: attrs[:workflow_id], run_id: attrs[:run_id]),
+      cause: Temporalio::Api::Enums::V1::SignalExternalWorkflowExecutionFailedCause::SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_EXTERNAL_WORKFLOW_EXECUTION_NOT_FOUND
+    )
+  end
+end

--- a/spec/unit/lib/temporal/workflow/context_spec.rb
+++ b/spec/unit/lib/temporal/workflow/context_spec.rb
@@ -312,11 +312,8 @@ describe Temporal::Workflow::Context do
       expect(future.finished?).to be(false)
       expect(future.failed?).to be(false)
 
-      dispatcher.dispatch(
-        target,
-        'failed',
-        :SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_EXTERNAL_WORKFLOW_EXECUTION_NOT_FOUND
-      )
+      error = Temporal::ExternalSignalExecutionNotFoundError.new
+      dispatcher.dispatch(target, 'failed', error)
 
       expect(future.finished?).to be(true)
       expect(future.failed?).to be(true)
@@ -324,7 +321,7 @@ describe Temporal::Workflow::Context do
       # no waiting for either of these
       future.wait
 
-      expect(future.get).to eq(:workflow_execution_not_found)
+      expect(future.get).to eq(error)
     end
   end
 

--- a/spec/unit/lib/temporal/workflow/state_manager_spec.rb
+++ b/spec/unit/lib/temporal/workflow/state_manager_spec.rb
@@ -508,14 +508,14 @@ describe Temporal::Workflow::StateManager do
           dispatcher.register_handler(
             history_target,
             'failed'
-          ) do |cause|
-            failed = cause
+          ) do |error|
+            failed = error
           end
 
           state_manager.apply(history.next_window)
           state_manager.apply(history.next_window)
 
-          expect(failed).to be(:SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_EXTERNAL_WORKFLOW_EXECUTION_NOT_FOUND)
+          expect(failed).to be_instance_of(Temporal::ExternalSignalExecutionNotFoundError)
         end
       end
     end


### PR DESCRIPTION
This change is a follow up to #134 that improves error handling when using external signals to send a signal from one workflow to another.

The core change is that when sending a signal fails, the value returned by calling `.get` or passed as the argument to a callback on the future returned by `workflow.signal_external_workflow` now is an error indicating the error type rather than the fixed string of `'StandardError'`. Previously, although the cause enum was passed to the dispatcher in the state manager, it was not propagated to callbacks on the future, only the fixed string.

Technically, this is a breaking change. It's unlikely existing usage of this would rely on a meaningless string constant. Still, usage of type checking of callback methods via Sorbet could be impacted when a different type is now passed (see [Sorbet docs](https://sorbet.org/docs/runtime#runtime-checked-sigs)) even if the value is not used.

There's a few other supporting changes here:
- The `WaitForExternalSignalWorkflow` sample has been updated. Its test has been updated for the most common failure mode that the target workflow does not exist. I've also added some default execution timeouts to these tests to reduce lingering workflow runs when the tests fail.
- New `StateManager` and `Workflow::Context` unit specs have been added to cover this new failure mode as well as success cases previously not covered. These can be run with,
  - `bundle exec rspec spec/unit/lib/temporal/workflow/context_spec.rb:265`
  - `bundle exec rspec spec/unit/lib/temporal/workflow/state_manager_spec.rb:437`