### PR TITLE
Ignore unknown fields on proto message decoding

### DIFF
--- a/lib/temporal/connection/converter/payload/proto_json.rb
+++ b/lib/temporal/connection/converter/payload/proto_json.rb
@@ -15,7 +15,7 @@ module Temporal
             # TODO: Add error handling.
             message_type = payload.metadata['messageType']
             descriptor = Google::Protobuf::DescriptorPool.generated_pool.lookup(message_type)
-            descriptor.msgclass.decode_json(payload.data)
+            descriptor.msgclass.decode_json(payload.data, ignore_unknown_fields: true)
           end
 
           def to_payload(data)

--- a/spec/unit/lib/temporal/connection/converter/payload/proto_json_spec.rb
+++ b/spec/unit/lib/temporal/connection/converter/payload/proto_json_spec.rb
@@ -29,4 +29,18 @@ describe Temporal::Connection::Converter::Payload::ProtoJSON do
 
     expect(subject.to_payload(input)).to be nil
   end
+
+  describe ".from_payload" do
+    it "ignores unknown fields" do
+      payload = Temporalio::Api::Common::V1::Payload.new(
+        metadata: {
+          'encoding' => described_class::ENCODING,
+          'messageType' => Temporalio::Api::Common::V1::Payload.descriptor.name,
+        },
+        data: { 'unknown' => 'field' }.to_json.b,
+      )
+
+      expect(subject.from_payload(payload)).to be_instance_of(Temporalio::Api::Common::V1::Payload)
+    end
+  end
 end


### PR DESCRIPTION
We use protocol buffers between our Ruby and Go applications at FireHydrant, and when we update the proto descriptor to add a field, it can break our Temporal workflows because the Rails application has not regenerated the messages yet (and may not need to)

Instead of breaking workflows/activities entirely, it is better to ignore missing fields on the incoming protobuf message when decoding the JSON.

This is supported by the Ruby protocol buffer gem, [see spec here.](https://github.com/protocolbuffers/protobuf/blob/243b023c4530c1349437f036feb96cd053c0a8b2/conformance/conformance_ruby.rb#L50).

I'd add this to the configuration object, [but converters are initialized as the class level](https://github.com/coinbase/temporal-ruby/blob/f41efb7bb0c9e755a07382b94e00a4f31bcd33c1/lib/temporal/configuration.rb#L59), and refactoring that is a much bigger task. 
