### PR TITLE
Remove deprecated `Temporal.configuration` function

### DIFF
--- a/lib/temporal.rb
+++ b/lib/temporal.rb
@@ -56,9 +56,8 @@ module Temporal
       @default_client = nil
     end
 
-    def configuration
-      warn '[DEPRECATION] This method is now deprecated without a substitution'
-      config
+    def config
+      @config ||= Configuration.new
     end
 
     def logger
@@ -75,9 +74,6 @@ module Temporal
       @default_client ||= Client.new(config)
     end
 
-    def config
-      @config ||= Configuration.new
-    end
 
   end
 end

--- a/lib/temporal/testing/local_workflow_context.rb
+++ b/lib/temporal/testing/local_workflow_context.rb
@@ -12,7 +12,7 @@ module Temporal
     class LocalWorkflowContext
       attr_reader :metadata, :config
 
-      def initialize(execution, workflow_id, run_id, disabled_releases, metadata, config = Temporal.configuration)
+      def initialize(execution, workflow_id, run_id, disabled_releases, metadata, config = Temporal.config)
         @last_event_id = 0
         @execution = execution
         @run_id = run_id

--- a/lib/temporal/testing/replay_tester.rb
+++ b/lib/temporal/testing/replay_tester.rb
@@ -12,7 +12,7 @@ module Temporal
     end
 
     class ReplayTester
-      def initialize(config: Temporal.configuration)
+      def initialize(config: Temporal.config)
         @config = config
       end
 

--- a/lib/temporal/worker.rb
+++ b/lib/temporal/worker.rb
@@ -33,7 +33,7 @@ module Temporal
     #   to be executed once every 10 seconds. This can be used to protect down stream services from
     #   flooding. The zero value of this uses the default value. Default is unlimited.
     def initialize(
-      config = Temporal.configuration,
+      config = Temporal.config,
       activity_thread_pool_size: Temporal::Activity::Poller::DEFAULT_OPTIONS[:thread_pool_size],
       workflow_thread_pool_size: Temporal::Workflow::Poller::DEFAULT_OPTIONS[:thread_pool_size],
       binary_checksum: Temporal::Workflow::Poller::DEFAULT_OPTIONS[:binary_checksum],

--- a/spec/unit/lib/temporal_spec.rb
+++ b/spec/unit/lib/temporal_spec.rb
@@ -71,14 +71,10 @@ describe Temporal do
     end
   end
 
-  describe '.configuration' do
-    before { allow(described_class).to receive(:warn) }
+  describe '.config' do
 
-    it 'returns Temporal::Configuration object' do
-      expect(described_class.configuration).to be_an_instance_of(Temporal::Configuration)
-      expect(described_class)
-        .to have_received(:warn)
-        .with('[DEPRECATION] This method is now deprecated without a substitution')
+    it 'returns configured Temporal::Configuration object' do
+      expect(described_class.config).to be_an_instance_of(Temporal::Configuration)
     end
   end
 


### PR DESCRIPTION
Fixes #143. For a few years there has been a noise `warn` message telling people to not use the function Temporal.configuration, but this function was still used internall in temporal-ruby.

The options were:
a) Remove the logger warn message, as whoever in the past had planned to deprecate access via `Temporal.configuration` never followed up. I don't know why they were trying to remove this method of accessing it. b) **[CHOSEN OPTION]** Raise the `config` function from `private` to be accessible externally. I don't see why this wouldn't be okay.

I ran the tests per the instructions and I get the same amount of test passes, without the noisy deprecation warnings.

I don't know the full history that led to this being half-deprecated, but this seems like a fine way to clean it up.

## Before
<img width="778" alt="image" src="https://github.com/user-attachments/assets/c9122777-9f29-4f47-8295-6099f213da2d" />

## After
<img width="832" alt="image" src="https://github.com/user-attachments/assets/52def8b4-cbb2-4194-a6af-1320e48d3bd7" />

## Breaking Change

CHANGELOG.md should have:

* **Breaking change:** `Temporal.configuration` was removed and replace by `Temporal.config`. If you previously relied on `Temporal.configuration` just update the reference to `Temporal.config`.

Also if this Gem is still doing any versioning, it's a MAJOR patch (i.e. first digit) because if removes a public-facing API, i.e. `Temporal.configuration`. If we don't want to create a breaking change, I recommend Option A above, just remove the annoying log message and let the method live on into the future.