### PR TITLE
Support gRPC default authority

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,20 @@ Temporal::Worker.new # uses global host
 Temporal.start_workflow(...) # uses global host
 ```
 
+When the resolver target and the TLS/HTTP2 authority differ, set the authority
+explicitly through the connection options. This is useful when an absolute DNS
+name is required for resolution but the certificate is issued for the canonical
+undotted hostname:
+
+```ruby
+Temporal.configure do |config|
+  config.host = 'temporal.example.com.'
+  config.connection_options = {
+    default_authority: 'temporal.example.com'
+  }
+end
+```
+
 This will work just fine for simpler use-cases, however at some point you might need to setup
 multiple clients and workers within the same instance of your app (e.g. you have different Temporal
 hosts, need to use different codecs/converters for different parts of your app, etc). Should this be

--- a/lib/temporal/connection/grpc.rb
+++ b/lib/temporal/connection/grpc.rb
@@ -808,7 +808,7 @@ module Temporal
       def client
         return @client if @client
 
-        channel_args = {}
+        channel_args = default_authority_channel_args
 
         if options[:keepalive_time_ms]
           channel_args["grpc.keepalive_time_ms"] = options[:keepalive_time_ms]
@@ -849,12 +849,26 @@ module Temporal
       end
 
       def operator_client
-        @operator_client ||= Temporalio::Api::OperatorService::V1::OperatorService::Stub.new(
-          url,
-          credentials,
+        return @operator_client if @operator_client
+
+        stub_options = {
           timeout: CONNECTION_TIMEOUT_SECONDS,
           interceptors: [ClientNameVersionInterceptor.new]
+        }
+        channel_args = default_authority_channel_args
+        stub_options[:channel_args] = channel_args unless channel_args.empty?
+
+        @operator_client = Temporalio::Api::OperatorService::V1::OperatorService::Stub.new(
+          url,
+          credentials,
+          **stub_options
         )
+      end
+
+      def default_authority_channel_args
+        return {} unless options[:default_authority]
+
+        { "grpc.default_authority" => options[:default_authority] }
       end
 
       def can_poll?

--- a/spec/unit/lib/temporal/grpc_spec.rb
+++ b/spec/unit/lib/temporal/grpc_spec.rb
@@ -904,6 +904,37 @@ describe Temporal::Connection::GRPC do
       end
     end
 
+    context "when default_authority is passed" do
+      let(:options) { { default_authority: "temporal.example.com" } }
+
+      it "passes the authority to the workflow service channel" do
+        expect(Temporalio::Api::WorkflowService::V1::WorkflowService::Stub).to receive(:new).with(
+          ":",
+          :this_channel_is_insecure,
+          timeout: 60,
+          interceptors: [instance_of(Temporal::Connection::ClientNameVersionInterceptor)],
+          channel_args: {
+            "grpc.default_authority" => "temporal.example.com"
+          }
+        )
+        subject.send(:client)
+      end
+
+      it "passes the authority to the operator service channel" do
+        allow(subject).to receive(:operator_client).and_call_original
+        expect(Temporalio::Api::OperatorService::V1::OperatorService::Stub).to receive(:new).with(
+          ":",
+          :this_channel_is_insecure,
+          timeout: 60,
+          interceptors: [instance_of(Temporal::Connection::ClientNameVersionInterceptor)],
+          channel_args: {
+            "grpc.default_authority" => "temporal.example.com"
+          }
+        )
+        subject.send(:operator_client)
+      end
+    end
+
     context "when passing retry_connection" do
       let(:options) { { retry_connection: true } }
 


### PR DESCRIPTION
## Summary

- add a `default_authority` connection option backed by `grpc.default_authority`
- apply the authority to both workflow and operator service channels
- document absolute resolver targets with a separate TLS/HTTP2 authority

This allows clients to use a DNS target with a trailing dot while preserving
the certificate and HTTP/2 authority of the canonical undotted hostname.

## Tests

- `bundle exec rspec spec/unit/lib/temporal/grpc_spec.rb -e default_authority`
- full suite adds no failures relative to current `master` under Ruby 3.2.2
