### PR TITLE
Support disabling proto load via environment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,10 @@ PROTO_OUT := lib/gen
 proto:
 	$(foreach PROTO_DIR,$(PROTO_DIRS),bundle exec grpc_tools_ruby_protoc -Iproto --ruby_out=$(PROTO_OUT) --grpc_out=$(PROTO_OUT) $(PROTO_DIR)*.proto;)
 
+	# Need to only load imports if not disabled
+	sed -i "/require 'temporal/ s|\(.*\)|\1 unless ENV['COINBASE_TEMPORAL_RUBY_DISABLE_PROTO_LOAD'] == '1'|" \
+		lib/gen/temporal/api/operatorservice/v1/service_services_pb.rb
+	sed -i "/require 'temporal/ s|\(.*\)|\1 unless ENV['COINBASE_TEMPORAL_RUBY_DISABLE_PROTO_LOAD'] == '1'|" \
+		lib/gen/temporal/api/workflowservice/v1/service_services_pb.rb
+
 .PHONY: proto

--- a/lib/gen/temporal/api/operatorservice/v1/service_services_pb.rb
+++ b/lib/gen/temporal/api/operatorservice/v1/service_services_pb.rb
@@ -25,7 +25,7 @@
 #
 
 require 'grpc'
-require 'temporal/api/operatorservice/v1/service_pb'
+require 'temporal/api/operatorservice/v1/service_pb' unless ENV['COINBASE_TEMPORAL_RUBY_DISABLE_PROTO_LOAD'] == '1'
 
 module Temporalio
   module Api

--- a/lib/gen/temporal/api/workflowservice/v1/service_services_pb.rb
+++ b/lib/gen/temporal/api/workflowservice/v1/service_services_pb.rb
@@ -25,7 +25,7 @@
 #
 
 require 'grpc'
-require 'temporal/api/workflowservice/v1/service_pb'
+require 'temporal/api/workflowservice/v1/service_pb' unless ENV['COINBASE_TEMPORAL_RUBY_DISABLE_PROTO_LOAD'] == '1'
 
 module Temporalio
   module Api

--- a/lib/temporal.rb
+++ b/lib/temporal.rb
@@ -1,5 +1,7 @@
-# Protoc wants all of its generated files on the LOAD_PATH
-$LOAD_PATH << File.expand_path('./gen', __dir__)
+# Protoc wants all of its generated files on the LOAD_PATH. Only require protos if not disabled.
+unless ENV['COINBASE_TEMPORAL_RUBY_DISABLE_PROTO_LOAD'] == '1'
+  $LOAD_PATH << File.expand_path('./gen', __dir__)
+end
 
 require 'securerandom'
 require 'forwardable'

--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -3,8 +3,6 @@ require 'time'
 require 'google/protobuf/well_known_types'
 require 'securerandom'
 require 'json'
-require 'gen/temporal/api/workflowservice/v1/service_services_pb'
-require 'gen/temporal/api/operatorservice/v1/service_services_pb'
 require 'temporal/connection/errors'
 require 'temporal/connection/interceptors/client_name_version_interceptor'
 require 'temporal/connection/serializer'
@@ -13,12 +11,16 @@ require 'temporal/connection/serializer/backfill'
 require 'temporal/connection/serializer/schedule'
 require 'temporal/connection/serializer/workflow_id_reuse_policy'
 
-# Only require protos if not disabled
+# Only require protos if not disabled. This env var is commonly set to work alongside the temporalio/sdk-ruby project.
 unless ENV['COINBASE_TEMPORAL_RUBY_DISABLE_PROTO_LOAD'] == '1'
   require 'gen/temporal/api/filter/v1/message_pb'
   require 'gen/temporal/api/enums/v1/workflow_pb'
   require 'gen/temporal/api/enums/v1/common_pb'
 end
+
+# These are gRPC stubs, not protos, and therefore are not disabled when protos are
+require 'gen/temporal/api/workflowservice/v1/service_services_pb'
+require 'gen/temporal/api/operatorservice/v1/service_services_pb'
 
 module Temporal
   module Connection

--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -3,11 +3,8 @@ require 'time'
 require 'google/protobuf/well_known_types'
 require 'securerandom'
 require 'json'
-require 'gen/temporal/api/filter/v1/message_pb'
 require 'gen/temporal/api/workflowservice/v1/service_services_pb'
 require 'gen/temporal/api/operatorservice/v1/service_services_pb'
-require 'gen/temporal/api/enums/v1/workflow_pb'
-require 'gen/temporal/api/enums/v1/common_pb'
 require 'temporal/connection/errors'
 require 'temporal/connection/interceptors/client_name_version_interceptor'
 require 'temporal/connection/serializer'
@@ -15,6 +12,13 @@ require 'temporal/connection/serializer/failure'
 require 'temporal/connection/serializer/backfill'
 require 'temporal/connection/serializer/schedule'
 require 'temporal/connection/serializer/workflow_id_reuse_policy'
+
+# Only require protos if not disabled
+unless ENV['COINBASE_TEMPORAL_RUBY_DISABLE_PROTO_LOAD'] == '1'
+  require 'gen/temporal/api/filter/v1/message_pb'
+  require 'gen/temporal/api/enums/v1/workflow_pb'
+  require 'gen/temporal/api/enums/v1/common_pb'
+end
 
 module Temporal
   module Connection

--- a/lib/temporal/connection/serializer/base.rb
+++ b/lib/temporal/connection/serializer/base.rb
@@ -1,6 +1,10 @@
 require 'oj'
-require 'gen/temporal/api/common/v1/message_pb'
-require 'gen/temporal/api/command/v1/message_pb'
+
+# Only require protos if not disabled
+unless ENV['COINBASE_TEMPORAL_RUBY_DISABLE_PROTO_LOAD'] == '1'
+  require 'gen/temporal/api/common/v1/message_pb'
+  require 'gen/temporal/api/command/v1/message_pb'
+end
 
 module Temporal
   module Connection

--- a/lib/temporal/testing/replay_tester.rb
+++ b/lib/temporal/testing/replay_tester.rb
@@ -1,10 +1,14 @@
-require "gen/temporal/api/history/v1/message_pb"
 require "json"
 require "temporal/errors"
 require "temporal/metadata/workflow_task"
 require "temporal/middleware/chain"
 require "temporal/workflow/executor"
 require "temporal/workflow/stack_trace_tracker"
+
+# Only require protos if not disabled
+unless ENV['COINBASE_TEMPORAL_RUBY_DISABLE_PROTO_LOAD'] == '1'
+  require "gen/temporal/api/history/v1/message_pb"
+end
 
 module Temporal
   module Testing


### PR DESCRIPTION
When working through an interop sample that has both https://github.com/coinbase/temporal-ruby and https://github.com/temporalio/sdk-ruby in the same process, it clashed due to how Google protobuf library does not allow the same qualified proto generated in different places.

After testing, I am happy to report the projects can coexist so long as the Temporal Ruby SDK's generated protos are loaded instead. So this PR checks for an env var and if that env var is set, the `require` is not called for loading protos. With this change, I have confirmed that the Coinbase Ruby SDK client can use Temporal Ruby SDK workflows, and vice versa, and that Coinbase Ruby SDK workflows can use Temporal Ruby SDK activities, and vice versa. I should have a sample showing this soon.

Note, for the `sed` changes to `Makefile`, the protos have not been regenerated for a couple of years, and if the latest `protoc` from `grpc-tools` is used it makes several changes which I didn't want to do. So I manually/temporarily run `bundle add grpc-tools --version 1.53.2` (the version at the time of last proto gen in this repo) before `make proto` to ensure these changes add no unnecessary side effects.