### PR TITLE
[WorkerPoller] Make poller threads configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Changelog
 
+## 0.0.5
+
+- Make poller threads configurable
+
 ## 0.0.4
+
 - Patching
 
 ## 0.0.1
+
 - First release

--- a/README.md
+++ b/README.md
@@ -90,7 +90,9 @@ Temporal::Worker.new(
   workflow_thread_pool_size: 10, # how many threads poll for workflows
   binary_checksum: nil, # identifies the version of workflow worker code
   activity_poll_retry_seconds: 0, # how many seconds to wait after unsuccessful poll for activities
-  workflow_poll_retry_seconds: 0  # how many seconds to wait after unsuccessful poll for workflows
+  workflow_poll_retry_seconds: 0,  # how many seconds to wait after unsuccessful poll for workflows
+  activity_poller_threads: 1, # how many poller threads run for activities
+  workflow_poller_threads: 1, # how many poller threads run for workflows
 )
 ```
 

--- a/lib/temporal/activity/poller.rb
+++ b/lib/temporal/activity/poller.rb
@@ -11,6 +11,7 @@ module Temporal
     class Poller
       DEFAULT_OPTIONS = {
         thread_pool_size: 20,
+        poller_threads: 1,
         poll_retry_seconds: 0
       }.freeze
 
@@ -26,7 +27,9 @@ module Temporal
 
       def start
         @shutting_down = false
-        @thread = Thread.new(&method(:poll_loop))
+        @threads = Array.new(options[:poller_threads]) do |_i|
+          Thread.new(&method(:poll_loop))
+        end
       end
 
       def stop_polling
@@ -43,14 +46,14 @@ module Temporal
           raise "Activity poller waiting for shutdown completion without being in shutting_down state!"
         end
 
-        thread.join
+        threads.each(&:join)
         thread_pool.shutdown
         heartbeat_thread_pool.shutdown
       end
 
       private
 
-      attr_reader :namespace, :task_queue, :activity_lookup, :config, :middleware, :options, :thread
+      attr_reader :namespace, :task_queue, :activity_lookup, :config, :middleware, :options, :threads
 
       def connection
         @connection ||= Temporal::Connection.generate(config.for_connection)

--- a/lib/temporal/version.rb
+++ b/lib/temporal/version.rb
@@ -1,3 +1,3 @@
 module Temporal
-  VERSION = '0.0.4'.freeze
+  VERSION = '0.0.5'.freeze
 end

--- a/lib/temporal/worker.rb
+++ b/lib/temporal/worker.rb
@@ -26,7 +26,9 @@ module Temporal
       workflow_thread_pool_size: Temporal::Workflow::Poller::DEFAULT_OPTIONS[:thread_pool_size],
       binary_checksum: Temporal::Workflow::Poller::DEFAULT_OPTIONS[:binary_checksum],
       activity_poll_retry_seconds: Temporal::Activity::Poller::DEFAULT_OPTIONS[:poll_retry_seconds],
-      workflow_poll_retry_seconds: Temporal::Workflow::Poller::DEFAULT_OPTIONS[:poll_retry_seconds]
+      workflow_poll_retry_seconds: Temporal::Workflow::Poller::DEFAULT_OPTIONS[:poll_retry_seconds],
+      activity_poller_threads: Temporal::Activity::Poller::DEFAULT_OPTIONS[:poller_threads],
+      workflow_poller_threads: Temporal::Workflow::Poller::DEFAULT_OPTIONS[:poller_threads]
     )
       @config = config
       @workflows = Hash.new { |hash, key| hash[key] = ExecutableLookup.new }
@@ -38,10 +40,12 @@ module Temporal
       @shutting_down = false
       @activity_poller_options = {
         thread_pool_size: activity_thread_pool_size,
+        poller_threads: activity_poller_threads,
         poll_retry_seconds: activity_poll_retry_seconds
       }
       @workflow_poller_options = {
         thread_pool_size: workflow_thread_pool_size,
+        poller_threads: workflow_poller_threads,
         binary_checksum: binary_checksum,
         poll_retry_seconds: workflow_poll_retry_seconds
       }

--- a/lib/temporal/workflow/poller.rb
+++ b/lib/temporal/workflow/poller.rb
@@ -11,6 +11,7 @@ module Temporal
     class Poller
       DEFAULT_OPTIONS = {
         thread_pool_size: 10,
+        poller_threads: 1,
         binary_checksum: nil,
         poll_retry_seconds: 0
       }.freeze
@@ -28,7 +29,9 @@ module Temporal
 
       def start
         @shutting_down = false
-        @thread = Thread.new(&method(:poll_loop))
+        @threads = Array.new(options[:poller_threads]) do |_i|
+          Thread.new(&method(:poll_loop))
+        end
       end
 
       def stop_polling
@@ -45,13 +48,13 @@ module Temporal
           raise "Workflow poller waiting for shutdown completion without being in shutting_down state!"
         end
 
-        thread.join
+        threads.each(&:join)
         thread_pool.shutdown
       end
 
       private
 
-      attr_reader :namespace, :task_queue, :connection, :workflow_lookup, :config, :middleware, :workflow_middleware, :options, :thread
+      attr_reader :namespace, :task_queue, :connection, :workflow_lookup, :config, :middleware, :workflow_middleware, :options, :threads
 
       def connection
         @connection ||= Temporal::Connection.generate(config.for_connection)

--- a/spec/fabricators/grpc/history_event_fabricator.rb
+++ b/spec/fabricators/grpc/history_event_fabricator.rb
@@ -9,12 +9,12 @@ end
 include Temporal::Concerns::Payloads
 
 Fabricator(:api_history_event, from: Temporalio::Api::History::V1::HistoryEvent) do
-  event_id { 1 }
+  transient :eventId, :input
+  event_id { |attrs| attrs[:eventId] || attrs[:event_id] || 1 }
   event_time { Time.now }
-  transient input: nil
 end
 
-Fabricator(:api_workflow_execution_started_eevent, from: :api_history_event) do
+Fabricator(:api_workflow_execution_started_event, from: :api_history_event) do
   transient :headers, :search_attributes
   event_type { Temporalio::Api::Enums::V1::EventType::EVENT_TYPE_WORKFLOW_EXECUTION_STARTED }
   event_time { Time.now }
@@ -26,7 +26,7 @@ Fabricator(:api_workflow_execution_started_eevent, from: :api_history_event) do
     Temporalio::Api::History::V1::WorkflowExecutionStartedEventAttributes.new(
       workflow_type: Fabricate(:api_workflow_type),
       task_queue: Fabricate(:api_task_queue),
-      input: Temporal::JSON.serialize(attrs[:input]),
+      input: to_payloads(attrs[:input]),
       workflow_execution_timeout: 60,
       workflow_task_timeout: 15,
       original_execution_run_id: SecureRandom.uuid,
@@ -198,6 +198,36 @@ Fabricator(:api_upsert_search_attributes_event, from: :api_history_event) do
       search_attributes: Temporalio::Api::Common::V1::SearchAttributes.new(
         indexed_fields: indexed_fields
       )
+    )
+  end
+end
+
+# Thrift-style fabricators for backward compatibility
+Fabricator(:activity_task_scheduled_event_thrift, from: :api_history_event) do
+  transient :input, :eventId
+  event_id { |attrs| attrs[:eventId] || attrs[:event_id] || 1 }
+  event_type { Temporalio::Api::Enums::V1::EventType::EVENT_TYPE_ACTIVITY_TASK_SCHEDULED }
+  activity_task_scheduled_event_attributes do |attrs|
+    eid = attrs[:eventId] || attrs[:event_id] || 1
+    Temporalio::Api::History::V1::ActivityTaskScheduledEventAttributes.new(
+      activity_id: eid.to_s,
+      activity_type: Temporalio::Api::Common::V1::ActivityType.new(name: 'TestActivity'),
+      input: to_payloads(attrs[:input]),
+      workflow_task_completed_event_id: eid - 1,
+      task_queue: Fabricate(:api_task_queue)
+    )
+  end
+end
+
+Fabricator(:workflow_task_scheduled_event_thrift, from: :api_history_event) do
+  transient :eventId
+  event_id { |attrs| attrs[:eventId] || attrs[:event_id] || 1 }
+  event_type { Temporalio::Api::Enums::V1::EventType::EVENT_TYPE_WORKFLOW_TASK_SCHEDULED }
+  workflow_task_scheduled_event_attributes do |attrs|
+    Temporalio::Api::History::V1::WorkflowTaskScheduledEventAttributes.new(
+      task_queue: Fabricate(:api_task_queue),
+      start_to_close_timeout: 15,
+      attempt: 0
     )
   end
 end

--- a/spec/unit/lib/temporal/worker_spec.rb
+++ b/spec/unit/lib/temporal/worker_spec.rb
@@ -247,6 +247,7 @@ describe Temporal::Worker do
           [],
           [],
           thread_pool_size: 10,
+          poller_threads: 1,
           binary_checksum: nil,
           poll_retry_seconds: 0
         )
@@ -262,6 +263,7 @@ describe Temporal::Worker do
           [],
           [],
           thread_pool_size: 10,
+          poller_threads: 1,
           binary_checksum: nil,
           poll_retry_seconds: 0
         )
@@ -276,6 +278,7 @@ describe Temporal::Worker do
           config,
           [],
           thread_pool_size: 20,
+          poller_threads: 1,
           poll_retry_seconds: 0
         )
         .and_return(activity_poller_1)
@@ -289,6 +292,7 @@ describe Temporal::Worker do
           config,
           [],
           thread_pool_size: 20,
+          poller_threads: 1,
           poll_retry_seconds: 0
         )
         .and_return(activity_poller_2)
@@ -316,7 +320,7 @@ describe Temporal::Worker do
           an_instance_of(Temporal::ExecutableLookup),
           an_instance_of(Temporal::Configuration),
           [],
-          {thread_pool_size: 10, poll_retry_seconds: 0}
+          {thread_pool_size: 10, poller_threads: 1, poll_retry_seconds: 0}
         )
         .and_return(activity_poller)
 
@@ -365,6 +369,7 @@ describe Temporal::Worker do
           [],
           [],
           thread_pool_size: 10,
+          poller_threads: 1,
           binary_checksum: binary_checksum,
           poll_retry_seconds: 0
         )
@@ -389,7 +394,7 @@ describe Temporal::Worker do
           an_instance_of(Temporal::ExecutableLookup),
           an_instance_of(Temporal::Configuration),
           [],
-          {thread_pool_size: 20, poll_retry_seconds: 10}
+          {thread_pool_size: 20, poller_threads: 1, poll_retry_seconds: 10}
         )
         .and_return(activity_poller)
 
@@ -413,7 +418,7 @@ describe Temporal::Worker do
           an_instance_of(Temporal::Configuration),
           [],
           [],
-          {binary_checksum: nil, poll_retry_seconds: 10, thread_pool_size: 10}
+          {binary_checksum: nil, poll_retry_seconds: 10, thread_pool_size: 10, poller_threads: 1}
         )
         .and_return(workflow_poller)
 
@@ -463,6 +468,7 @@ describe Temporal::Worker do
             [entry_1],
             [entry_3],
             thread_pool_size: 10,
+            poller_threads: 1,
             binary_checksum: nil,
             poll_retry_seconds: 0
           )
@@ -477,6 +483,7 @@ describe Temporal::Worker do
             config,
             [entry_2],
             thread_pool_size: 20,
+            poller_threads: 1,
             poll_retry_seconds: 0
           )
           .and_return(activity_poller_1)

--- a/spec/unit/lib/temporal/workflow/history/event_target_spec.rb
+++ b/spec/unit/lib/temporal/workflow/history/event_target_spec.rb
@@ -43,7 +43,7 @@ describe Temporal::Workflow::History::EventTarget do
     subject { described_class.from_command(42, decision) }
 
     context 'when decision is ScheduleActivity' do
-      let(:raw_decision) { { activity_type: 'foo', activity_id: 123, input: ['bar'], domain: 'domain' } }
+      let(:raw_decision) { { activity_type: 'foo', activity_id: 123, input: ['bar'] } }
       let(:decision) { Temporal::Workflow::Command::ScheduleActivity.new(**raw_decision) }
 
       it 'sets id, type' do
@@ -102,6 +102,11 @@ describe Temporal::Workflow::History::EventTarget do
         expect(subject).to eq(false)
       end
     end
+  end
+
+  describe '.from_event for specific event types' do
+    subject { described_class.from_event(event) }
+    let(:event) { Temporal::Workflow::History::Event.new(raw_event) }
 
     context 'when event is ACTIVITY_CANCELED' do
       let(:raw_event) { Fabricate(:api_activity_task_canceled_event) }

--- a/spec/unit/lib/temporal/workflow/state_manager_spec.rb
+++ b/spec/unit/lib/temporal/workflow/state_manager_spec.rb
@@ -32,7 +32,7 @@ describe Temporal::Workflow::StateManager do
         )
 
         state_manager.schedule(terminal_command)
-        expect(state_manager.workflows.length).to eq(1)
+        expect(state_manager.commands.length).to eq(1)
         expect do
           state_manager.schedule(next_command)
         end.to raise_error(Temporal::WorkflowAlreadyCompletingError)
@@ -74,11 +74,11 @@ describe Temporal::Workflow::StateManager do
         end
 
         it 'applies' do
-          expect(subject.decisions.length).to eq(1)
+          expect(subject.commands.length).to eq(1)
 
           subject.apply(window)
 
-          expect(subject.decisions.length).to eq(0)
+          expect(subject.commands.length).to eq(0)
         end
       end
 


### PR DESCRIPTION
Add support for configurable number of poller threads via `activity_poller_threads` and `workflow_poller_threads` config.