### PR TITLE
fix: middleware example to correctly return yield result

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ To add a middleware, you need to define a class that responds to the call method
 class MyMiddleware
   def call(metadata)
     puts "Before execution"
-    yield
+    result = yield
     puts "After execution"
     result
   end


### PR DESCRIPTION
In the `Middleware` code block, the example in `README` was incorrect:
```
class MyMiddleware
  def call(metadata)
    puts "Before execution"
    yield
    puts "After execution"
    result
  end
end
```
Why this is wrong:
- The variable `result` is used, but it is not assigned anywhere.
- The method does not return a `yield` result.

Correction:
```
class MyMiddleware
  def call(metadata)
    puts "Before execution"
    result = yield
    puts "After execution"
    result
  end
end
```
Now, an example:
- Stores the result of executing the block in result.
- Explicitly returns the result of the block, allowing the middleware chain to pass values correctly.