### PR TITLE
Set the task queue kind to prevent "Unspecified task queue kind" warning

### DIFF
--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -198,7 +198,8 @@ module Temporal
           identity: identity,
           namespace: namespace,
           task_queue: Temporalio::Api::TaskQueue::V1::TaskQueue.new(
-            name: task_queue
+            name: task_queue,
+            kind: Temporalio::Api::Enums::V1::TaskQueueKind::TASK_QUEUE_KIND_NORMAL
           ),
           binary_checksum: binary_checksum
         )


### PR DESCRIPTION
Set the task queue kind when long polling for a workflow task to avoid the "Unspecified task queue kind" warning from the [Temporal server](https://github.com/temporalio/temporal/blob/0eb7f21c34b9f5c8f48878af9200db6ddab5b276/service/frontend/workflow_handler.go#L859).

This is aligned with the default behavior of the Temporal SDKs. See this PR that implements the same change in the Java SDK for reference: https://github.com/temporalio/sdk-java/pull/1420